### PR TITLE
fix(participants): responsive mobile layout + use server availableSkills

### DIFF
--- a/app/(landing)/hackathons/[slug]/components/tabs/contents/Participants.tsx
+++ b/app/(landing)/hackathons/[slug]/components/tabs/contents/Participants.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useState, useMemo } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useParams } from 'next/navigation';
 import {
   useHackathon,
@@ -99,30 +99,7 @@ const Participants = () => {
     }
   }, [participantsData?.participants, page]);
 
-  // Dynamically derive unique skills from participants
-  const availableSkills = useMemo(() => {
-    const skillsSet = new Set<string>();
-    // Try to get skills from all participants fetchable (if we had them all)
-    // For now, we derive from what we have in the current view or mock if empty
-    accumulatedParticipants.forEach((p: Participant) => {
-      p.user.profile.skills?.forEach((s: string) => {
-        skillsSet.add(s);
-      });
-    });
-
-    if (skillsSet.size === 0) {
-      return [
-        'Solidity',
-        'Rust',
-        'React',
-        'TypeScript',
-        'Python',
-        'Go',
-        'Design',
-      ];
-    }
-    return Array.from(skillsSet).sort();
-  }, [accumulatedParticipants]);
+  const availableSkills = participantsData?.availableSkills ?? [];
 
   if (!hackathon) return null;
 
@@ -166,23 +143,23 @@ const Participants = () => {
           </div>
         </div>
 
-        <div className='flex items-center gap-3'>
+        <div className='grid grid-cols-1 gap-2 sm:grid-cols-3 md:flex md:items-center md:gap-3'>
           {/* Skills Filter */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <button className='hover:border-primary/20 flex min-w-[140px] items-center justify-between gap-2 rounded-xl border border-white/5 bg-[#141517] px-4 py-2.5 text-sm font-medium text-gray-400 transition-all hover:text-white'>
-                <div className='flex items-center gap-2'>
-                  <Filter className='h-3.5 w-3.5' />
-                  <span>
+              <button className='hover:border-primary/20 flex w-full items-center justify-between gap-2 rounded-xl border border-white/5 bg-[#141517] px-4 py-2.5 text-sm font-medium text-gray-400 transition-all hover:text-white md:w-auto md:min-w-[140px]'>
+                <div className='flex min-w-0 items-center gap-2'>
+                  <Filter className='h-3.5 w-3.5 shrink-0' />
+                  <span className='truncate'>
                     {skillFilter === 'all' ? 'All Skills' : skillFilter}
                   </span>
                 </div>
-                <ChevronDown className='h-4 w-4 opacity-50' />
+                <ChevronDown className='h-4 w-4 shrink-0 opacity-50' />
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent
               align='end'
-              className='w-48 border-white/10 bg-[#141517] text-gray-300'
+              className='max-h-[60vh] w-48 overflow-y-auto border-white/10 bg-[#141517] text-gray-300'
             >
               <DropdownMenuItem onClick={() => setSkillFilter('all')}>
                 All Skills
@@ -201,15 +178,15 @@ const Participants = () => {
           {/* Type Filter */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <button className='hover:border-primary/20 flex min-w-[140px] items-center justify-between gap-2 rounded-xl border border-white/5 bg-[#141517] px-4 py-2.5 text-sm font-medium text-gray-400 transition-all hover:text-white'>
-                <span>
+              <button className='hover:border-primary/20 flex w-full items-center justify-between gap-2 rounded-xl border border-white/5 bg-[#141517] px-4 py-2.5 text-sm font-medium text-gray-400 transition-all hover:text-white md:w-auto md:min-w-[140px]'>
+                <span className='truncate'>
                   {participationType === 'all'
                     ? 'Type: All'
                     : participationType === 'individual'
                       ? 'Type: Individual'
                       : 'Type: Team'}
                 </span>
-                <ChevronDown className='h-4 w-4 opacity-50' />
+                <ChevronDown className='h-4 w-4 shrink-0 opacity-50' />
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent
@@ -233,15 +210,15 @@ const Participants = () => {
           {/* Status Filter */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <button className='hover:border-primary/20 flex min-w-[140px] items-center justify-between gap-2 rounded-xl border border-white/5 bg-[#141517] px-4 py-2.5 text-sm font-medium text-gray-400 transition-all hover:text-white'>
-                <span>
+              <button className='hover:border-primary/20 flex w-full items-center justify-between gap-2 rounded-xl border border-white/5 bg-[#141517] px-4 py-2.5 text-sm font-medium text-gray-400 transition-all hover:text-white md:w-auto md:min-w-[140px]'>
+                <span className='truncate'>
                   {statusFilter === 'all'
                     ? 'Status: All'
                     : statusFilter === 'submitted'
                       ? 'Status: Submitted'
                       : 'Status: In Progress'}
                 </span>
-                <ChevronDown className='h-4 w-4 opacity-50' />
+                <ChevronDown className='h-4 w-4 shrink-0 opacity-50' />
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent

--- a/hooks/hackathon/use-hackathon-queries.ts
+++ b/hooks/hackathon/use-hackathon-queries.ts
@@ -159,11 +159,13 @@ export function useHackathonParticipants(
             hasNext: false,
             hasPrev: false,
           },
+          availableSkills: [],
         };
       }
       return {
         participants: response.data.participants,
         pagination: response.data.pagination,
+        availableSkills: response.data.availableSkills ?? [],
       };
     },
     enabled: !!slug,

--- a/types/hackathon/participant.ts
+++ b/types/hackathon/participant.ts
@@ -136,6 +136,7 @@ export interface ParticipantsData {
     hasNext: boolean;
     hasPrev: boolean;
   };
+  availableSkills?: string[];
 }
 
 export interface CreateSubmissionRequest {


### PR DESCRIPTION
## Summary
Two fixes to the hackathon participants tab:

1. **Mobile overflow:** the filter row was a non-wrapping `flex` with three `min-w-[140px]` buttons (~420px + gaps). On phones it pushed the whole page off the right edge.
2. **Skills filter source:** the dropdown was deriving skills from `accumulatedParticipants` (only the currently-paginated 12), with a **hardcoded fallback list** when empty (`Solidity, Rust, React, …` — fake data). Now uses the `availableSkills` list returned by the backend, which is sorted, deduped, and reflects the full participant set.

## Changes
- `Participants.tsx`: filter row → `grid grid-cols-1 sm:grid-cols-3 md:flex`; each trigger button → `w-full md:w-auto md:min-w-[140px]` with `truncate` on labels so the longest value never breaks layout. Removed the `useMemo`/hardcoded skills block.
- `useHackathonParticipants` hook: pass-through `availableSkills` from the API response (defaults to `[]` on error so the dropdown gracefully shows only "All Skills").
- `ParticipantsData` type: added optional `availableSkills?: string[]`.

## Dependency
Pairs with [boundless-nestjs `fix/participants-filters`](https://github.com/boundlessfi/boundless-nestjs/pull/) — without the backend PR, the filters appear to work in the UI but the API ignores them. Merge the backend PR first or together.

## Test plan
- [ ] Resize to ~375px width on the participants tab — no horizontal scrollbar, filters stack vertically.
- [ ] At sm breakpoint (≥640px) filters lay out as a 3-column grid.
- [ ] At md breakpoint (≥768px) filters return to inline flex with min-width.
- [ ] Skills dropdown is populated from real participant skills (no longer shows the fake hardcoded list when no one has skills yet).
- [ ] Long skill names truncate with ellipsis rather than overflowing the trigger.
- [ ] Status / Type / Skill / Search filters actually narrow the result set (requires backend PR merged).