### PR TITLE
fix(org): synchronize state after creation and add loading guard to ProfileTab

### DIFF
--- a/components/organization/tabs/ProfileTab.tsx
+++ b/components/organization/tabs/ProfileTab.tsx
@@ -51,6 +51,7 @@ export default function ProfileTab({
     updateOrganization,
     isLoading,
     isLoadingOrganizations,
+    isLoadingActiveOrg,
   } = useOrganization();
 
   const [formData, setFormData] = useState({
@@ -124,6 +125,13 @@ export default function ProfileTab({
       setHasUserChanges(false);
       setIsInitialized(true);
     } else if (!isInitialized) {
+      // Guard: If we have an ID but the active org is still loading or hasn't matched our ID yet, wait
+      if (organizationId && (!activeOrg || activeOrg.id !== organizationId)) {
+        if (isLoadingActiveOrg) {
+          return;
+        }
+      }
+
       if (activeOrg) {
         setFormData({
           name: activeOrg.name || '',
@@ -164,7 +172,14 @@ export default function ProfileTab({
         setIsInitialized(true);
       }
     }
-  }, [activeOrg, initialData, isInitialized, isCreating]);
+  }, [
+    activeOrg,
+    initialData,
+    isInitialized,
+    isCreating,
+    isLoadingActiveOrg,
+    organizationId,
+  ]);
 
   useEffect(() => {
     if (activeOrg && isInitialized && !isCreating) {
@@ -483,7 +498,10 @@ export default function ProfileTab({
     }
   };
 
-  const loadingui = isSaving || isLoadingOrganizations;
+  const loadingui =
+    isSaving ||
+    isLoadingOrganizations ||
+    (isLoadingActiveOrg && !isInitialized);
   if (loadingui) {
     return (
       <div className='relative h-[calc(100vh-300px)] space-y-8'>

--- a/lib/providers/OrganizationProvider.tsx
+++ b/lib/providers/OrganizationProvider.tsx
@@ -59,26 +59,26 @@ const CACHE_DURATION = 5 * 60 * 1000;
 
 type OrganizationAction =
   | {
-      type: 'SET_LOADING';
-      payload: {
-        isLoading: boolean;
-        isLoadingOrganizations?: boolean;
-        isLoadingActiveOrg?: boolean;
-      };
-    }
+    type: 'SET_LOADING';
+    payload: {
+      isLoading: boolean;
+      isLoadingOrganizations?: boolean;
+      isLoadingActiveOrg?: boolean;
+    };
+  }
   | {
-      type: 'SET_ERROR';
-      payload: {
-        error: string | null;
-        organizationsError?: string | null;
-        activeOrgError?: string | null;
-      };
-    }
+    type: 'SET_ERROR';
+    payload: {
+      error: string | null;
+      organizationsError?: string | null;
+      activeOrgError?: string | null;
+    };
+  }
   | { type: 'SET_ORGANIZATIONS'; payload: OrganizationSummary[] }
   | {
-      type: 'SET_ACTIVE_ORG';
-      payload: { org: Organization | null; orgId: string | null };
-    }
+    type: 'SET_ACTIVE_ORG';
+    payload: { org: Organization | null; orgId: string | null };
+  }
   | { type: 'UPDATE_ORGANIZATION'; payload: Organization }
   | { type: 'ADD_ORGANIZATION'; payload: OrganizationSummary }
   | { type: 'REMOVE_ORGANIZATION'; payload: string }
@@ -216,26 +216,33 @@ function organizationReducer(
       };
 
     case 'UPDATE_ORGANIZATION':
-      if (!action.payload || !action.payload.id) {
+      const updatePayload = action.payload as any;
+      const orgId = updatePayload?.id || updatePayload?._id;
+
+      if (!action.payload || !orgId) {
         return state;
       }
       return {
         ...state,
         activeOrg:
-          state.activeOrgId === action.payload.id
-            ? action.payload
-            : state.activeOrg,
+          state.activeOrgId === orgId ? action.payload : state.activeOrg,
         organizations: state.organizations.map(org =>
-          org.organizationId === action.payload.id
+          org.organizationId === orgId
             ? {
-                ...org,
-                name: action.payload.name,
-                logo: action.payload.logo,
-                tagline: action.payload.tagline,
-                about: action.payload.about,
-                links: action.payload.links,
-                isProfileComplete: action.payload.isProfileComplete,
-              }
+              ...org,
+              name: action.payload.name,
+              logo: action.payload.logo,
+              tagline:
+                action.payload.tagline ||
+                (action.payload as any).metadata?.tagline,
+              about:
+                action.payload.about ||
+                (action.payload as any).metadata?.about,
+              links:
+                action.payload.links ||
+                (action.payload as any).metadata?.links,
+              isProfileComplete: action.payload.isProfileComplete,
+            }
             : org
         ),
       };
@@ -464,12 +471,12 @@ export function OrganizationProvider({
         count: organizationSummaries.length,
         sampleOrg: organizationSummaries[0]
           ? {
-              organizationId: organizationSummaries[0].organizationId,
-              name: organizationSummaries[0].name,
-              hackathonCount: organizationSummaries[0].hackathonCount,
-              grantCount: organizationSummaries[0].grantCount,
-              memberCount: organizationSummaries[0].memberCount,
-            }
+            organizationId: organizationSummaries[0].organizationId,
+            name: organizationSummaries[0].name,
+            hackathonCount: organizationSummaries[0].hackathonCount,
+            grantCount: organizationSummaries[0].grantCount,
+            memberCount: organizationSummaries[0].memberCount,
+          }
           : null,
       });
       dispatch({ type: 'SET_ORGANIZATIONS', payload: organizationSummaries });
@@ -755,6 +762,35 @@ export function OrganizationProvider({
           },
         });
         if (error) throw error;
+
+        // Immediately update local state before redirect to avoid empty form/state mismatch
+        const orgData: Organization = {
+          id: newOrg.id,
+          name: newOrg.name,
+          slug: newOrg.slug,
+          logo: newOrg.logo || '',
+          metadata: newOrg.metadata as any,
+          tagline: (newOrg.metadata as any)?.tagline || '',
+          about: (newOrg.metadata as any)?.about || '',
+          links: (newOrg.metadata as any)?.links || {},
+          isProfileComplete: !!(
+            newOrg.name &&
+            newOrg.slug &&
+            (newOrg.metadata as any)?.tagline &&
+            (newOrg.metadata as any)?.about
+          ),
+          members: [],
+          owner: '',
+          hackathons: [],
+          grants: [],
+          createdAt: newOrg.createdAt.toISOString(),
+          updatedAt: newOrg.createdAt.toISOString(),
+        };
+
+        dispatch({
+          type: 'SET_ACTIVE_ORG',
+          payload: { org: orgData, orgId: newOrg.id },
+        });
 
         await refreshOrganizations();
 


### PR DESCRIPTION
## Summary
This PR addresses a critical race condition where organization profile data entered during creation failed to persist in the UI immediately after redirection. 

## The Problem
After creating an organization, the system would redirect to the settings page before the local application context ([OrganizationProvider](cci:1://file:///home/jahrulez/Desktop/Projects/boundless/lib/providers/OrganizationProvider.tsx:287:0-1503:1)) correctly updated the `activeOrg` state. Consequently:
- [ProfileTab](cci:1://file:///home/jahrulez/Desktop/Projects/boundless/components/organization/tabs/ProfileTab.tsx:40:0-698:1) would mount with a `null` or stale organization.
- The form would initialize with empty/default values.
- Subsequent updates could lead to data loss or require double-entry.

## Changes

### 1. Synchronous State Synchronization in [OrganizationProvider](cci:1://file:///home/jahrulez/Desktop/Projects/boundless/lib/providers/OrganizationProvider.tsx:287:0-1503:1)
- **Immediate Dispatch**: Updated [createOrg](cci:1://file:///home/jahrulez/Desktop/Projects/boundless/lib/api/organization.ts:228:0-236:2) to manually dispatch `SET_ACTIVE_ORG` with the API response data *before* the redirect occurs. This ensures the context is fully populated by the time the settings page mounts.
- **Robust Identifier Support**: Refined the `UPDATE_ORGANIZATION` reducer to handle organizations using either [id](cci:2://file:///home/jahrulez/Desktop/Projects/boundless/lib/api/types.ts:20:0-24:1) or `_id`, ensuring consistent lookups across different backend response formats.

### 2. Guarded Initialization in [ProfileTab](cci:1://file:///home/jahrulez/Desktop/Projects/boundless/components/organization/tabs/ProfileTab.tsx:40:0-698:1)
- **Loading State Guard**: Introduced a check in the initialization `useEffect`. If an `organizationId` is present in the URL, the component now waits for `activeOrg` to match that ID before initializing form data.
- **Improved UX**: Integrated the `isLoadingActiveOrg` state into the component's loading UI, showing a spinner rather than an empty form during the brief state resolution period.

## Verification Plan
1. Navigate to `/organizations/new`.
2. Fill in Profile data (Name, Logo, Tagline, About).
3. Click "Create Organization".
4. Confirm successful redirect to `/organizations/[id]/settings`.
5. **Verify**: The Profile tab should be pre-populated with all submitted data.
6. **Verify**: Immediate subsequent edits should save successfully without requiring a manual refresh.
7. **Verify**: Existing organizations still load their profile data correctly.

Closes #415 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading state handling when viewing organization profiles to prevent UI conflicts
  * Enhanced form data synchronization to ensure consistency with active organization data before rendering
  * Optimized organization update and creation flows for more reliable data handling and display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->