### PR TITLE
Add hackathon detail page redesign (Figma link)

### DIFF
--- a/app/(landing)/hackathons/[slug]/hackathon-detail-design.md
+++ b/app/(landing)/hackathons/[slug]/hackathon-detail-design.md
@@ -1,0 +1,30 @@
+Hackathon Detail Page Redesign
+Issue: #414
+
+Figma Design
+https://www.figma.com/design/EMNGAQl1SGObXcsoa24krt/Boundless_Project-Details?node-id=0-1&t=A1ywRcn60Xyw0X6h-1
+
+This design proposes a cleaner and more professional UI/UX for the hackathon detail page.
+
+Included in the Figma file:
+- Desktop layout
+- Mobile layout
+- Banner / hero placement proposal
+- Redesigned hero section
+- Sticky sidebar card
+- Tab navigation
+- All tab layouts (overview, participants, resources, announcements, submissions, discussions, find team, winners)
+- Loading state
+- Hackathon not found state
+
+Banner Placement Proposal
+The hackathon banner is placed as a full-width hero image at the top of the page, allowing it to visually represent the hackathon and improve page identity.
+
+The sidebar becomes a compact summary card with key information and actions.
+
+Design Goals
+- Simpler UI and improved visual hierarchy
+- Clear primary actions (Join, Submit, View Submission)
+- Consistent spacing and typography
+- Better mobile usability
+- Professional and product-quality look


### PR DESCRIPTION
Added Figma design proposal for Hackathon Detail Page redesign.
Includes desktop and mobile layouts and banner placement.

Closes: #414

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design documentation for the redesigned hackathon detail page, featuring improved desktop and mobile layouts with tab-based navigation covering overview, participants, resources, announcements, submissions, discussions, find team, and winners. Includes updates to hero section design, sticky summary card, and enhanced visual hierarchy for better user experience.

[Design](https://www.figma.com/design/EMNGAQl1SGObXcsoa24krt/Boundless_Project-Details?node-id=0-1&t=A1ywRcn60Xyw0X6h-1)


<!-- end of auto-generated comment: release notes by coderabbit.ai -->