### PR TITLE
Winners tab refactor

### DIFF
--- a/app/(landing)/hackathons/[slug]/HackathonPageClient.tsx
+++ b/app/(landing)/hackathons/[slug]/HackathonPageClient.tsx
@@ -159,6 +159,7 @@ export default function HackathonPageClient() {
       tabs.push({
         id: 'winners',
         label: 'Winners',
+        badge: winners.length,
       });
     }
 

--- a/components/hackathons/winners/WinnersTab.tsx
+++ b/components/hackathons/winners/WinnersTab.tsx
@@ -116,9 +116,13 @@ const WinnerCard = ({
     return 'md:scale-95 opacity-90';
   };
 
-  const projectUrl = winner.projectId
-    ? `/projects/${winner.projectId}?type=submission`
-    : null;
+  const projectUrl = winner.submissionId
+    ? `/projects/${winner.submissionId}?type=submission`
+    : winner.slug
+      ? `/projects/${winner.slug}`
+      : winner.projectId
+        ? `/projects/${winner.projectId}`
+        : null;
 
   const { primaryColor, secondaryColor } = getRibbonColors(winner.rank);
 
@@ -168,8 +172,18 @@ const WinnerCard = ({
     >
       {/* Prize Header */}
       <div className='mb-4 flex items-center justify-center gap-2'>
-        <Trophy className='h-4 w-4 text-yellow-500' />
-        <span className='text-sm font-bold text-white'>{winner.prize}</span>
+        <div className='flex items-center gap-1.5 rounded-full border border-[#2775CA]/20 bg-[#2775CA]/10 px-3 py-1'>
+          <Trophy className='h-4 w-4 text-yellow-500' />
+          <span className='text-sm font-bold text-white uppercase'>
+            {(() => {
+              const prize = winner.prize || '';
+              const match = prize.match(
+                /^(?:USDC)?\s*(\d+(?:\.\d+)?)\s*(?:USDC)?$/i
+              );
+              return match ? `${match[1]} USDC` : prize;
+            })()}
+          </span>
+        </div>
       </div>
 
       {/* Ranks/Participants */}


### PR DESCRIPTION
Closes #399 

# Winners Tab Refactor — Premium Organizer Design Integration

## Overview

This PR overhauls the participant-facing **Winners Tab** to match the premium **Podium** design already established in the organizer's `PublishWinnersWizard`.

The previous basic card grid has been replaced with a high-fidelity visual hierarchy that mirrors the administrative view.

---

## Key Changes

### UI & Design Replication

- **Podium Layout**
  - Implemented a 1st–2nd–3rd podium effect (2nd → 1st → 3rd)
  - Elevated scaling effect for the 1st place winner

- **Premium Components**
  - Integrated canonical `Ribbon` component for rank display
  - Added high-quality Avatar circles with initials fallback

- **Project Preview**
  - Each winner card now includes a styled project preview tile

- **USDC Branding**
  - Inline prize amounts now include a trophy icon for consistent financial branding

---

### Deep Linking & Navigation

- **Project Links**
  - Project names and thumbnails link to:
    `/projects/${projectId}?type=submission`

- **Participant Links**
  - Participant names and avatars link to:
    `/profile/${username}`

- **Graceful Fallbacks**
  - Safe rendering for missing metadata (null IDs or usernames)
  - Prevents broken links and rendering errors

---

##  Technical Details

- **Component Updated**
  - `components/hackathons/winners/WinnersTab.tsx`

- **Data Flow**
  - Strictly uses `useHackathonData()` hook
  - No redundant API calls introduced

- **Type Safety**
  - Fully typed using `HackathonWinner` interface
  - Removed all `any` types

- **Animation**
  - Added entrance animations via `motion/react` for premium UX polish

[Video Proof](https://www.loom.com/share/447ccfac1dae4efdb15f0ed7a1a41328)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated podium section for top‑3 winners with reordered podium presentation and rank ribbons
  * Participant avatars, tooltips, project badges, and optional project links on winner cards
  * Separate grid for ranks 4+ and a badge showing total winners on the Winners tab

* **Style**
  * Responsive two‑section layout, refined card visuals, prize header for top entries, and updated entry animations for smoother reveal
<!-- end of auto-generated comment: release notes by coderabbit.ai -->