### PR TITLE
feat(landing): explore section, newsletter page, link cleanup

### DIFF
--- a/app/(landing)/newsletter/page.tsx
+++ b/app/(landing)/newsletter/page.tsx
@@ -1,0 +1,54 @@
+import Image from 'next/image';
+import { Metadata } from 'next';
+import NewsletterForm from '@/components/overview/NewsletterForm';
+
+export const metadata: Metadata = {
+  title: 'Subscribe to the Boundless Newsletter',
+  description:
+    'Stay Boundless. Get updates on grants, hackathons, bounties, and projects across the Stellar ecosystem.',
+};
+
+export default function NewsletterPage() {
+  return (
+    <main className='relative flex min-h-screen w-full items-center justify-center px-5 py-16 md:py-24'>
+      <div className='mx-auto w-full max-w-xl'>
+        <div
+          className='rounded-[12px] p-[1px]'
+          style={{
+            background:
+              'radial-gradient(circle at center, rgba(255, 255, 255, 0.0) 34%, rgba(255, 255, 255, 0.2) 90%)',
+          }}
+        >
+          <div className='bg-background rounded-[12px] p-8 md:p-10'>
+            <div className='flex flex-col items-start gap-6 sm:flex-row sm:gap-6'>
+              <div className='h-[80px] w-[80px] flex-shrink-0 md:h-[90px] md:w-[90px]'>
+                <Image
+                  src='/mail.png'
+                  alt='newsletter'
+                  width={89}
+                  height={89}
+                  quality={100}
+                  unoptimized
+                  className='h-full w-full object-cover'
+                />
+              </div>
+              <div className='flex-1 text-left'>
+                <h1 className='leading-[120%] font-medium tracking-[-0.48px] text-white md:text-2xl'>
+                  Join Our Newsletter
+                </h1>
+                <p className='mt-1 text-sm leading-[160%] font-normal text-[#D9D9D9] md:text-base'>
+                  Stay Boundless! Never miss updates on grants, hackathons, and
+                  projects.
+                </p>
+              </div>
+            </div>
+
+            <div className='mt-10'>
+              <NewsletterForm source='newsletter-page' />
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/(landing)/page.tsx
+++ b/app/(landing)/page.tsx
@@ -1,25 +1,45 @@
 import BeamBackground from '@/components/landing-page/BeamBackground';
-import WhyBoundless from '@/components/landing-page/WhyBoundless';
-import BackedBy from '@/components/landing-page/BackedBy';
 import NewsLetter from '@/components/landing-page/NewsLetter';
 import BlogSection from '@/components/landing-page/blog/BlogSection';
-import Explore from '@/components/landing-page/Explore';
-import CleanBanner from '@/components/landing-page/Banner';
 import Hero2 from '@/components/landing-page/Hero2';
+import AudienceSplit from '@/components/landing-page/AudienceSplit';
+import FourPrograms from '@/components/landing-page/FourPrograms';
+import HowItWorksCompact from '@/components/landing-page/HowItWorksCompact';
+import WhyStellar from '@/components/landing-page/WhyStellar';
+import TrustAndProof from '@/components/landing-page/TrustAndProof';
+import FinalCta from '@/components/landing-page/FinalCta';
 
 export default function LandingPage() {
   return (
     <div className='relative overflow-hidden'>
       <BeamBackground />
-      <div className='relative z-10 mx-auto max-w-[1440px] space-y-[60px] px-5 pt-0 pb-5 md:space-y-[80px] md:px-[50px] lg:px-[100px]'>
-        {/* <Hero /> */}
+      <div className='relative z-10 mx-auto max-w-[1440px] space-y-[80px] px-5 pt-0 pb-5 md:space-y-[120px] md:px-[50px] lg:px-[100px]'>
+        {/* §1 — Hero (production) */}
         <Hero2 />
-        <Explore />
-        <WhyBoundless />
-        <BackedBy />
-        <NewsLetter />
+
+        {/* §2 — Two-audience split */}
+        <AudienceSplit />
+
+        {/* §3 — The four programs */}
+        <FourPrograms />
+
+        {/* §4 — How it works (compact) */}
+        <HowItWorksCompact />
+
+        {/* §5 — Why Stellar */}
+        <WhyStellar />
+
+        {/* §6 — Trust and proof (SCF #40) */}
+        <TrustAndProof />
+
+        {/* §7 — From the blog */}
         <BlogSection />
-        <CleanBanner />
+
+        {/* Newsletter — between blog and final CTA */}
+        <NewsLetter />
+
+        {/* §8 — Final CTA */}
+        <FinalCta />
       </div>
     </div>
   );

--- a/app/(landing)/page.tsx
+++ b/app/(landing)/page.tsx
@@ -2,6 +2,7 @@ import BeamBackground from '@/components/landing-page/BeamBackground';
 import NewsLetter from '@/components/landing-page/NewsLetter';
 import BlogSection from '@/components/landing-page/blog/BlogSection';
 import Hero2 from '@/components/landing-page/Hero2';
+import Explore from '@/components/landing-page/Explore';
 import AudienceSplit from '@/components/landing-page/AudienceSplit';
 import FourPrograms from '@/components/landing-page/FourPrograms';
 import HowItWorksCompact from '@/components/landing-page/HowItWorksCompact';
@@ -11,11 +12,14 @@ import FinalCta from '@/components/landing-page/FinalCta';
 
 export default function LandingPage() {
   return (
-    <div className='relative overflow-hidden'>
+    <div className='relative overflow-x-clip'>
       <BeamBackground />
       <div className='relative z-10 mx-auto max-w-[1440px] space-y-[80px] px-5 pt-0 pb-5 md:space-y-[120px] md:px-[50px] lg:px-[100px]'>
         {/* §1 — Hero (production) */}
         <Hero2 />
+
+        {/* Active opportunities */}
+        <Explore />
 
         {/* §2 — Two-audience split */}
         <AudienceSplit />

--- a/components/landing-page/AudienceSplit.tsx
+++ b/components/landing-page/AudienceSplit.tsx
@@ -34,6 +34,19 @@ const AudienceCard = ({
 }: AudienceCardProps) => {
   const router = useRouter();
 
+  const isExternal = /^https?:\/\//.test(secondaryHref);
+  const isAnchor = secondaryHref.startsWith('#');
+  const secondaryClassName =
+    'text-sm text-white/50 underline-offset-4 transition-colors hover:text-white hover:underline';
+
+  const handleAnchorClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (!isAnchor) return;
+    e.preventDefault();
+    document
+      .getElementById(secondaryHref.slice(1))
+      ?.scrollIntoView({ behavior: 'smooth' });
+  };
+
   return (
     <div className='bg-background-card relative flex h-full flex-col gap-6 rounded-2xl border border-white/10 p-5 md:gap-8 md:p-6'>
       {/* Stage panel with mock illustration */}
@@ -69,12 +82,28 @@ const AudienceCard = ({
             <ArrowRight className='h-4 w-4 transition-transform group-hover:translate-x-1' />
           </BoundlessButton>
 
-          <Link
-            href={secondaryHref}
-            className='text-sm text-white/50 underline-offset-4 transition-colors hover:text-white hover:underline'
-          >
-            {secondaryLabel}
-          </Link>
+          {isExternal ? (
+            <a
+              href={secondaryHref}
+              target='_blank'
+              rel='noopener noreferrer'
+              className={secondaryClassName}
+            >
+              {secondaryLabel}
+            </a>
+          ) : isAnchor ? (
+            <a
+              href={secondaryHref}
+              onClick={handleAnchorClick}
+              className={secondaryClassName}
+            >
+              {secondaryLabel}
+            </a>
+          ) : (
+            <Link href={secondaryHref} className={secondaryClassName}>
+              {secondaryLabel}
+            </Link>
+          )}
         </div>
       </div>
     </div>
@@ -104,9 +133,9 @@ export default function AudienceSplit() {
           headline='Drive impactful initiatives with confidence.'
           body='Boundless offers a unified platform to launch hackathons, grants, and bounties, ensuring every disbursement is transparent and verifiable on Stellar. Focus on fostering innovation — we handle the precision.'
           ctaLabel='Run your first program'
-          ctaHref='/auth/signup?role=organizer'
+          ctaHref='/organizations'
           secondaryLabel='Or talk to our team'
-          secondaryHref='/contact?topic=organizer'
+          secondaryHref='https://discord.gg/k6eaFZ2vr'
           accent
         />
 
@@ -117,9 +146,9 @@ export default function AudienceSplit() {
           headline='Fund your next big idea and get rewarded for your progress.'
           body="Whether it's a crowdfunding campaign, a grant application, or a bounty, Boundless connects you directly with your backers and ensures you get paid for verified work."
           ctaLabel='Get started'
-          ctaHref='/auth/signup?role=builder'
+          ctaHref='/organizations'
           secondaryLabel='Or browse open programs'
-          secondaryHref='/programs'
+          secondaryHref='#explore'
         />
       </div>
     </section>

--- a/components/landing-page/AudienceSplit.tsx
+++ b/components/landing-page/AudienceSplit.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import { BoundlessButton } from '../buttons';
+import OrganizerMock from './illustrations/OrganizerMock';
+import BuilderMock from './illustrations/BuilderMock';
+
+interface AudienceCardProps {
+  index: string;
+  illustration: React.ReactNode;
+  eyebrow: string;
+  headline: string;
+  body: string;
+  ctaLabel: string;
+  ctaHref: string;
+  secondaryLabel: string;
+  secondaryHref: string;
+  accent?: boolean;
+}
+
+const AudienceCard = ({
+  index,
+  illustration,
+  eyebrow,
+  headline,
+  body,
+  ctaLabel,
+  ctaHref,
+  secondaryLabel,
+  secondaryHref,
+  accent = false,
+}: AudienceCardProps) => {
+  const router = useRouter();
+
+  return (
+    <div className='bg-background-card relative flex h-full flex-col gap-6 rounded-2xl border border-white/10 p-5 md:gap-8 md:p-6'>
+      {/* Stage panel with mock illustration */}
+      <div className='relative h-56 w-full overflow-hidden rounded-xl border border-white/10 bg-white/5 md:h-64'>
+        <div className='bg-background-card/80 absolute top-3 left-3 z-10 rounded-md border border-white/10 px-1.5 py-0.5'>
+          <span className='font-mono text-[10px] tracking-tight text-white/50'>
+            [{index}]
+          </span>
+        </div>
+        {illustration}
+      </div>
+
+      {/* Editorial copy */}
+      <div className='flex flex-1 flex-col gap-4 px-1 md:px-2'>
+        <span className='text-primary font-mono text-[11px] font-medium tracking-[0.2em] uppercase'>
+          {eyebrow}
+        </span>
+
+        <h3 className='text-2xl leading-[1.2] font-semibold tracking-tight text-white md:text-[28px]'>
+          {headline}
+        </h3>
+
+        <p className='flex-1 text-base leading-[160%] text-white/70'>{body}</p>
+
+        <div className='flex flex-col gap-3 pt-2'>
+          <BoundlessButton
+            variant={accent ? 'default' : 'outline'}
+            size='xl'
+            onClick={() => router.push(ctaHref)}
+            className='group w-full sm:w-auto'
+          >
+            {ctaLabel}
+            <ArrowRight className='h-4 w-4 transition-transform group-hover:translate-x-1' />
+          </BoundlessButton>
+
+          <Link
+            href={secondaryHref}
+            className='text-sm text-white/50 underline-offset-4 transition-colors hover:text-white hover:underline'
+          >
+            {secondaryLabel}
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default function AudienceSplit() {
+  return (
+    <section
+      className='relative w-full'
+      aria-labelledby='audience-split-heading'
+    >
+      <header className='mx-auto max-w-3xl text-center'>
+        <h2
+          id='audience-split-heading'
+          className='text-3xl leading-[140%] tracking-tight text-white md:text-4xl xl:text-[48px]'
+        >
+          Your Vision, Our Foundation: For Every Creator &amp; Catalyst.
+        </h2>
+      </header>
+
+      <div className='mt-12 grid gap-6 md:mt-16 md:grid-cols-2'>
+        <AudienceCard
+          index='01'
+          illustration={<OrganizerMock />}
+          eyebrow='For Catalysts & Communities'
+          headline='Drive impactful initiatives with confidence.'
+          body='Boundless offers a unified platform to launch hackathons, grants, and bounties, ensuring every disbursement is transparent and verifiable on Stellar. Focus on fostering innovation — we handle the precision.'
+          ctaLabel='Run your first program'
+          ctaHref='/auth/signup?role=organizer'
+          secondaryLabel='Or talk to our team'
+          secondaryHref='/contact?topic=organizer'
+          accent
+        />
+
+        <AudienceCard
+          index='02'
+          illustration={<BuilderMock />}
+          eyebrow='For Visionaries & Creators'
+          headline='Fund your next big idea and get rewarded for your progress.'
+          body="Whether it's a crowdfunding campaign, a grant application, or a bounty, Boundless connects you directly with your backers and ensures you get paid for verified work."
+          ctaLabel='Get started'
+          ctaHref='/auth/signup?role=builder'
+          secondaryLabel='Or browse open programs'
+          secondaryHref='/programs'
+        />
+      </div>
+    </section>
+  );
+}

--- a/components/landing-page/Explore.tsx
+++ b/components/landing-page/Explore.tsx
@@ -3,8 +3,8 @@
 import { cn } from '@/lib/utils';
 import { ArrowRight } from 'lucide-react';
 import Image from 'next/image';
-import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
-import { HackathonCard } from './hackathon/HackathonCard';
+import { useState, useRef, useEffect, useMemo } from 'react';
+import HackathonCard from './hackathon/HackathonCard';
 import Link from 'next/link';
 import { getPublicHackathonsList } from '@/lib/api/hackathons';
 import type { Hackathon } from '@/lib/api/hackathons';
@@ -73,15 +73,7 @@ const HackathonCardSkeleton = () => (
   </div>
 );
 
-const tabs = [
-  { name: 'Featured Projects', value: 'featured-projects' },
-  { name: 'Ongoing Hackathons', value: 'ongoing-hackathons' },
-  { name: 'Open Grants', value: 'open-grants' },
-  { name: 'Bounties', value: 'live-grants' },
-];
-
 export default function Explore() {
-  const [activeTab, setActiveTab] = useState(tabs[0].value);
   const [underlineStyle, setUnderlineStyle] = useState({});
   const tabRefs = useRef<Record<string, HTMLParagraphElement | null>>({});
 
@@ -98,49 +90,48 @@ export default function Explore() {
   });
 
   const [hackathons, setHackathons] = useState<Hackathon[]>([]);
-  const [hackathonsLoading, setHackathonsLoading] = useState(false);
+  const [hackathonsLoading, setHackathonsLoading] = useState(true);
   const [hackathonsError, setHackathonsError] = useState<string | null>(null);
-  const [hackathonsFetched, setHackathonsFetched] = useState(false);
 
-  const fetchHackathons = useCallback(async () => {
-    if (hackathonsFetched) return;
-
-    try {
-      setHackathonsLoading(true);
-      setHackathonsError(null);
-
-      const response = await getPublicHackathonsList({
-        status: 'active',
-        limit: 6,
-        page: 1,
+  useEffect(() => {
+    let cancelled = false;
+    setHackathonsLoading(true);
+    getPublicHackathonsList({ limit: 6, page: 1 })
+      .then(response => {
+        if (cancelled) return;
+        setHackathons(response.hackathons || []);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setHackathonsError('Failed to fetch hackathons');
+      })
+      .finally(() => {
+        if (!cancelled) setHackathonsLoading(false);
       });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
-      const hackathonsList = response.hackathons || [];
-      setHackathons(hackathonsList);
-      setHackathonsFetched(true);
-    } catch {
-      setHackathonsError('Failed to fetch hackathons');
-      setHackathonsFetched(true);
-    } finally {
-      setHackathonsLoading(false);
-    }
-  }, [hackathonsFetched]);
+  const visibleTabs = useMemo(() => {
+    const all: { name: string; value: string }[] = [];
+    if (hackathons.length > 0 || projects.length > 0)
+      all.push({ name: 'All', value: 'all' });
+    if (projects.length > 0)
+      all.push({ name: 'Featured Projects', value: 'featured-projects' });
+    if (hackathons.length > 0)
+      all.push({ name: 'Ongoing Hackathons', value: 'ongoing-hackathons' });
+    return all;
+  }, [hackathons.length, projects.length]);
+
+  const [activeTab, setActiveTab] = useState('all');
 
   useEffect(() => {
-    if (activeTab === 'ongoing-hackathons') {
-      setHackathonsFetched(false);
+    if (visibleTabs.length === 0) return;
+    if (!visibleTabs.some(t => t.value === activeTab)) {
+      setActiveTab(visibleTabs[0].value);
     }
-  }, [activeTab]);
-
-  useEffect(() => {
-    if (
-      activeTab === 'ongoing-hackathons' &&
-      !hackathonsFetched &&
-      !hackathonsLoading
-    ) {
-      fetchHackathons();
-    }
-  }, [activeTab, fetchHackathons, hackathonsFetched, hackathonsLoading]);
+  }, [visibleTabs, activeTab]);
 
   useEffect(() => {
     const currentTab = tabRefs.current[activeTab];
@@ -150,10 +141,16 @@ export default function Explore() {
         left: currentTab.offsetLeft,
       });
     }
-  }, [activeTab]);
+  }, [activeTab, visibleTabs]);
+
+  const isInitialLoading = projectsLoading || hackathonsLoading;
+  if (!isInitialLoading && visibleTabs.length === 0) return null;
 
   return (
-    <section className='relative flex flex-col items-center justify-center text-white'>
+    <section
+      id='explore'
+      className='relative -mt-12 flex scroll-mt-24 flex-col items-center justify-center text-white md:-mt-24'
+    >
       <div className='flex flex-col items-center gap-6 text-center'>
         <p className='to-primary bg-gradient-to-r from-[#3AE6B2] bg-clip-text text-transparent'>
           Active Opportunities
@@ -161,7 +158,7 @@ export default function Explore() {
         <h2 className='text-5xl max-sm:text-3xl'>Explore What's Happening</h2>
 
         <div className='relative flex gap-8 overflow-auto border-b border-gray-700 px-4 md:px-0'>
-          {tabs.map(tab => (
+          {visibleTabs.map(tab => (
             <p
               key={tab.value}
               ref={el => {
@@ -187,6 +184,39 @@ export default function Explore() {
       </div>
 
       <div className='mt-10 grid w-full grid-cols-1 gap-6 md:grid-cols-2 md:px-6 lg:grid-cols-3 xl:max-w-7xl xl:px-0'>
+        {activeTab === 'all' && (
+          <>
+            {projectsLoading || hackathonsLoading ? (
+              <>
+                {Array.from({ length: 6 }).map((_, index) => (
+                  <ProjectCardSkeleton key={index} />
+                ))}
+              </>
+            ) : projects.length === 0 && hackathons.length === 0 ? (
+              <div className='col-span-full py-12 text-center text-gray-400'>
+                No opportunities available at the moment.
+              </div>
+            ) : (
+              <>
+                {hackathons.map(hackathon => (
+                  <HackathonCard
+                    key={`hackathon-${hackathon.id}`}
+                    isFullWidth={true}
+                    {...hackathon}
+                  />
+                ))}
+                {projects.map(project => (
+                  <ProjectCard
+                    isFullWidth={true}
+                    key={`project-${project.id}`}
+                    data={project}
+                  />
+                ))}
+              </>
+            )}
+          </>
+        )}
+
         {activeTab === 'featured-projects' && (
           <>
             {projectsLoading ? (
@@ -242,24 +272,10 @@ export default function Explore() {
             )}
           </>
         )}
-
-        {activeTab === 'open-grants' && (
-          <div className='col-span-full py-12 text-center text-gray-400'>
-            <p className='mb-2 text-lg font-medium text-white'>Coming Soon</p>
-            <p>Open Grants feature will be available soon.</p>
-          </div>
-        )}
-
-        {activeTab === 'live-grants' && (
-          <div className='col-span-full py-12 text-center text-gray-400'>
-            <p className='mb-2 text-lg font-medium text-white'>Coming Soon</p>
-            <p>Bounties feature will be available soon.</p>
-          </div>
-        )}
       </div>
 
       <div className='mt-20 flex cursor-pointer items-center gap-1'>
-        <Link href='/projects'>
+        <Link href='/hackathons'>
           <p className='font-medium underline'>View More Opportunities</p>
         </Link>
         <ArrowRight className='h-3 w-3' />

--- a/components/landing-page/FinalCta.tsx
+++ b/components/landing-page/FinalCta.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { ArrowRight } from 'lucide-react';
+import { BoundlessButton } from '../buttons';
+
+export default function FinalCta() {
+  const router = useRouter();
+
+  return (
+    <section className='mb-20' aria-labelledby='final-cta-heading'>
+      <div className='bg-background-card relative mx-auto min-h-[20rem] overflow-hidden rounded-[3.2rem] border border-white/10'>
+        <div className='absolute inset-0 -z-10'>
+          <div className='bg-primary/10 absolute -top-32 left-1/2 h-72 w-[60%] -translate-x-1/2 rounded-full blur-3xl' />
+        </div>
+
+        <div className='relative z-10 flex flex-col items-center justify-center gap-8 px-6 py-16 text-center sm:px-10 lg:py-20'>
+          <div className='flex flex-col gap-4'>
+            <h2
+              id='final-cta-heading'
+              className='text-3xl leading-[120%] font-semibold tracking-tight text-white md:text-4xl lg:text-[44px]'
+            >
+              Ready to Build?
+            </h2>
+            <p className='mx-auto max-w-xl text-base leading-[170%] text-white/70 md:text-lg'>
+              Launch your program or campaign in moments. With funds securely
+              held in on-chain escrow on Stellar, you&apos;re ready to go
+              without complex setup.
+            </p>
+          </div>
+
+          <div className='flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-center'>
+            <BoundlessButton
+              variant='default'
+              size='xl'
+              onClick={() => router.push('/auth/signup?role=organizer')}
+              className='group'
+            >
+              Run a program
+              <ArrowRight className='h-4 w-4 transition-transform group-hover:translate-x-1' />
+            </BoundlessButton>
+
+            <BoundlessButton
+              variant='outline'
+              size='xl'
+              onClick={() => router.push('/auth/signup?role=builder')}
+              className='group'
+            >
+              Launch a campaign
+              <ArrowRight className='h-4 w-4 transition-transform group-hover:translate-x-1' />
+            </BoundlessButton>
+          </div>
+
+          <p className='text-sm leading-[170%] text-white/50'>
+            Already on Boundless?{' '}
+            <Link
+              href='/auth/signin'
+              className='hover:text-primary text-white underline underline-offset-4 transition-colors'
+            >
+              Sign in
+            </Link>
+            . Looking for a partnership?{' '}
+            <Link
+              href='/contact'
+              className='hover:text-primary text-white underline underline-offset-4 transition-colors'
+            >
+              Talk to our team
+            </Link>
+            .
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/landing-page/FinalCta.tsx
+++ b/components/landing-page/FinalCta.tsx
@@ -34,7 +34,7 @@ export default function FinalCta() {
             <BoundlessButton
               variant='default'
               size='xl'
-              onClick={() => router.push('/auth/signup?role=organizer')}
+              onClick={() => router.push('/organizations')}
               className='group'
             >
               Run a program
@@ -44,7 +44,7 @@ export default function FinalCta() {
             <BoundlessButton
               variant='outline'
               size='xl'
-              onClick={() => router.push('/auth/signup?role=builder')}
+              onClick={() => router.push('/organizations')}
               className='group'
             >
               Launch a campaign
@@ -55,18 +55,20 @@ export default function FinalCta() {
           <p className='text-sm leading-[170%] text-white/50'>
             Already on Boundless?{' '}
             <Link
-              href='/auth/signin'
+              href='/auth?mode=signin'
               className='hover:text-primary text-white underline underline-offset-4 transition-colors'
             >
               Sign in
             </Link>
             . Looking for a partnership?{' '}
-            <Link
-              href='/contact'
+            <a
+              href='https://discord.gg/k6eaFZ2vr'
+              target='_blank'
+              rel='noopener noreferrer'
               className='hover:text-primary text-white underline underline-offset-4 transition-colors'
             >
               Talk to our team
-            </Link>
+            </a>
             .
           </p>
         </div>

--- a/components/landing-page/FourPrograms.tsx
+++ b/components/landing-page/FourPrograms.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { ArrowUpRight } from 'lucide-react';
+import HackathonMock from './illustrations/HackathonMock';
+import GrantMock from './illustrations/GrantMock';
+import BountyMock from './illustrations/BountyMock';
+import CrowdfundingMock from './illustrations/CrowdfundingMock';
+
+interface ProgramCardProps {
+  illustration: React.ReactNode;
+  hostedBy: string;
+  title: string;
+  body: string;
+  ctaLabel: string;
+  ctaHref: string;
+  layout: 'wide' | 'narrow';
+}
+
+const ProgramCard = ({
+  illustration,
+  hostedBy,
+  title,
+  body,
+  ctaLabel,
+  ctaHref,
+  layout,
+}: ProgramCardProps) => {
+  const router = useRouter();
+  const isWide = layout === 'wide';
+
+  return (
+    <button
+      type='button'
+      onClick={() => router.push(ctaHref)}
+      className='group bg-background-card hover:border-border-strong focus-visible:ring-mint/40 relative flex h-full w-full flex-col overflow-hidden rounded-2xl border border-white/10 text-left transition-colors focus:outline-none focus-visible:ring-2'
+    >
+      <div
+        className={
+          isWide
+            ? 'grid h-full grid-cols-1 md:grid-cols-2'
+            : 'flex h-full flex-col'
+        }
+      >
+        {/* Stage panel with mock */}
+        <div
+          className={
+            isWide
+              ? 'relative flex min-h-[220px] items-center justify-center bg-white/5 md:min-h-0 md:border-r md:border-white/10'
+              : 'relative flex h-44 items-center justify-center bg-white/5 md:h-52'
+          }
+        >
+          {illustration}
+        </div>
+
+        {/* Text content */}
+        <div className='relative flex flex-1 flex-col gap-3 p-6 md:p-7'>
+          <ArrowUpRight
+            className='text-subtle-text absolute top-5 right-5 h-5 w-5 transition-all group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:text-white'
+            strokeWidth={1.75}
+          />
+          <p className='pr-7 text-xs font-medium tracking-wide text-white/50 italic'>
+            {hostedBy}
+          </p>
+          <h3
+            className={
+              isWide
+                ? 'text-2xl leading-[1.2] font-semibold tracking-tight text-white md:text-[28px]'
+                : 'text-xl leading-[1.2] font-semibold tracking-tight text-white md:text-2xl'
+            }
+          >
+            {title}
+          </h3>
+          <p className='flex-1 text-[15px] leading-[160%] text-white/70'>
+            {body}
+          </p>
+          <p className='mt-2 text-sm font-medium text-white/50 transition-colors group-hover:text-white'>
+            {ctaLabel}
+          </p>
+        </div>
+      </div>
+    </button>
+  );
+};
+
+export default function FourPrograms() {
+  return (
+    <section className='relative w-full' aria-labelledby='programs-heading'>
+      <header className='mx-auto max-w-3xl text-center'>
+        <h2
+          id='programs-heading'
+          className='text-3xl leading-[140%] tracking-tight text-white md:text-4xl xl:text-[48px]'
+        >
+          Every funding shape, one home.
+        </h2>
+        <p className='mx-auto mt-4 max-w-2xl text-base leading-[160%] text-white/70 md:text-lg'>
+          Boundless provides tailored frameworks for every type of initiative,
+          ensuring funds move precisely when your project milestones are met or
+          work is verified.
+        </p>
+      </header>
+
+      {/* Bento grid: 8/4 in row 1, 4/8 in row 2 */}
+      <div className='mt-12 grid grid-cols-1 gap-5 md:mt-16 md:grid-cols-12'>
+        <div className='md:col-span-8'>
+          <ProgramCard
+            layout='wide'
+            illustration={<HackathonMock />}
+            hostedBy='Hosted by ecosystems, foundations, projects, and DAOs.'
+            title='Hackathons: Discover Breakthroughs.'
+            body='Attract top talent and unearth novel solutions. Define your challenge, set the stakes, and let Boundless manage the secure prize distribution upon successful judging.'
+            ctaLabel='Run a hackathon'
+            ctaHref='/hackathons'
+          />
+        </div>
+
+        <div className='md:col-span-4'>
+          <ProgramCard
+            layout='narrow'
+            illustration={<GrantMock />}
+            hostedBy='Hosted by foundations, DAOs, and ecosystems.'
+            title='Grants: Fuel Progress.'
+            body='Support vital projects with confidence. Structure your grant program with clear milestones or single approvals, knowing every disbursement is transparently recorded and released on-chain.'
+            ctaLabel='Run a grant program'
+            ctaHref='/grants'
+          />
+        </div>
+
+        <div className='md:col-span-4'>
+          <ProgramCard
+            layout='narrow'
+            illustration={<BountyMock />}
+            hostedBy='Hosted by projects, DAOs, and organizers.'
+            title='Bounties: Get Work Done.'
+            body='Accelerate your project by rewarding specific tasks. Post your challenge, define the reward, and Boundless ensures contributors are paid instantly upon verified work acceptance.'
+            ctaLabel='Post a bounty'
+            ctaHref='/bounties'
+          />
+        </div>
+
+        <div className='md:col-span-8'>
+          <ProgramCard
+            layout='wide'
+            illustration={<CrowdfundingMock />}
+            hostedBy='Launched by builders.'
+            title='Crowdfunding: Bring Ideas to Life.'
+            body='Rally your community and fund your vision. Launch milestone-driven campaigns where backers contribute securely, and funds are released as you achieve verified progress.'
+            ctaLabel='Launch a campaign'
+            ctaHref='/campaigns'
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/landing-page/FourPrograms.tsx
+++ b/components/landing-page/FourPrograms.tsx
@@ -13,7 +13,7 @@ interface ProgramCardProps {
   title: string;
   body: string;
   ctaLabel: string;
-  ctaHref: string;
+  ctaHref?: string;
   layout: 'wide' | 'narrow';
 }
 
@@ -28,12 +28,14 @@ const ProgramCard = ({
 }: ProgramCardProps) => {
   const router = useRouter();
   const isWide = layout === 'wide';
+  const disabled = !ctaHref;
 
   return (
     <button
       type='button'
-      onClick={() => router.push(ctaHref)}
-      className='group bg-background-card hover:border-border-strong focus-visible:ring-mint/40 relative flex h-full w-full flex-col overflow-hidden rounded-2xl border border-white/10 text-left transition-colors focus:outline-none focus-visible:ring-2'
+      onClick={() => ctaHref && router.push(ctaHref)}
+      disabled={disabled}
+      className='group bg-background-card hover:border-border-strong focus-visible:ring-mint/40 relative flex h-full w-full flex-col overflow-hidden rounded-2xl border border-white/10 text-left transition-colors focus:outline-none focus-visible:ring-2 disabled:cursor-default'
     >
       <div
         className={
@@ -85,7 +87,11 @@ const ProgramCard = ({
 
 export default function FourPrograms() {
   return (
-    <section className='relative w-full' aria-labelledby='programs-heading'>
+    <section
+      id='programs'
+      className='relative w-full scroll-mt-24'
+      aria-labelledby='programs-heading'
+    >
       <header className='mx-auto max-w-3xl text-center'>
         <h2
           id='programs-heading'
@@ -110,7 +116,7 @@ export default function FourPrograms() {
             title='Hackathons: Discover Breakthroughs.'
             body='Attract top talent and unearth novel solutions. Define your challenge, set the stakes, and let Boundless manage the secure prize distribution upon successful judging.'
             ctaLabel='Run a hackathon'
-            ctaHref='/hackathons'
+            ctaHref='/organizations'
           />
         </div>
 
@@ -122,7 +128,6 @@ export default function FourPrograms() {
             title='Grants: Fuel Progress.'
             body='Support vital projects with confidence. Structure your grant program with clear milestones or single approvals, knowing every disbursement is transparently recorded and released on-chain.'
             ctaLabel='Run a grant program'
-            ctaHref='/grants'
           />
         </div>
 
@@ -134,7 +139,6 @@ export default function FourPrograms() {
             title='Bounties: Get Work Done.'
             body='Accelerate your project by rewarding specific tasks. Post your challenge, define the reward, and Boundless ensures contributors are paid instantly upon verified work acceptance.'
             ctaLabel='Post a bounty'
-            ctaHref='/bounties'
           />
         </div>
 
@@ -146,7 +150,7 @@ export default function FourPrograms() {
             title='Crowdfunding: Bring Ideas to Life.'
             body='Rally your community and fund your vision. Launch milestone-driven campaigns where backers contribute securely, and funds are released as you achieve verified progress.'
             ctaLabel='Launch a campaign'
-            ctaHref='/campaigns'
+            ctaHref='/organizations'
           />
         </div>
       </div>

--- a/components/landing-page/Hero2.tsx
+++ b/components/landing-page/Hero2.tsx
@@ -8,11 +8,7 @@ import {
   CursorBody,
   CursorMessage,
 } from '../ui/shadcn-io/cursor';
-import Image from 'next/image';
 import { BoundlessButton } from '../buttons';
-import { HackathonCard } from '@/components/landing-page/hackathon/HackathonCard';
-import ProjectCard from '@/features/projects/components/ProjectCard';
-import { Crowdfunding } from '@/features/projects/types';
 
 const BRAND_COLOR = '#a7f950';
 
@@ -20,7 +16,7 @@ export default function Hero2() {
   const router = useRouter();
 
   return (
-    <section className='relative flex min-h-screen w-full items-center justify-center overflow-hidden py-12 md:py-20'>
+    <section className='relative flex w-full items-center justify-center overflow-hidden py-12 md:py-20'>
       <Cursor className='animate-float-slow absolute top-32 left-20 z-20 hidden text-sm font-medium lg:block'>
         <CursorPointer style={{ color: BRAND_COLOR }} />
         <CursorBody
@@ -36,59 +32,36 @@ export default function Hero2() {
           <CursorMessage>Community Validation</CursorMessage>
         </CursorBody>
       </Cursor>
-
       <div className='relative z-10 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8'>
         <div className='mb-8 flex justify-center md:mb-12'>
           <div className='inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-5 py-2 backdrop-blur-sm'>
-            <div
-              className='flex h-4 w-4 items-center justify-center rounded-full'
-              style={{ backgroundColor: `${BRAND_COLOR}40` }}
-            >
-              <CheckCircle2
-                className='h-3 w-3'
-                style={{ color: BRAND_COLOR }}
-              />
+            <div className='bg-primary/10 flex h-4 w-4 items-center justify-center rounded-full'>
+              <CheckCircle2 className='text-primary h-3 w-3' />
             </div>
-            <span className='text-xs font-medium tracking-wide text-white/80 uppercase'>
-              The #1 milestone-based funding platform on Stellar
+            <span className='text-xs font-medium tracking-wide text-white/70 uppercase'>
+              The Future of Funding, Built on Stellar
             </span>
           </div>
         </div>
 
         <div className='mx-auto mb-12 max-w-4xl space-y-8 text-center md:mb-16'>
           <div className='space-y-4'>
-            <h1 className='text-4xl leading-none font-bold tracking-tight md:text-6xl lg:text-7xl'>
-              <span
-                className='from-primary bg-linear-to-r to-[#8ae63a] bg-clip-text text-transparent'
-                style={{ color: BRAND_COLOR }}
-              >
-                Launch Projects
-              </span>
-              <br />
-              <span className='relative inline-block text-white'>
-                Manage Hackathons.
-                <div className='mt-2'>
-                  <Image
-                    src='/lines.svg'
-                    alt=''
-                    width={100}
-                    height={12}
-                    className='h-[12px] w-full'
-                  />
-                </div>
-              </span>
+            <h1 className='mx-auto max-w-4xl text-4xl leading-[1.05] font-semibold tracking-tight text-balance text-white md:text-6xl'>
+              Drive Progress.{' '}
+              <span className='text-primary'>Reward Talent.</span> Grow
+              Communities.
             </h1>
 
-            <p className='mx-auto max-w-2xl text-lg leading-relaxed text-white/70 md:text-xl'>
-              Turn your ideas into reality with{' '}
-              <span
-                className='font-medium underline decoration-2 underline-offset-2'
-                style={{
-                  color: BRAND_COLOR,
-                  textDecorationColor: `${BRAND_COLOR}60`,
-                }}
-              >
-                milestone-based funding
+            <p className='mx-auto max-w-4xl text-lg leading-relaxed text-white/70 md:text-xl'>
+              <span className='block md:inline'>
+                Boundless provides robust infrastructure for organizations
+              </span>{' '}
+              <span className='block md:inline'>
+                to launch impactful programs and for creators to fund their
+                groundbreaking projects.
+              </span>{' '}
+              <span className='block md:inline'>
+                Clarity and reliability, every transaction.
               </span>
             </p>
           </div>
@@ -100,272 +73,23 @@ export default function Hero2() {
               onClick={() => router.push('/auth?mode=signup')}
               className='group'
             >
-              Get Started for Free
+              Start Your Program{' '}
               <ArrowRight className='h-4 w-4 transition-transform group-hover:translate-x-1' />
             </BoundlessButton>
 
             <BoundlessButton
               variant='outline'
               size='xl'
-              onClick={() => router.push('/organizations/new')}
+              onClick={() =>
+                document
+                  .getElementById('programs')
+                  ?.scrollIntoView({ behavior: 'smooth' })
+              }
               className='group'
             >
-              Host a Hackathon
+              Explore How It Works{' '}
               <ArrowRight className='h-4 w-4 transition-transform group-hover:translate-x-1' />
             </BoundlessButton>
-          </div>
-        </div>
-
-        <div className='relative mx-auto hidden h-[500px] max-w-5xl md:block'>
-          <div className='absolute top-12 left-0 z-10 w-72 -rotate-3 transform cursor-pointer shadow-xl transition-transform duration-300 hover:rotate-0'>
-            <HackathonCard
-              {...{
-                id: 'hackathon-1',
-                name: 'Boundless Innovation Hackathon',
-                slug: 'boundless-hackathon-2024',
-                tagline: 'Build the future of boundless',
-                description:
-                  'Join the biggest hackathon on Stellar blockchain. Build innovative solutions and compete for $50,000 in prizes.',
-                banner: '/banner.png',
-                organizationId: '1',
-                organization: {
-                  id: '1',
-                  name: 'Boundless',
-                  logo: '/bitmed.png',
-                },
-                status: 'ACTIVE' as const,
-                isActive: true,
-                isParticipant: false,
-                venueType: 'VIRTUAL' as const,
-                venueName: 'Virtual',
-                venueAddress: '123 Main St, Anytown, USA',
-                city: 'Anytown',
-                state: 'CA',
-                country: 'USA',
-                timezone: 'UTC',
-                startDate: '2024-05-01T09:00:00Z',
-                submissionDeadline: '2024-06-01T23:59:59Z',
-                registrationDeadline: '2024-05-15T23:59:59Z',
-                judgingDeadline: '2024-06-10T18:00:00Z',
-                registrationOpen: true,
-                daysUntilStart: 0,
-                participantType: 'INDIVIDUAL' as const,
-                teamMin: 1,
-                teamMax: 4,
-                categories: ['Web3', 'DeFi', 'Blockchain'],
-                enabledTabs: [
-                  'detailsTab',
-                  'participantsTab',
-                  'resourcesTab',
-                  'submissionTab',
-                  'announcementsTab',
-                  'discussionTab',
-                  'winnersTab',
-                  'sponsorsTab',
-                  'joinATeamTab',
-                  'rulesTab',
-                ],
-                judgingCriteria: [
-                  {
-                    id: '1',
-                    name: 'Best Project',
-                    description: 'For the best project',
-                    weight: 100,
-                  },
-                ],
-                prizeTiers: [
-                  {
-                    id: '1',
-                    name: '1',
-                    prizeAmount: '50000',
-                    description: 'For the best project',
-                  },
-                ],
-                phases: [
-                  {
-                    id: '1',
-                    name: 'Phase 1',
-                    startDate: '2024-01-01',
-                    endDate: '2024-01-01',
-                  },
-                ],
-                resources: [],
-                sponsorsPartners: [],
-                submissions: [],
-                followers: [],
-                participants: [],
-                requireGithub: true,
-                requireDemoVideo: true,
-                requireOtherLinks: true,
-                contactEmail: 'contact@boundless.com',
-                discord: 'https://discord.com/boundless',
-                telegram: 'https://t.me/boundless',
-                socialLinks: [
-                  'https://x.com/boundless',
-                  'https://www.linkedin.com/company/boundless',
-                ],
-                publishedAt: '2024-01-01',
-                createdAt: '2024-01-01',
-                updatedAt: '2024-01-01',
-                _count: { participants: 0, submissions: 0, followers: 0 },
-              }}
-            />
-          </div>
-
-          <div className='absolute top-0 left-1/2 z-20 w-80 -translate-x-1/2 transform cursor-pointer rounded-2xl shadow-xl transition-transform duration-300 hover:scale-105'>
-            <ProjectCard
-              data={
-                {
-                  id: 'project-1',
-                  slug: 'solar-power-initiative',
-                  fundingGoal: 100000,
-                  fundingRaised: 25000,
-                  fundingCurrency: 'USD',
-                  fundingEndDate: new Date(
-                    Date.now() + 15 * 24 * 60 * 60 * 1000
-                  ).toISOString(),
-                  voteGoal: 500,
-                  _count: { votes: 450 },
-                  project: {
-                    title: 'Solar Power Initiative',
-                    vision:
-                      'Revolutionary solar energy solution for rural communities',
-                    banner: '/banner.png',
-                    logo: '/bitmed.png',
-                    category: 'Sustainability',
-                    status: 'ACTIVE',
-                    creator: {
-                      name: 'Green Energy Team',
-                      image: '/bitmed.png',
-                    },
-                  },
-                } as any as Crowdfunding
-              }
-            />
-          </div>
-
-          <div className='absolute top-20 right-0 z-10 w-72 rotate-3 transform cursor-pointer rounded-2xl shadow-xl transition-transform duration-300 hover:rotate-0'>
-            <ProjectCard
-              data={
-                {
-                  id: 'project-2',
-                  slug: 'ai-learning-platform',
-                  voteGoal: 500,
-                  _count: { votes: 320 },
-                  fundingEndDate: new Date(
-                    Date.now() + 8 * 24 * 60 * 60 * 1000
-                  ).toISOString(),
-                  project: {
-                    title: 'AI Learning Platform',
-                    vision:
-                      'Democratizing AI education through interactive learning',
-                    banner: '/banner.png',
-                    logo: '/bitmed.png',
-                    category: 'Education',
-                    status: 'IDEA',
-                    creator: {
-                      name: 'AI Research Lab',
-                      image: '/bitmed.png',
-                    },
-                  },
-                } as any as Crowdfunding
-              }
-            />
-          </div>
-
-          <div className='absolute bottom-0 left-1/2 z-20 w-96 -translate-x-1/2 transform cursor-pointer rounded-2xl shadow-xl transition-transform duration-300 hover:scale-105'>
-            <HackathonCard
-              {...{
-                id: 'hackathon-2',
-                name: 'AI Innovation Challenge',
-                slug: 'ai-innovation-challenge',
-                tagline: 'Build the future of boundless',
-                description:
-                  'Build the next generation of AI-powered applications',
-                banner: '/banner.png',
-                organizationId: '1',
-                organization: {
-                  id: '1',
-                  name: 'Boundless',
-                  logo: '/bitmed.png',
-                },
-                status: 'UPCOMING' as const,
-                isActive: true,
-                isParticipant: false,
-                venueType: 'PHYSICAL' as const,
-                venueName: 'University of California, Los Angeles',
-                venueAddress: '123 Main St, Anytown, USA',
-                city: 'Los Angeles',
-                state: 'California',
-                country: 'United States',
-                timezone: 'America/Los_Angeles',
-                startDate: '2026-06-01T10:00:00Z',
-                submissionDeadline: '2026-06-25T23:59:59Z',
-                registrationDeadline: '2026-05-25T23:59:59Z',
-                judgingDeadline: '2026-06-28T18:00:00Z',
-                registrationOpen: true,
-                daysUntilStart: 100,
-                participantType: 'INDIVIDUAL' as const,
-                teamMin: 1,
-                teamMax: 4,
-                categories: ['AI', 'Machine Learning', 'Open Source'],
-                enabledTabs: [
-                  'detailsTab',
-                  'participantsTab',
-                  'resourcesTab',
-                  'submissionTab',
-                  'announcementsTab',
-                  'discussionTab',
-                  'winnersTab',
-                  'sponsorsTab',
-                  'joinATeamTab',
-                  'rulesTab',
-                ],
-                judgingCriteria: [
-                  {
-                    id: '1',
-                    name: 'Best Project',
-                    description: 'For the best project',
-                    weight: 100,
-                  },
-                ],
-                prizeTiers: [
-                  {
-                    id: '1',
-                    name: '1st Place',
-                    prizeAmount: '50000',
-                    description: 'For the best project',
-                  },
-                ],
-                phases: [
-                  {
-                    id: '1',
-                    name: 'Phase 1',
-                    startDate: '2026-06-01T10:00:00Z',
-                    endDate: '2026-06-30T17:00:00Z',
-                  },
-                ],
-                resources: [],
-                sponsorsPartners: [],
-                submissions: [],
-                followers: [],
-                participants: [],
-                requireGithub: true,
-                requireDemoVideo: true,
-                requireOtherLinks: true,
-                contactEmail: 'contact@boundless.com',
-                discord: 'https://discord.com/boundless',
-                telegram: 'https://t.me/boundless',
-                socialLinks: [
-                  'https://x.com/boundless',
-                  'https://www.linkedin.com/company/boundless',
-                ],
-                publishedAt: '2024-01-01',
-                createdAt: '2024-01-01',
-                updatedAt: '2024-01-01',
-                _count: { participants: 0, submissions: 0, followers: 0 },
-              }}
-            />
           </div>
         </div>
       </div>

--- a/components/landing-page/HowItWorksCompact.tsx
+++ b/components/landing-page/HowItWorksCompact.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { ArrowRight } from 'lucide-react';
 
 interface StepProps {
@@ -57,13 +56,15 @@ export default function HowItWorksCompact() {
       </div>
 
       <div className='mt-10 flex justify-center'>
-        <Link
-          href='/how-it-works'
+        <a
+          href='https://docs.boundlessfi.xyz/'
+          target='_blank'
+          rel='noopener noreferrer'
           className='text-primary group inline-flex items-center gap-2 text-sm font-medium underline-offset-4 hover:underline'
         >
           Dive Deeper into Our Mechanism
           <ArrowRight className='h-4 w-4 transition-transform group-hover:translate-x-1' />
-        </Link>
+        </a>
       </div>
     </section>
   );

--- a/components/landing-page/HowItWorksCompact.tsx
+++ b/components/landing-page/HowItWorksCompact.tsx
@@ -1,0 +1,70 @@
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+
+interface StepProps {
+  number: string;
+  title: string;
+  body: string;
+}
+
+const Step = ({ number, title, body }: StepProps) => (
+  <div className='bg-background-card relative flex flex-col gap-4 rounded-2xl border border-white/10 p-6 md:p-8'>
+    <div className='relative z-10 flex flex-col gap-4'>
+      <div className='flex items-center gap-3'>
+        <div className='flex h-9 w-9 items-center justify-center rounded-lg border border-white/10 bg-white/5 font-mono text-sm font-medium text-white'>
+          {number}
+        </div>
+        <div className='bg-border-subtle h-px flex-1' />
+      </div>
+
+      <h3 className='text-xl leading-[1.3] font-semibold text-white md:text-[22px]'>
+        {title}
+      </h3>
+
+      <p className='text-[15px] leading-[160%] text-white/70'>{body}</p>
+    </div>
+  </div>
+);
+
+export default function HowItWorksCompact() {
+  return (
+    <section className='relative w-full' aria-labelledby='how-it-works-heading'>
+      <header className='mx-auto max-w-3xl text-center'>
+        <h2
+          id='how-it-works-heading'
+          className='text-3xl leading-[140%] tracking-tight text-white md:text-4xl xl:text-[48px]'
+        >
+          Your Journey, Simplified.
+        </h2>
+      </header>
+
+      <div className='mt-12 grid gap-5 md:mt-16 md:grid-cols-3'>
+        <Step
+          number='01'
+          title='Define Your Vision.'
+          body='Quickly configure your program type, identify your audience, and set the conditions for success.'
+        />
+        <Step
+          number='02'
+          title='Secure Your Funds.'
+          body='Funds are held securely in a Soroban smart contract, releasing only when your predefined conditions are met.'
+        />
+        <Step
+          number='03'
+          title='Achieve & Receive.'
+          body='Upon verified outcomes — be it judged work, completed milestones, or accepted submissions — funds are automatically disbursed on-chain.'
+        />
+      </div>
+
+      <div className='mt-10 flex justify-center'>
+        <Link
+          href='/how-it-works'
+          className='text-primary group inline-flex items-center gap-2 text-sm font-medium underline-offset-4 hover:underline'
+        >
+          Dive Deeper into Our Mechanism
+          <ArrowRight className='h-4 w-4 transition-transform group-hover:translate-x-1' />
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/components/landing-page/NewsLetter.tsx
+++ b/components/landing-page/NewsLetter.tsx
@@ -13,7 +13,8 @@ const NewsLetter = () => {
 
   return (
     <section
-      className='relative my-[98px] h-full w-full'
+      id='newsletter'
+      className='relative my-[98px] h-full w-full scroll-mt-24'
       aria-labelledby='newsletter-heading'
     >
       <div

--- a/components/landing-page/TrustAndProof.tsx
+++ b/components/landing-page/TrustAndProof.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link';
+import { ArrowRight, BadgeCheck } from 'lucide-react';
+
+const fundedCapabilities = [
+  'Milestone contracts on Soroban',
+  'Contribution Hub for bounties and open-source work',
+  'Wallet-linked contributor profiles',
+  'KYC and on-ramp integrations',
+];
+
+export default function TrustAndProof() {
+  return (
+    <section className='relative w-full' aria-labelledby='trust-heading'>
+      <div className='bg-background-card relative overflow-hidden rounded-[24px] border border-white/10 p-8 md:p-12 lg:p-16'>
+        <div className='grid gap-10 lg:grid-cols-[7fr_5fr] lg:items-center lg:gap-16'>
+          <div>
+            <div className='border-primary/30 bg-primary/10 inline-flex items-center gap-2 rounded-full border px-3 py-1.5'>
+              <BadgeCheck className='text-primary' size={14} strokeWidth={2} />
+              <span className='text-primary text-xs font-medium tracking-wide uppercase'>
+                Stellar Community Fund #40
+              </span>
+            </div>
+
+            <h2
+              id='trust-heading'
+              className='mt-5 text-3xl leading-[120%] tracking-tight text-white md:text-4xl xl:text-[44px]'
+            >
+              Validated by the Community.
+            </h2>
+
+            <p className='mt-5 max-w-2xl text-base leading-[170%] text-white/70 md:text-lg'>
+              Boundless proudly received the Stellar Community Fund #40 award.
+              This grant directly supported the development of key features now
+              live on our platform, including Soroban milestone contracts, the
+              Contribution Hub for bounties, wallet-linked contributor profiles,
+              and essential KYC and on-ramp integrations.
+            </p>
+
+            <Link
+              href='/blog/boundless-wins-stellar-community-fund-40'
+              className='hover:text-primary group mt-6 inline-flex items-center gap-2 text-sm font-medium text-white underline-offset-4 hover:underline'
+            >
+              Read the SCF #40 announcement
+              <ArrowRight className='h-4 w-4 transition-transform group-hover:translate-x-1' />
+            </Link>
+          </div>
+
+          <div className='relative rounded-2xl border border-white/10 bg-white/5 p-6 md:p-8'>
+            <p className='text-xs font-medium tracking-wide text-white/50 uppercase'>
+              What the grant funded — now live
+            </p>
+            <ul className='mt-4 space-y-3'>
+              {fundedCapabilities.map(item => (
+                <li
+                  key={item}
+                  className='flex items-start gap-3 text-sm leading-[160%] text-white/85 md:text-base'
+                >
+                  <span className='bg-primary mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full' />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/landing-page/WhyStellar.tsx
+++ b/components/landing-page/WhyStellar.tsx
@@ -1,0 +1,85 @@
+import Link from 'next/link';
+import {
+  ArrowRight,
+  Zap,
+  CircleDollarSign,
+  Globe2,
+  ShieldCheck,
+} from 'lucide-react';
+
+interface ReasonProps {
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+}
+
+const Reason = ({ icon, title, body }: ReasonProps) => (
+  <div className='flex flex-col gap-3 rounded-xl border border-white/10 bg-white/5 p-5'>
+    <div className='bg-background-card flex h-9 w-9 items-center justify-center rounded-lg border border-white/10'>
+      <div className='text-white/75'>{icon}</div>
+    </div>
+    <h3 className='text-base font-semibold text-white md:text-lg'>{title}</h3>
+    <p className='text-sm leading-[160%] text-white/70'>{body}</p>
+  </div>
+);
+
+export default function WhyStellar() {
+  return (
+    <section className='relative w-full' aria-labelledby='why-stellar-heading'>
+      <div className='bg-background-card relative overflow-hidden rounded-[24px] border border-white/10 p-8 md:p-12 lg:p-16'>
+        <div className='relative grid gap-12 lg:grid-cols-[5fr_7fr] lg:gap-16'>
+          <header className='flex flex-col justify-center'>
+            <p className='text-primary text-sm font-medium tracking-wide uppercase'>
+              Built on Stellar
+            </p>
+            <h2
+              id='why-stellar-heading'
+              className='mt-3 text-3xl leading-[120%] tracking-tight text-white md:text-4xl xl:text-[44px]'
+            >
+              The Stellar Advantage.
+            </h2>
+            <p className='mt-5 text-base leading-[170%] text-white/70 md:text-lg'>
+              Boundless leverages Stellar to deliver unparalleled speed,
+              cost-efficiency, and reliability. Experience near-instant fund
+              finalization, minimal transaction fees, native USDC support for
+              frictionless funding, and robust dispute resolution powered by
+              Soroban&apos;s clawback functionality.
+            </p>
+            <Link
+              href='https://stellar.org/'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='hover:text-primary group mt-6 inline-flex items-center gap-2 self-start text-sm font-medium text-white underline-offset-4 hover:underline'
+            >
+              Explore Stellar&apos;s Power
+              <ArrowRight className='h-4 w-4 transition-transform group-hover:translate-x-1' />
+            </Link>
+          </header>
+
+          <div className='grid gap-4 sm:grid-cols-2'>
+            <Reason
+              icon={<Zap size={18} strokeWidth={1.75} />}
+              title='3–5 second finality'
+              body='Transactions finalize in 3–5 seconds, so funds release at human speed.'
+            />
+            <Reason
+              icon={<CircleDollarSign size={18} strokeWidth={1.75} />}
+              title='Sub-cent fees'
+              body='Fees are fractions of a cent, so on-chain milestone checks are not economically prohibitive.'
+            />
+            <Reason
+              icon={<Globe2 size={18} strokeWidth={1.75} />}
+              title='Native USDC'
+              body='USDC is native on Stellar, so funding rounds work without bridging.'
+            />
+            <Reason
+              icon={<ShieldCheck size={18} strokeWidth={1.75} />}
+              title='Soroban clawback'
+              body='Soroban supports clawback, which gives every program a working dispute path.'
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/landing-page/blog/BlogSectionClient.tsx
+++ b/components/landing-page/blog/BlogSectionClient.tsx
@@ -45,7 +45,7 @@ const BlogSectionClient = ({ posts }: BlogSectionClientProps) => {
               id='blog-heading'
               className='mt-3 text-left text-[32px] leading-[140%] tracking-[0.48px] text-white md:text-[48px]'
             >
-              Ideas that shape the future
+              Insights &amp; Stories.
             </h2>
             <p className='gradient-text-2 mt-3 max-w-[550px] text-left text-base leading-[160%] tracking-[-0.48px]'>
               Discover stories, tips, and updates on crowdfunding, grants, and

--- a/components/landing-page/footer.tsx
+++ b/components/landing-page/footer.tsx
@@ -48,6 +48,12 @@ export function Footer() {
                 Docs
               </Link>
               <Link
+                href='/newsletter'
+                className='hover:text-primary rounded text-sm text-[#B5B5B5] transition-colors focus:ring-2 focus:ring-white/50 focus:outline-none'
+              >
+                Newsletter
+              </Link>
+              <Link
                 href='/terms'
                 className='hover:text-primary rounded text-sm text-[#B5B5B5] transition-colors focus:ring-2 focus:ring-white/50 focus:outline-none'
               >
@@ -130,6 +136,12 @@ export function Footer() {
               rel='noopener noreferrer'
             >
               Docs
+            </Link>
+            <Link
+              href='/newsletter'
+              className='hover:text-primary rounded text-sm text-[#B5B5B5] transition-colors focus:ring-2 focus:ring-white/50 focus:outline-none'
+            >
+              Newsletter
             </Link>
             <Link
               href='/terms'

--- a/components/landing-page/illustrations/BountyMock.tsx
+++ b/components/landing-page/illustrations/BountyMock.tsx
@@ -1,0 +1,67 @@
+/**
+ * BountyMock
+ *
+ * Flat UI mockup of a posted bounty, themed via tokens.
+ */
+const BountyMock = () => {
+  return (
+    <div
+      className='flex h-full w-full items-center justify-center px-3 py-3'
+      role='img'
+      aria-label='Mockup of an open $1,200 bounty for a CSV exporter task'
+    >
+      <div className='bg-elevated w-full max-w-[240px] rounded-xl border border-white/10 px-3.5 py-3 shadow-[0_12px_40px_rgba(0,0,0,0.18)] dark:shadow-[0_12px_40px_rgba(0,0,0,0.45)]'>
+        <div className='flex items-start justify-between'>
+          <div className='flex-1'>
+            <div className='font-mono text-[8px] tracking-[0.18em] text-white/50 uppercase'>
+              Bounty · #b_148
+            </div>
+            <div className='mt-1 text-[13px] font-semibold tracking-tight text-white'>
+              CSV exporter
+            </div>
+          </div>
+          <div className='ml-2 rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[8px] font-bold tracking-[0.15em] text-white uppercase'>
+            Open
+          </div>
+        </div>
+
+        {/* Description lines */}
+        <div className='mt-3 space-y-1.5'>
+          <div className='bg-border-subtle h-1 w-full rounded-full' />
+          <div className='bg-border-subtle h-1 w-5/6 rounded-full' />
+          <div className='bg-border-subtle h-1 w-2/3 rounded-full' />
+        </div>
+
+        {/* Tags */}
+        <div className='mt-3 flex flex-wrap gap-1'>
+          <span className='rounded-md border border-white/10 px-1.5 py-0.5 font-mono text-[8px] tracking-wide text-white/50 uppercase'>
+            Backend
+          </span>
+          <span className='rounded-md border border-white/10 px-1.5 py-0.5 font-mono text-[8px] tracking-wide text-white/50 uppercase'>
+            14d
+          </span>
+        </div>
+
+        {/* Reward */}
+        <div className='mt-3 flex items-end justify-between border-t border-white/10 pt-2.5'>
+          <div>
+            <div className='font-mono text-[8px] tracking-[0.18em] text-white/50 uppercase'>
+              Reward
+            </div>
+            <div className='mt-0.5 text-base font-semibold tracking-tight text-white'>
+              $1,200
+            </div>
+          </div>
+          <div className='flex items-center gap-1'>
+            <span className='bg-primary h-1.5 w-1.5 rounded-full' />
+            <span className='font-mono text-[8px] tracking-[0.15em] text-white/50 uppercase'>
+              On-chain
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BountyMock;

--- a/components/landing-page/illustrations/BuilderMock.tsx
+++ b/components/landing-page/illustrations/BuilderMock.tsx
@@ -1,0 +1,68 @@
+/**
+ * BuilderMock
+ *
+ * Stacked submission cards showing milestone-based payout. Themed via tokens.
+ */
+const BuilderMock = () => {
+  return (
+    <div
+      className='relative flex h-full w-full items-center justify-center px-5 py-5'
+      role='img'
+      aria-label='Mockup of a builder submission card showing milestone 2 of 3 paid out at $2,500 with a PAID status pill'
+    >
+      {/* Back card 2 */}
+      <div
+        className='bg-elevated/50 absolute h-[140px] w-[230px] translate-x-6 -translate-y-2 rotate-[6deg] rounded-xl border border-white/10'
+        aria-hidden='true'
+      />
+      {/* Back card 1 */}
+      <div
+        className='bg-elevated/75 absolute h-[148px] w-[240px] translate-x-3 -translate-y-1 -rotate-[4deg] rounded-xl border border-white/10'
+        aria-hidden='true'
+      />
+
+      {/* Front card */}
+      <div className='bg-elevated relative w-full max-w-[260px] rounded-xl border border-white/10 px-4 py-4 shadow-[0_12px_40px_rgba(0,0,0,0.18)] dark:shadow-[0_12px_40px_rgba(0,0,0,0.45)]'>
+        <div className='flex items-start justify-between'>
+          <div>
+            <div className='font-mono text-[8px] tracking-[0.18em] text-white/50 uppercase'>
+              Submission · #sub_a42
+            </div>
+            <div className='mt-1 text-base font-semibold tracking-tight text-white'>
+              Milestone 2 of 3
+            </div>
+          </div>
+          <div className='bg-primary rounded-full px-2 py-0.5 text-[9px] font-bold tracking-wider text-black'>
+            PAID
+          </div>
+        </div>
+
+        {/* Milestone progress bar */}
+        <div className='mt-3 flex items-center gap-1.5'>
+          <span className='bg-primary h-1.5 flex-1 rounded-full' />
+          <span className='bg-primary h-1.5 flex-1 rounded-full' />
+          <span className='bg-border-subtle h-1.5 flex-1 rounded-full' />
+        </div>
+
+        {/* Body lines */}
+        <div className='mt-3.5 space-y-1.5'>
+          <div className='bg-border-subtle h-1 w-full rounded-full' />
+          <div className='bg-border-subtle h-1 w-5/6 rounded-full' />
+          <div className='bg-border-subtle h-1 w-2/3 rounded-full' />
+        </div>
+
+        {/* Total */}
+        <div className='mt-3.5 flex items-end justify-between border-t border-white/10 pt-2.5'>
+          <span className='font-mono text-[9px] tracking-[0.18em] text-white/50 uppercase'>
+            Released
+          </span>
+          <span className='text-base font-semibold tracking-tight text-white'>
+            $2,500
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BuilderMock;

--- a/components/landing-page/illustrations/CrowdfundingMock.tsx
+++ b/components/landing-page/illustrations/CrowdfundingMock.tsx
@@ -1,0 +1,107 @@
+/**
+ * CrowdfundingMock
+ *
+ * Flat UI mockup of a crowdfunding campaign card with funding progress, themed via tokens.
+ */
+const CrowdfundingMock = () => {
+  return (
+    <div
+      className='flex h-full w-full items-center justify-center px-4 py-4'
+      role='img'
+      aria-label='Mockup of a crowdfunding campaign at 65 percent funded with $32,500 raised of $50,000, 47 backers, 8 days left'
+    >
+      <div className='bg-elevated w-full max-w-[300px] rounded-xl border border-white/10 shadow-[0_12px_40px_rgba(0,0,0,0.18)] dark:shadow-[0_12px_40px_rgba(0,0,0,0.45)]'>
+        {/* Header — project identity */}
+        <div className='flex items-center gap-2.5 border-b border-white/10 px-3.5 py-3'>
+          <div className='flex h-8 w-8 items-center justify-center rounded-md border border-white/10 bg-white/5'>
+            <svg
+              width='16'
+              height='16'
+              viewBox='0 0 16 16'
+              fill='none'
+              xmlns='http://www.w3.org/2000/svg'
+            >
+              <circle
+                cx='8'
+                cy='8'
+                r='3'
+                fill='currentColor'
+                className='text-white/85'
+              />
+              <g
+                stroke='currentColor'
+                strokeWidth='1.25'
+                strokeLinecap='round'
+                opacity='0.6'
+                className='text-white/70'
+              >
+                <line x1='8' y1='1.5' x2='8' y2='3' />
+                <line x1='8' y1='13' x2='8' y2='14.5' />
+                <line x1='1.5' y1='8' x2='3' y2='8' />
+                <line x1='13' y1='8' x2='14.5' y2='8' />
+                <line x1='3.5' y1='3.5' x2='4.5' y2='4.5' />
+                <line x1='11.5' y1='11.5' x2='12.5' y2='12.5' />
+                <line x1='3.5' y1='12.5' x2='4.5' y2='11.5' />
+                <line x1='11.5' y1='4.5' x2='12.5' y2='3.5' />
+              </g>
+            </svg>
+          </div>
+          <div className='flex-1'>
+            <div className='text-[13px] font-semibold tracking-tight text-white'>
+              SolarFi
+            </div>
+            <div className='font-mono text-[8px] tracking-[0.18em] text-white/50 uppercase'>
+              Sustainability · M1 of 4
+            </div>
+          </div>
+          <div className='rounded-md border border-white/10 px-1.5 py-0.5 font-mono text-[8px] tracking-[0.15em] text-white/50 uppercase'>
+            Funding
+          </div>
+        </div>
+
+        {/* Progress */}
+        <div className='px-3.5 py-3'>
+          <div className='flex items-baseline justify-between'>
+            <span className='text-lg font-bold tracking-tight text-white'>
+              $32,500
+            </span>
+            <span className='font-mono text-[10px] text-white/50'>
+              of $50,000
+            </span>
+          </div>
+          <div className='bg-border-subtle mt-2 h-2 w-full overflow-hidden rounded-full'>
+            <div className='bg-primary h-full w-[65%] rounded-full' />
+          </div>
+        </div>
+
+        {/* Stats row */}
+        <div className='grid grid-cols-3 gap-2 border-t border-white/10 px-3.5 py-2.5'>
+          <div>
+            <div className='font-mono text-[8px] tracking-[0.15em] text-white/50 uppercase'>
+              Backers
+            </div>
+            <div className='mt-0.5 text-[11px] font-semibold text-white'>
+              47
+            </div>
+          </div>
+          <div>
+            <div className='font-mono text-[8px] tracking-[0.15em] text-white/50 uppercase'>
+              Days left
+            </div>
+            <div className='mt-0.5 text-[11px] font-semibold text-white'>8</div>
+          </div>
+          <div>
+            <div className='font-mono text-[8px] tracking-[0.15em] text-white/50 uppercase'>
+              Funded
+            </div>
+            <div className='mt-0.5 text-[11px] font-semibold text-white'>
+              65%
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CrowdfundingMock;

--- a/components/landing-page/illustrations/GrantMock.tsx
+++ b/components/landing-page/illustrations/GrantMock.tsx
@@ -1,0 +1,106 @@
+/**
+ * GrantMock
+ *
+ * Flat UI mockup of a staged grant program with three milestones, themed via tokens.
+ */
+const GrantMock = () => {
+  return (
+    <div
+      className='flex h-full w-full items-center justify-center px-3 py-3'
+      role='img'
+      aria-label='Mockup of a staged grant program with three milestones, two completed and one pending'
+    >
+      <div className='bg-elevated w-full max-w-[240px] rounded-xl border border-white/10 px-3.5 py-3 shadow-[0_12px_40px_rgba(0,0,0,0.18)] dark:shadow-[0_12px_40px_rgba(0,0,0,0.45)]'>
+        <div className='font-mono text-[8px] tracking-[0.18em] text-white/50 uppercase'>
+          Grant · #infra-2026
+        </div>
+        <div className='mt-1 text-[13px] font-semibold tracking-tight text-white'>
+          Staged release
+        </div>
+
+        {/* Milestones */}
+        <div className='mt-3 space-y-1.5'>
+          {/* M1 — paid */}
+          <div className='border-primary/30 bg-primary/10 flex items-center justify-between rounded-md border px-2.5 py-1.5'>
+            <div className='flex items-center gap-2'>
+              <span className='bg-primary flex h-3.5 w-3.5 items-center justify-center rounded-full'>
+                <svg
+                  width='7'
+                  height='7'
+                  viewBox='0 0 7 7'
+                  fill='none'
+                  xmlns='http://www.w3.org/2000/svg'
+                >
+                  <path
+                    d='M1 3.5 L2.75 5 L6 1.75'
+                    stroke='var(--on-mint)'
+                    strokeWidth='1.2'
+                    strokeLinecap='round'
+                    strokeLinejoin='round'
+                  />
+                </svg>
+              </span>
+              <span className='text-[10px] font-medium text-white'>M1</span>
+            </div>
+            <span className='text-primary font-mono text-[9px] font-semibold'>
+              $10,000
+            </span>
+          </div>
+
+          {/* M2 — paid */}
+          <div className='border-primary/30 bg-primary/10 flex items-center justify-between rounded-md border px-2.5 py-1.5'>
+            <div className='flex items-center gap-2'>
+              <span className='bg-primary flex h-3.5 w-3.5 items-center justify-center rounded-full'>
+                <svg
+                  width='7'
+                  height='7'
+                  viewBox='0 0 7 7'
+                  fill='none'
+                  xmlns='http://www.w3.org/2000/svg'
+                >
+                  <path
+                    d='M1 3.5 L2.75 5 L6 1.75'
+                    stroke='var(--on-mint)'
+                    strokeWidth='1.2'
+                    strokeLinecap='round'
+                    strokeLinejoin='round'
+                  />
+                </svg>
+              </span>
+              <span className='text-[10px] font-medium text-white'>M2</span>
+            </div>
+            <span className='text-primary font-mono text-[9px] font-semibold'>
+              $10,000
+            </span>
+          </div>
+
+          {/* M3 — pending */}
+          <div className='flex items-center justify-between rounded-md border border-white/10 px-2.5 py-1.5'>
+            <div className='flex items-center gap-2'>
+              <span className='border-border-strong h-3.5 w-3.5 rounded-full border' />
+              <span className='text-[10px] font-medium text-white/70'>M3</span>
+            </div>
+            <span className='font-mono text-[9px] font-medium text-white/50'>
+              $10,000
+            </span>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className='mt-3 flex items-center justify-between border-t border-white/10 pt-2'>
+          <span className='font-mono text-[8px] tracking-[0.15em] text-white/50 uppercase'>
+            Released
+          </span>
+          <span className='text-[11px] font-semibold text-white'>
+            $20K{' '}
+            <span className='font-mono text-[9px] font-normal text-white/50'>
+              / $30K
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GrantMock;

--- a/components/landing-page/illustrations/HackathonMock.tsx
+++ b/components/landing-page/illustrations/HackathonMock.tsx
@@ -1,0 +1,86 @@
+/**
+ * HackathonMock
+ *
+ * Flat UI mockup of a hackathon leaderboard. Themed via tokens.
+ */
+const HackathonMock = () => {
+  return (
+    <div
+      className='flex h-full w-full items-center justify-center px-4 py-4'
+      role='img'
+      aria-label='Mockup of a hackathon final standings leaderboard with three placed entries and a $50,000 prize pool'
+    >
+      <div className='bg-elevated w-full max-w-[300px] rounded-xl border border-white/10 shadow-[0_12px_40px_rgba(0,0,0,0.18)] dark:shadow-[0_12px_40px_rgba(0,0,0,0.45)]'>
+        {/* Header */}
+        <div className='flex items-start justify-between border-b border-white/10 px-3.5 py-2.5'>
+          <div>
+            <div className='font-mono text-[8px] tracking-[0.18em] text-white/50 uppercase'>
+              Hackathon · #boundless_q4
+            </div>
+            <div className='mt-0.5 text-[13px] font-semibold tracking-tight text-white'>
+              Final standings
+            </div>
+          </div>
+          <div className='rounded-md border border-white/10 bg-white/5 px-2 py-0.5 font-mono text-[9px] font-semibold tracking-wider text-white'>
+            $50K POOL
+          </div>
+        </div>
+
+        {/* Leaderboard */}
+        <div className='space-y-1.5 px-3.5 py-3'>
+          {/* 1st place — highlighted */}
+          <div className='border-primary/30 bg-primary/10 flex items-center justify-between rounded-md border px-2.5 py-2'>
+            <div className='flex items-center gap-2.5'>
+              <span className='text-primary font-mono text-[10px] font-bold'>
+                01
+              </span>
+              <span className='bg-primary/60 h-2 w-2 rounded-full' />
+              <span className='bg-foreground/30 h-1 w-20 rounded-full' />
+            </div>
+            <span className='text-[11px] font-semibold text-white'>
+              $25,000
+            </span>
+          </div>
+
+          {/* 2nd */}
+          <div className='flex items-center justify-between rounded-md border border-white/10 px-2.5 py-2'>
+            <div className='flex items-center gap-2.5'>
+              <span className='font-mono text-[10px] font-bold text-white/50'>
+                02
+              </span>
+              <span className='bg-border-strong h-2 w-2 rounded-full' />
+              <span className='bg-border-strong h-1 w-16 rounded-full' />
+            </div>
+            <span className='text-[11px] font-medium text-white/70'>
+              $15,000
+            </span>
+          </div>
+
+          {/* 3rd */}
+          <div className='flex items-center justify-between rounded-md border border-white/10 px-2.5 py-2'>
+            <div className='flex items-center gap-2.5'>
+              <span className='font-mono text-[10px] font-bold text-white/50'>
+                03
+              </span>
+              <span className='bg-border-strong h-2 w-2 rounded-full' />
+              <span className='bg-border-strong h-1 w-14 rounded-full' />
+            </div>
+            <span className='text-[11px] font-medium text-white/70'>
+              $10,000
+            </span>
+          </div>
+        </div>
+
+        {/* Footer / status */}
+        <div className='flex items-center justify-between border-t border-white/10 px-3.5 py-2'>
+          <span className='font-mono text-[8px] tracking-[0.15em] text-white/50 uppercase'>
+            Released on-chain
+          </span>
+          <span className='bg-primary h-1.5 w-1.5 rounded-full' />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HackathonMock;

--- a/components/landing-page/illustrations/OrganizerMock.tsx
+++ b/components/landing-page/illustrations/OrganizerMock.tsx
@@ -1,0 +1,89 @@
+/**
+ * OrganizerMock
+ *
+ * A flat browser-window UI mockup showing the program-creation flow on
+ * Boundless. Themed via tokens so it works in both light and dark mode.
+ * Mint accent on the active program-type chip and the primary CTA.
+ */
+const OrganizerMock = () => {
+  return (
+    <div
+      className='flex h-full w-full items-center justify-center px-5 py-5'
+      role='img'
+      aria-label='Mockup of the Boundless program-creation screen with a $50,000 hackathon prize pool and a Create program button'
+    >
+      <div className='bg-elevated w-full max-w-[280px] rounded-xl border border-white/10 shadow-[0_12px_40px_rgba(0,0,0,0.18)] dark:shadow-[0_12px_40px_rgba(0,0,0,0.45)]'>
+        {/* Title bar */}
+        <div className='flex items-center gap-2 border-b border-white/10 px-3 py-2'>
+          <div className='flex gap-1'>
+            <span
+              className='bg-border-strong h-2 w-2 rounded-full'
+              aria-hidden
+            />
+            <span
+              className='bg-border-strong h-2 w-2 rounded-full'
+              aria-hidden
+            />
+            <span
+              className='bg-border-strong h-2 w-2 rounded-full'
+              aria-hidden
+            />
+          </div>
+          <div className='ml-1 flex flex-1 items-center justify-center rounded-md border border-white/10 bg-white/5 px-2 py-1'>
+            <span className='font-mono text-[9px] tracking-tight text-white/50'>
+              boundless.xyz/programs/new
+            </span>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className='px-4 py-3.5'>
+          <div className='font-mono text-[8px] tracking-[0.18em] text-white/50 uppercase'>
+            New program · #hck_q4
+          </div>
+          <div className='mt-1.5 text-lg font-semibold tracking-tight text-white'>
+            $50,000 USD
+          </div>
+
+          <div className='mt-3 flex flex-wrap gap-1.5'>
+            <span className='bg-primary rounded-full px-2.5 py-0.5 text-[9px] font-semibold text-black'>
+              Hackathon
+            </span>
+            <span className='rounded-full border border-white/10 px-2.5 py-0.5 text-[9px] font-medium text-white/70'>
+              Grant
+            </span>
+            <span className='rounded-full border border-white/10 px-2.5 py-0.5 text-[9px] font-medium text-white/70'>
+              Bounty
+            </span>
+          </div>
+
+          {/* Field rows */}
+          <div className='mt-3 space-y-1.5'>
+            <div className='flex items-center justify-between border-b border-white/10 pb-1.5'>
+              <span className='font-mono text-[9px] tracking-wide text-white/50 uppercase'>
+                Release rule
+              </span>
+              <span className='text-[10px] font-medium text-white'>
+                Judging
+              </span>
+            </div>
+            <div className='flex items-center justify-between'>
+              <span className='font-mono text-[9px] tracking-wide text-white/50 uppercase'>
+                Escrow
+              </span>
+              <span className='text-[10px] font-medium text-white'>
+                Soroban · USDC
+              </span>
+            </div>
+          </div>
+
+          <div className='bg-primary mt-3 flex w-full items-center justify-center gap-1 rounded-lg px-3 py-2 text-[11px] font-semibold text-black'>
+            Create program →
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OrganizerMock;

--- a/components/overview/Newsletter.tsx
+++ b/components/overview/Newsletter.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useRef, useState } from 'react';
+import React from 'react';
 import {
   Dialog,
   DialogClose,
@@ -8,34 +8,8 @@ import {
   DialogTitle,
 } from '../ui/dialog';
 import Image from 'next/image';
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '../ui/form';
-
-import { z } from 'zod';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { User, Mail } from 'lucide-react';
-import { BoundlessButton } from '../buttons';
-import { Input } from '../ui/input';
-import gsap from 'gsap';
-import { useGSAP } from '@gsap/react';
-import {
-  newsletterSubscribe,
-  type NewsletterApiError,
-  type NewsletterTag,
-} from '@/lib/api/waitlist';
 import { Button } from '../ui/button';
-
-const formSchema = z.object({
-  name: z.string().min(2).max(50),
-  email: z.email(),
-});
+import NewsletterForm from './NewsletterForm';
 
 const Newsletter = ({
   open,
@@ -44,70 +18,6 @@ const Newsletter = ({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) => {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [selectedTags, setSelectedTags] = useState<NewsletterTag[]>([]);
-  const form = useForm<z.infer<typeof formSchema>>({
-    resolver: zodResolver(formSchema),
-    defaultValues: {
-      name: '',
-      email: '',
-    },
-  });
-  gsap.registerPlugin(useGSAP);
-  const nameFieldRef = useRef<HTMLDivElement>(null);
-  const emailFieldRef = useRef<HTMLDivElement>(null);
-
-  const animateFieldFocus = (
-    fieldRef: React.RefObject<HTMLDivElement | null>
-  ) => {
-    if (fieldRef.current) {
-      gsap.to(fieldRef.current, {
-        duration: 0.3,
-        scale: 1.02,
-        boxShadow: '0 0 0 1px rgb(167,249,80)',
-        ease: 'power2.out',
-      });
-    }
-  };
-
-  const animateFieldBlur = (
-    fieldRef: React.RefObject<HTMLDivElement | null>
-  ) => {
-    if (fieldRef.current) {
-      gsap.to(fieldRef.current, {
-        duration: 0.3,
-        scale: 1,
-        boxShadow: 'none',
-        ease: 'power2.out',
-      });
-    }
-  };
-
-  const onSubmit = async (values: z.infer<typeof formSchema>) => {
-    setError(null);
-    setIsSubmitting(true);
-    try {
-      await newsletterSubscribe({
-        email: values.email,
-        name: values.name,
-        source: 'website',
-        tags: selectedTags,
-      });
-      onOpenChange(false);
-      window.location.href = '/newsletter/confirmed';
-    } catch (err) {
-      const e = err as NewsletterApiError;
-      if (e.code === 'ALREADY_SUBSCRIBED')
-        setError('This email is already subscribed.');
-      else if (e.code === 'RATE_LIMITED')
-        setError('Too many attempts. Please try again in a minute.');
-      else if (e.code === 'INVALID_TAGS') setError('Invalid topic selection.');
-      else setError('Failed to submit form. Please try again.');
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
@@ -147,106 +57,8 @@ const Newsletter = ({
                 </div>
               </DialogTitle>
               <div className='mt-10'>
-                <Form {...form}>
-                  <form onSubmit={form.handleSubmit(onSubmit)}>
-                    <FormField
-                      control={form.control}
-                      name='name'
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel className='sr-only'>Name</FormLabel>
-                          <FormControl>
-                            <div
-                              ref={nameFieldRef}
-                              className='relative flex h-12 items-center rounded-lg border border-[#2B2B2B] bg-[#101010] p-4 backdrop-blur-sm transition-all duration-300'
-                              onFocus={() => animateFieldFocus(nameFieldRef)}
-                              onBlur={() => animateFieldBlur(nameFieldRef)}
-                            >
-                              <User className='h-5 w-5 text-[#B5B5B5]' />
-                              <Input
-                                {...field}
-                                placeholder='Enter your name'
-                                className='focus-visible:ring-none absolute top-0 left-0 h-full border-none bg-transparent pl-10 text-white caret-[rgb(167,249,80)] placeholder:text-[#B5B5B5] focus-visible:ring-[0px]'
-                              />
-                            </div>
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                    <FormField
-                      control={form.control}
-                      name='email'
-                      render={({ field }) => (
-                        <FormItem className='mt-3'>
-                          <FormLabel className='sr-only'>Email</FormLabel>
-                          <FormControl>
-                            <div
-                              ref={emailFieldRef}
-                              className='relative flex h-12 items-center rounded-lg border border-[#2B2B2B] bg-[#101010] p-4 backdrop-blur-sm transition-all duration-300'
-                              onFocus={() => animateFieldFocus(emailFieldRef)}
-                              onBlur={() => animateFieldBlur(emailFieldRef)}
-                            >
-                              <Mail className='h-5 w-5 text-[#B5B5B5]' />
-                              <Input
-                                {...field}
-                                placeholder='Enter your email'
-                                className='focus-visible:ring-none caret-primary absolute top-0 left-0 h-full border-none bg-transparent pl-10 text-white placeholder:text-[#B5B5B5] focus-visible:ring-[0px]'
-                              />
-                            </div>
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-
-                    <div className='mt-4 flex flex-wrap gap-3'>
-                      {(
-                        [
-                          'bounties',
-                          'hackathons',
-                          'grants',
-                          'updates',
-                        ] as NewsletterTag[]
-                      ).map(tag => (
-                        <label
-                          key={tag}
-                          className='flex cursor-pointer items-center gap-1.5 text-sm text-[#D9D9D9]'
-                        >
-                          <input
-                            type='checkbox'
-                            className='accent-primary'
-                            checked={selectedTags.includes(tag)}
-                            onChange={() =>
-                              setSelectedTags(p =>
-                                p.includes(tag)
-                                  ? p.filter(t => t !== tag)
-                                  : [...p, tag]
-                              )
-                            }
-                          />
-                          {tag.charAt(0).toUpperCase() + tag.slice(1)}
-                        </label>
-                      ))}
-                    </div>
-
-                    <BoundlessButton
-                      variant={form.formState.isValid ? 'default' : 'outline'}
-                      type='submit'
-                      fullWidth
-                      size='xl'
-                      disabled={!form.formState.isValid}
-                      loading={isSubmitting}
-                      className='mt-11 w-full disabled:border-[#2B2B2B] disabled:bg-[#212121] disabled:text-[#787878]'
-                    >
-                      Subscribe
-                    </BoundlessButton>
-                  </form>
-                </Form>
+                <NewsletterForm onSuccess={() => onOpenChange(false)} />
               </div>
-              {error && (
-                <p className='mt-2 text-center text-sm text-red-500'>{error}</p>
-              )}
               <DialogClose asChild>
                 <Button variant='link' className='text-white underline'>
                   Maybe Later

--- a/components/overview/NewsletterForm.tsx
+++ b/components/overview/NewsletterForm.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '../ui/form';
+import { z } from 'zod';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { User, Mail } from 'lucide-react';
+import { BoundlessButton } from '../buttons';
+import { Input } from '../ui/input';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
+import {
+  newsletterSubscribe,
+  type NewsletterApiError,
+  type NewsletterTag,
+} from '@/lib/api/waitlist';
+
+const formSchema = z.object({
+  name: z.string().min(2).max(50),
+  email: z.email(),
+});
+
+interface NewsletterFormProps {
+  onSuccess?: () => void;
+  source?: string;
+}
+
+const NewsletterForm = ({
+  onSuccess,
+  source = 'website',
+}: NewsletterFormProps) => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedTags, setSelectedTags] = useState<NewsletterTag[]>([]);
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { name: '', email: '' },
+  });
+  gsap.registerPlugin(useGSAP);
+  const nameFieldRef = useRef<HTMLDivElement>(null);
+  const emailFieldRef = useRef<HTMLDivElement>(null);
+
+  const animateFieldFocus = (
+    fieldRef: React.RefObject<HTMLDivElement | null>
+  ) => {
+    if (fieldRef.current) {
+      gsap.to(fieldRef.current, {
+        duration: 0.3,
+        scale: 1.02,
+        boxShadow: '0 0 0 1px rgb(167,249,80)',
+        ease: 'power2.out',
+      });
+    }
+  };
+
+  const animateFieldBlur = (
+    fieldRef: React.RefObject<HTMLDivElement | null>
+  ) => {
+    if (fieldRef.current) {
+      gsap.to(fieldRef.current, {
+        duration: 0.3,
+        scale: 1,
+        boxShadow: 'none',
+        ease: 'power2.out',
+      });
+    }
+  };
+
+  const onSubmit = async (values: z.infer<typeof formSchema>) => {
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      await newsletterSubscribe({
+        email: values.email,
+        name: values.name,
+        source,
+        tags: selectedTags,
+      });
+      onSuccess?.();
+      window.location.href = '/newsletter/confirmed';
+    } catch (err) {
+      const e = err as NewsletterApiError;
+      if (e.code === 'ALREADY_SUBSCRIBED')
+        setError('This email is already subscribed.');
+      else if (e.code === 'RATE_LIMITED')
+        setError('Too many attempts. Please try again in a minute.');
+      else if (e.code === 'INVALID_TAGS') setError('Invalid topic selection.');
+      else setError('Failed to submit form. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <FormField
+            control={form.control}
+            name='name'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className='sr-only'>Name</FormLabel>
+                <FormControl>
+                  <div
+                    ref={nameFieldRef}
+                    className='relative flex h-12 items-center rounded-lg border border-[#2B2B2B] bg-[#101010] p-4 backdrop-blur-sm transition-all duration-300'
+                    onFocus={() => animateFieldFocus(nameFieldRef)}
+                    onBlur={() => animateFieldBlur(nameFieldRef)}
+                  >
+                    <User className='h-5 w-5 text-[#B5B5B5]' />
+                    <Input
+                      {...field}
+                      placeholder='Enter your name'
+                      className='focus-visible:ring-none absolute top-0 left-0 h-full border-none bg-transparent pl-10 text-white caret-[rgb(167,249,80)] placeholder:text-[#B5B5B5] focus-visible:ring-[0px]'
+                    />
+                  </div>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name='email'
+            render={({ field }) => (
+              <FormItem className='mt-3'>
+                <FormLabel className='sr-only'>Email</FormLabel>
+                <FormControl>
+                  <div
+                    ref={emailFieldRef}
+                    className='relative flex h-12 items-center rounded-lg border border-[#2B2B2B] bg-[#101010] p-4 backdrop-blur-sm transition-all duration-300'
+                    onFocus={() => animateFieldFocus(emailFieldRef)}
+                    onBlur={() => animateFieldBlur(emailFieldRef)}
+                  >
+                    <Mail className='h-5 w-5 text-[#B5B5B5]' />
+                    <Input
+                      {...field}
+                      placeholder='Enter your email'
+                      className='focus-visible:ring-none caret-primary absolute top-0 left-0 h-full border-none bg-transparent pl-10 text-white placeholder:text-[#B5B5B5] focus-visible:ring-[0px]'
+                    />
+                  </div>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div className='mt-4 flex flex-wrap gap-3'>
+            {(
+              ['bounties', 'hackathons', 'grants', 'updates'] as NewsletterTag[]
+            ).map(tag => (
+              <label
+                key={tag}
+                className='flex cursor-pointer items-center gap-1.5 text-sm text-[#D9D9D9]'
+              >
+                <input
+                  type='checkbox'
+                  className='accent-primary'
+                  checked={selectedTags.includes(tag)}
+                  onChange={() =>
+                    setSelectedTags(p =>
+                      p.includes(tag) ? p.filter(t => t !== tag) : [...p, tag]
+                    )
+                  }
+                />
+                {tag.charAt(0).toUpperCase() + tag.slice(1)}
+              </label>
+            ))}
+          </div>
+
+          <BoundlessButton
+            variant={form.formState.isValid ? 'default' : 'outline'}
+            type='submit'
+            fullWidth
+            size='xl'
+            disabled={!form.formState.isValid}
+            loading={isSubmitting}
+            className='mt-11 w-full disabled:border-[#2B2B2B] disabled:bg-[#212121] disabled:text-[#787878]'
+          >
+            Subscribe
+          </BoundlessButton>
+        </form>
+      </Form>
+      {error && (
+        <p className='mt-2 text-center text-sm text-red-500'>{error}</p>
+      )}
+    </>
+  );
+};
+
+export default NewsletterForm;


### PR DESCRIPTION
## Summary
- Replaced the static landing demo block with a real **Explore** section that fetches live hackathons + projects, hides empty tabs (no more "Bounties"/"Open Grants"), and adds an "All" tab as the default.
- New standalone **/newsletter** subscription page (deep-linkable) sharing one form with the existing dialog via a new `NewsletterForm` component.
- Reduced excess vertical whitespace under the hero (dropped `min-h-screen` + negative top margin on Explore).
- Wired all landing CTAs to their final destinations:
  - Hero "Explore How It Works" → smooth-scrolls to **Every funding shape, one home** (`#programs`)
  - "Or browse open programs" → smooth-scrolls to **Explore What's Happening** (`#explore`)
  - Auth links normalized to `/auth?mode=signup` and `/auth?mode=signin`
  - "Run a hackathon" / "Launch a campaign" / "Run your first program" / "Get started" → `/organizations`
  - "Run a grant program" / "Post a bounty" → no-op (disabled until live)
  - "Talk to our team" → `https://discord.gg/k6eaFZ2vr` in new tab
  - Docs / "Dive Deeper" → `https://docs.boundlessfi.xyz/` in new tab
  - "View More Opportunities" → `/hackathons`
- Footer gets a Newsletter link (desktop + mobile).
- Page wrapper switched from `overflow-hidden` to `overflow-x-clip` so hash anchors actually scroll.

## Test plan
- [ ] Visit `/` and confirm the Explore section renders with hackathons + projects under "All".
- [ ] Tabs only appear when there is data behind them; section is hidden if everything is empty.
- [ ] Hero "Explore How It Works" smooth-scrolls to FourPrograms.
- [ ] AudienceSplit "Or browse open programs" smooth-scrolls back up to Explore.
- [ ] All CTA destinations match the list above (organizations route, discord new tab, docs new tab, etc.).
- [ ] `/newsletter` renders the standalone subscribe form and on submit redirects to `/newsletter/confirmed`.
- [ ] Footer "Newsletter" link works on desktop and mobile layouts.