### PR TITLE
fix: team creation/list refresh, prize ordinals, submission categories, chat optimistic

### DIFF
--- a/app/(landing)/hackathons/[slug]/components/tabs/contents/FindTeam.tsx
+++ b/app/(landing)/hackathons/[slug]/components/tabs/contents/FindTeam.tsx
@@ -286,7 +286,6 @@ const FindTeam = () => {
 
           <CreateTeamPostModal
             hackathonSlugOrId={slug}
-            teamMin={hackathon.teamMin}
             teamMax={hackathon.teamMax}
             open={isCreateModalOpen}
             onOpenChange={setIsCreateModalOpen}

--- a/app/(landing)/hackathons/[slug]/components/tabs/contents/Overview.tsx
+++ b/app/(landing)/hackathons/[slug]/components/tabs/contents/Overview.tsx
@@ -10,6 +10,12 @@ import { cn } from '@/lib/utils';
 import { useMarkdown } from '@/hooks/use-markdown';
 import SponsorsSection from '../../SponsorsSection';
 
+function getOrdinal(n: number) {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}
+
 const Overview = () => {
   const { slug } = useParams<{ slug: string }>();
   const { data: hackathon } = useHackathon(slug);
@@ -247,8 +253,7 @@ const Overview = () => {
               </div>
 
               <h3 className='text-sm font-semibold text-gray-400'>
-                {tier.name ||
-                  (i === 0 ? '1st Place' : i === 1 ? '2nd Place' : '3rd Place')}
+                {tier.name || `${getOrdinal(i + 1)} Place`}
               </h3>
               <div className='my-2 flex items-baseline gap-1'>
                 <span className='text-3xl font-black text-white'>

--- a/app/(landing)/hackathons/[slug]/components/tabs/contents/teams/MyTeamView.tsx
+++ b/app/(landing)/hackathons/[slug]/components/tabs/contents/teams/MyTeamView.tsx
@@ -333,7 +333,6 @@ const MyTeamView = ({ team, hackathonSlug }: MyTeamViewProps) => {
         open={isEditModalOpen}
         onOpenChange={setIsEditModalOpen}
         hackathonSlugOrId={hackathonSlug}
-        teamMin={hackathon?.teamMin}
         teamMax={hackathon?.teamMax}
         initialData={team}
       />

--- a/app/(landing)/hackathons/[slug]/components/tabs/contents/teams/TeamCard.tsx
+++ b/app/(landing)/hackathons/[slug]/components/tabs/contents/teams/TeamCard.tsx
@@ -63,29 +63,31 @@ const TeamCard = ({ team, onJoin, onMessageLeader }: TeamCardProps) => {
           </div>
         </div>
 
-        <div className='flex w-full flex-wrap items-center gap-2 sm:w-auto sm:flex-nowrap'>
-          {onMessageLeader && team.leader?.id && (
+        {isOpen && (
+          <div className='flex w-full flex-wrap items-center gap-2 sm:w-auto sm:flex-nowrap'>
+            {onMessageLeader && team.leader?.id && (
+              <BoundlessButton
+                variant='outline'
+                size='sm'
+                className='h-11 shrink-0 rounded-xl border-white/10 bg-white/5 px-4 text-sm font-bold text-white transition-all hover:bg-white/10'
+                onClick={e => onMessageLeader(team, e.currentTarget)}
+                aria-label='Message team leader'
+              >
+                <MessageCircle className='mr-2 h-4 w-4' />
+                Message
+              </BoundlessButton>
+            )}
             <BoundlessButton
               variant='outline'
               size='sm'
-              className='h-11 shrink-0 rounded-xl border-white/10 bg-white/5 px-4 text-sm font-bold text-white transition-all hover:bg-white/10'
-              onClick={e => onMessageLeader(team, e.currentTarget)}
-              aria-label='Message team leader'
+              className='border-primary/20 text-primary hover:bg-primary h-11 w-full rounded-xl bg-[#232B20]/30 px-6 text-sm font-bold transition-all hover:text-black sm:w-auto'
+              onClick={() => onJoin?.(team)}
+              disabled={memberCount >= maxSize}
             >
-              <MessageCircle className='mr-2 h-4 w-4' />
-              Message
+              Join Team
             </BoundlessButton>
-          )}
-          <BoundlessButton
-            variant='outline'
-            size='sm'
-            className='border-primary/20 text-primary hover:bg-primary h-11 w-full rounded-xl bg-[#232B20]/30 px-6 text-sm font-bold transition-all hover:text-black sm:w-auto'
-            onClick={() => onJoin?.(team)}
-            disabled={!isOpen || memberCount >= maxSize}
-          >
-            Join Team
-          </BoundlessButton>
-        </div>
+          </div>
+        )}
       </div>
 
       {/* Description */}

--- a/components/hackathons/submissions/SubmissionForm.tsx
+++ b/components/hackathons/submissions/SubmissionForm.tsx
@@ -162,14 +162,20 @@ const LINK_TYPES = [
 
 const OTHER_LINK_TYPES = ['demo', 'website', 'documentation', 'other'];
 
-const CATEGORIES = [
-  'Web Development',
-  'Mobile App',
-  'Blockchain',
-  'AI/ML',
-  'IoT',
-  'Game Development',
-  'Design',
+// Used when a hackathon has no configured categories (legacy data). Mirrors
+// the wizard's CategorySelection list so the dropdown stays usable.
+const FALLBACK_CATEGORIES = [
+  'DeFi',
+  'NFTs',
+  'DAOs',
+  'Layer 2',
+  'Cross-chain',
+  'Web3 Gaming',
+  'Social Tokens',
+  'Infrastructure',
+  'Privacy',
+  'Sustainability',
+  'Real World Assets',
   'Other',
 ];
 
@@ -212,6 +218,15 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
   const requireGithub = currentHackathon?.requireGithub ?? false;
   const requireDemoVideo = currentHackathon?.requireDemoVideo ?? false;
   const requireOtherLinks = currentHackathon?.requireOtherLinks ?? false;
+
+  // Source the dropdown from the categories the organizer picked when creating
+  // this hackathon. If a hackathon has none configured (legacy data or empty
+  // save), fall back to the platform's standard category list so the dropdown
+  // is still usable.
+  const categoryOptions = useMemo(() => {
+    const list = currentHackathon?.categories ?? [];
+    return list.length > 0 ? list : FALLBACK_CATEGORIES;
+  }, [currentHackathon?.categories]);
 
   // participantType reaches us in mixed case across endpoints; normalize once.
   const rawParticipantType = currentHackathon?.participantType;
@@ -421,7 +436,7 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
   const handleFillMockData = () => {
     const mockData = {
       projectName: 'AI-Powered Task Manager',
-      category: 'AI/ML',
+      category: categoryOptions[0],
       description:
         'An intelligent task management application that uses machine learning to prioritize tasks...',
       logo: '',
@@ -1167,7 +1182,7 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent className='border-gray-700 bg-gray-800 text-white'>
-                      {CATEGORIES.map(category => (
+                      {categoryOptions.map(category => (
                         <SelectItem key={category} value={category}>
                           {category}
                         </SelectItem>

--- a/components/hackathons/team-formation/CreateTeamPostModal.tsx
+++ b/components/hackathons/team-formation/CreateTeamPostModal.tsx
@@ -35,16 +35,13 @@ const roleSchema = z.object({
   skills: z.array(z.string()).optional(),
 });
 
-// Fallbacks match the backend's default when a hackathon hasn't pinned team size.
-const DEFAULT_TEAM_MIN = 1;
+// Fallback matches the backend's default when a hackathon hasn't pinned team size.
 const DEFAULT_TEAM_MAX = 10;
 
 interface CreateTeamPostModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   hackathonSlugOrId: string;
-  /** Roles needed = teamMin - 1 (leader counts as one member). */
-  teamMin?: number;
   teamMax?: number;
   organizationId?: string;
   initialData?: TeamRecruitmentPost;
@@ -57,7 +54,6 @@ export function CreateTeamPostModal({
   open,
   onOpenChange,
   hackathonSlugOrId,
-  teamMin,
   teamMax,
   organizationId,
   initialData,
@@ -68,9 +64,9 @@ export function CreateTeamPostModal({
     autoFetch: false,
   });
 
-  const effectiveTeamMin = teamMin ?? DEFAULT_TEAM_MIN;
   const effectiveTeamMax = teamMax ?? DEFAULT_TEAM_MAX;
-  const minRoles = Math.max(0, effectiveTeamMin - 1);
+  // Roles are opt-in recruitment slots. Team size minimums are enforced at
+  // submission time once invites have filled the team.
   const maxRoles = Math.max(1, effectiveTeamMax - 1);
 
   const teamPostSchema = useMemo(
@@ -86,15 +82,9 @@ export function CreateTeamPostModal({
           .max(500, 'Description cannot exceed 500 characters'),
         lookingFor: z
           .array(roleSchema)
-          .min(
-            minRoles,
-            minRoles === 0
-              ? 'You can leave this empty to keep the team closed'
-              : `Add at least ${minRoles} role${minRoles === 1 ? '' : 's'} (the team needs ${effectiveTeamMin} member${effectiveTeamMin === 1 ? '' : 's'} including you)`
-          )
           .max(
             maxRoles,
-            `You can add at most ${maxRoles} role${maxRoles === 1 ? '' : 's'} (the team is capped at ${effectiveTeamMax} member${effectiveTeamMax === 1 ? '' : 's'} including you)`
+            `You can add at most ${maxRoles} open role${maxRoles === 1 ? '' : 's'} (the team is capped at ${effectiveTeamMax} member${effectiveTeamMax === 1 ? '' : 's'} including you)`
           ),
         contactMethod: z.enum([
           'email',
@@ -105,7 +95,7 @@ export function CreateTeamPostModal({
         ]),
         contactInfo: z.string().min(1, 'Contact info is required'),
       }),
-    [minRoles, maxRoles, effectiveTeamMin, effectiveTeamMax]
+    [maxRoles, effectiveTeamMax]
   );
 
   type TeamPostFormData = z.infer<typeof teamPostSchema>;
@@ -124,7 +114,7 @@ export function CreateTeamPostModal({
         initialData?.lookingFor.map(roleObj => ({
           role: typeof roleObj === 'string' ? roleObj : roleObj.role,
           skills: typeof roleObj === 'string' ? [] : roleObj.skills || [],
-        })) || (minRoles > 0 ? [{ role: '', skills: [] }] : []),
+        })) || [],
       contactMethod: initialData?.contactMethod || 'email',
       contactInfo: initialData?.contactInfo || '',
     },
@@ -256,12 +246,12 @@ export function CreateTeamPostModal({
           <div className='mb-8 flex items-center justify-between'>
             <div>
               <h2 className='text-2xl font-bold text-white'>
-                {isEditMode ? 'Edit Team Post' : 'Create Team Post'}
+                {isEditMode ? 'Edit Team' : 'Create Team'}
               </h2>
               <p className='mt-1 text-sm text-gray-500'>
                 {isEditMode
-                  ? 'Update your recruitment details'
-                  : 'Start your journey and find fellow builders'}
+                  ? 'Update your team details'
+                  : 'Form a team — invite people you know, or open roles to recruit'}
               </p>
             </div>
           </div>
@@ -352,14 +342,16 @@ export function CreateTeamPostModal({
                     <div className='flex items-center justify-between'>
                       <div>
                         <FormLabel className='text-xs font-bold tracking-[0.2em] text-gray-400 uppercase'>
-                          Roles Needed
+                          Open Roles (Optional)
                         </FormLabel>
                         <p className='mt-1 text-xs text-gray-500'>
-                          {minRoles === maxRoles
-                            ? `Add exactly ${minRoles} role${minRoles === 1 ? '' : 's'} — this hackathon's teams must have ${effectiveTeamMin} member${effectiveTeamMin === 1 ? '' : 's'} (you + ${minRoles}).`
-                            : minRoles === 0
-                              ? `Add up to ${maxRoles} role${maxRoles === 1 ? '' : 's'} — leave empty to keep the team closed. This hackathon caps teams at ${effectiveTeamMax} member${effectiveTeamMax === 1 ? '' : 's'} (you + ${maxRoles}).`
-                              : `Add ${minRoles}–${maxRoles} roles — this hackathon's teams have ${effectiveTeamMin}–${effectiveTeamMax} members (you + ${minRoles}–${maxRoles} others).`}
+                          Want others to find and join you? Add up to {maxRoles}{' '}
+                          open role{maxRoles === 1 ? '' : 's'} and your team
+                          will be visible to potential teammates. Already have
+                          your team? Skip this step — you can invite them
+                          directly after creating. This hackathon caps teams at{' '}
+                          {effectiveTeamMax} member
+                          {effectiveTeamMax === 1 ? '' : 's'} including you.
                         </p>
                       </div>
                       <BoundlessButton
@@ -377,10 +369,11 @@ export function CreateTeamPostModal({
 
                     {lookingFor.length === 0 && (
                       <div className='rounded-2xl border border-dashed border-white/10 bg-white/2 p-8 text-center text-sm text-gray-500'>
-                        No roles added. Click{' '}
+                        No open roles. Your team will be created as{' '}
+                        <span className='font-bold text-white'>private</span> —
+                        not listed for joiners. Click{' '}
                         <span className='font-bold text-white'>Add Role</span>{' '}
-                        if you want to open the team to joiners — otherwise
-                        leave it empty to keep the team closed.
+                        if you'd like to recruit teammates instead.
                       </div>
                     )}
 
@@ -390,7 +383,7 @@ export function CreateTeamPostModal({
                           key={roleIndex}
                           className='relative rounded-2xl border border-white/5 bg-white/2 p-6 transition-all hover:bg-white/4'
                         >
-                          {lookingFor.length > minRoles && (
+                          {lookingFor.length > 0 && (
                             <button
                               type='button'
                               onClick={() => removeRole(roleIndex)}
@@ -479,14 +472,14 @@ export function CreateTeamPostModal({
                         </FormLabel>
                         <Select
                           onValueChange={field.onChange}
-                          defaultValue={field.value}
+                          value={field.value}
                         >
                           <FormControl>
                             <SelectTrigger className='focus:border-primary/20 h-12 border-white/5 bg-white/5 text-white'>
                               <SelectValue placeholder='Select method' />
                             </SelectTrigger>
                           </FormControl>
-                          <SelectContent className='border-white/10 bg-[#0D0E10] text-white'>
+                          <SelectContent className='z-70 border-white/10 bg-[#0D0E10] text-white'>
                             <SelectItem value='email'>Email</SelectItem>
                             <SelectItem value='telegram'>Telegram</SelectItem>
                             <SelectItem value='discord'>Discord</SelectItem>
@@ -562,9 +555,9 @@ export function CreateTeamPostModal({
                     {isCreating || isUpdating ? (
                       <Loader2 className='h-4 w-4 animate-spin' />
                     ) : isEditMode ? (
-                      'Update Post'
+                      'Update Team'
                     ) : (
-                      'Finish & Post'
+                      'Create Team'
                     )}
                   </BoundlessButton>
                 )}

--- a/components/messages/MessagesSheet.tsx
+++ b/components/messages/MessagesSheet.tsx
@@ -209,6 +209,12 @@ function ThreadView({
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [body, setBody] = useState('');
   const [sending, setSending] = useState(false);
+  // Tracks the delivery state of optimistic messages by their temp client id.
+  // 'sending' shows the spinner, 'failed' shows a retry affordance. Confirmed
+  // messages have no entry (or are removed once the temp swaps to a real id).
+  const [messageStatus, setMessageStatus] = useState<
+    Record<string, 'sending' | 'failed'>
+  >({});
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const lastScrollBottomMessageId = useRef<string | null>(null);
 
@@ -276,28 +282,66 @@ function ThreadView({
     }
   }, [conversationId, nextCursor, loadingOlder]);
 
-  const handleSend = useCallback(async () => {
+  // Shared send path used by both first-time sends and retries. Keeps the
+  // optimistic message in place across attempts so the bubble's position is
+  // stable; only the status badge changes.
+  const performSend = useCallback(
+    async (clientId: string, messageBody: string) => {
+      setSendError(null);
+      setSending(true);
+      setMessageStatus(prev => ({ ...prev, [clientId]: 'sending' }));
+      try {
+        const sent = await sendMessage(conversationId, messageBody);
+        setMessages(prev => {
+          const withoutTemp = prev.filter(m => m.id !== clientId);
+          return withoutTemp.some(m => m.id === sent.id)
+            ? withoutTemp
+            : [...withoutTemp, sent];
+        });
+        setMessageStatus(prev => {
+          const next = { ...prev };
+          delete next[clientId];
+          return next;
+        });
+      } catch (e) {
+        setMessageStatus(prev => ({ ...prev, [clientId]: 'failed' }));
+        const msg = isApiError(e)
+          ? e.message
+          : e instanceof Error
+            ? e.message
+            : 'Failed to send message';
+        setSendError(msg);
+      } finally {
+        setSending(false);
+      }
+    },
+    [conversationId]
+  );
+
+  const handleSend = useCallback(() => {
     const trimmed = body.trim();
     if (!trimmed || sending || trimmed.length > MAX_BODY_LENGTH) return;
-    setSendError(null);
-    setSending(true);
-    try {
-      const sent = await sendMessage(conversationId, trimmed);
-      setMessages(prev =>
-        prev.some(m => m.id === sent.id) ? prev : [...prev, sent]
-      );
-      setBody('');
-    } catch (e) {
-      const msg = isApiError(e)
-        ? e.message
-        : e instanceof Error
-          ? e.message
-          : 'Failed to send message';
-      setSendError(msg);
-    } finally {
-      setSending(false);
-    }
-  }, [body, conversationId, sending]);
+    if (!currentUserId) return;
+
+    const clientId = `temp-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    const optimistic: Message = {
+      id: clientId,
+      conversationId,
+      senderId: currentUserId,
+      body: trimmed,
+      createdAt: new Date().toISOString(),
+    };
+    setMessages(prev => [...prev, optimistic]);
+    setBody('');
+    void performSend(clientId, trimmed);
+  }, [body, conversationId, sending, currentUserId, performSend]);
+
+  const retryMessage = useCallback(
+    (message: Message) => {
+      void performSend(message.id, message.body);
+    },
+    [performSend]
+  );
 
   if (loading && !conversation) {
     return (
@@ -367,6 +411,8 @@ function ThreadView({
                 key={msg.id}
                 message={msg}
                 isOwn={msg.senderId === currentUserId}
+                status={messageStatus[msg.id]}
+                onRetry={() => retryMessage(msg)}
               />
             ))}
             <div ref={messagesEndRef} />
@@ -417,10 +463,15 @@ function ThreadView({
 function MessageBubble({
   message,
   isOwn,
+  status,
+  onRetry,
 }: {
   message: Message;
   isOwn: boolean;
+  status?: 'sending' | 'failed';
+  onRetry?: () => void;
 }) {
+  const isFailed = status === 'failed';
   return (
     <div
       className={cn(
@@ -433,14 +484,32 @@ function MessageBubble({
           'rounded-2xl px-3 py-2 text-sm',
           isOwn
             ? 'bg-primary text-primary-foreground'
-            : 'bg-zinc-800 text-white'
+            : 'bg-zinc-800 text-white',
+          isFailed && 'opacity-60'
         )}
       >
         {message.body}
       </div>
-      <span className='text-[10px] text-zinc-500'>
-        {formatDistanceToNow(new Date(message.createdAt), { addSuffix: true })}
-      </span>
+      {isOwn && status === 'sending' ? (
+        <span className='flex items-center gap-1 text-[10px] text-zinc-500'>
+          <Loader2 className='h-2.5 w-2.5 animate-spin' />
+          Sending…
+        </span>
+      ) : isOwn && isFailed ? (
+        <button
+          type='button'
+          onClick={onRetry}
+          className='text-[10px] font-medium text-red-400 hover:text-red-300'
+        >
+          Not sent · Tap to retry
+        </button>
+      ) : (
+        <span className='text-[10px] text-zinc-500'>
+          {formatDistanceToNow(new Date(message.createdAt), {
+            addSuffix: true,
+          })}
+        </span>
+      )}
     </div>
   );
 }

--- a/components/messages/TetherMessage.tsx
+++ b/components/messages/TetherMessage.tsx
@@ -495,6 +495,12 @@ const ThreadContent: React.FC<ThreadContentProps> = ({
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [body, setBody] = useState('');
   const [sending, setSending] = useState(false);
+  // Tracks the delivery state of optimistic messages by their temp client id.
+  // 'sending' shows the spinner, 'failed' shows a retry affordance. Confirmed
+  // messages have no entry (or are removed once the temp swaps to a real id).
+  const [messageStatus, setMessageStatus] = useState<
+    Record<string, 'sending' | 'failed'>
+  >({});
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const lastScrollBottomMessageId = useRef<string | null>(null);
 
@@ -567,28 +573,66 @@ const ThreadContent: React.FC<ThreadContentProps> = ({
     }
   }, [conversationId, nextCursor, loadingOlder]);
 
-  const handleSend = useCallback(async () => {
+  // Shared send path used by both first-time sends and retries. Keeps the
+  // optimistic message in place across attempts so the bubble's position is
+  // stable; only the status badge changes.
+  const performSend = useCallback(
+    async (clientId: string, messageBody: string) => {
+      setSendError(null);
+      setSending(true);
+      setMessageStatus(prev => ({ ...prev, [clientId]: 'sending' }));
+      try {
+        const sent = await sendMessage(conversationId, messageBody);
+        setMessages(prev => {
+          const withoutTemp = prev.filter(m => m.id !== clientId);
+          return withoutTemp.some(m => m.id === sent.id)
+            ? withoutTemp
+            : [...withoutTemp, sent];
+        });
+        setMessageStatus(prev => {
+          const next = { ...prev };
+          delete next[clientId];
+          return next;
+        });
+      } catch (e) {
+        setMessageStatus(prev => ({ ...prev, [clientId]: 'failed' }));
+        const msg = isApiError(e)
+          ? e.message
+          : e instanceof Error
+            ? e.message
+            : 'Failed to send message';
+        setSendError(msg);
+      } finally {
+        setSending(false);
+      }
+    },
+    [conversationId]
+  );
+
+  const handleSend = useCallback(() => {
     const trimmed = body.trim();
     if (!trimmed || sending || trimmed.length > MAX_BODY_LENGTH) return;
-    setSendError(null);
-    setSending(true);
-    try {
-      const sent = await sendMessage(conversationId, trimmed);
-      setMessages(prev =>
-        prev.some(m => m.id === sent.id) ? prev : [...prev, sent]
-      );
-      setBody('');
-    } catch (e) {
-      const msg = isApiError(e)
-        ? e.message
-        : e instanceof Error
-          ? e.message
-          : 'Failed to send message';
-      setSendError(msg);
-    } finally {
-      setSending(false);
-    }
-  }, [body, conversationId, sending]);
+    if (!currentUserId) return;
+
+    const clientId = `temp-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    const optimistic: MessageType = {
+      id: clientId,
+      conversationId,
+      senderId: currentUserId,
+      body: trimmed,
+      createdAt: new Date().toISOString(),
+    };
+    setMessages(prev => [...prev, optimistic]);
+    setBody('');
+    void performSend(clientId, trimmed);
+  }, [body, conversationId, sending, currentUserId, performSend]);
+
+  const retryMessage = useCallback(
+    (message: MessageType) => {
+      void performSend(message.id, message.body);
+    },
+    [performSend]
+  );
 
   const header = useMemo(() => {
     if (!conversation) return null;
@@ -700,6 +744,8 @@ const ThreadContent: React.FC<ThreadContentProps> = ({
                 <MessageBubble
                   message={msg}
                   isOwn={msg.senderId === currentUserId}
+                  status={messageStatus[msg.id]}
+                  onRetry={() => retryMessage(msg)}
                 />
               </motion.div>
             ))}
@@ -754,7 +800,10 @@ const ThreadContent: React.FC<ThreadContentProps> = ({
 const MessageBubble: React.FC<{
   message: MessageType;
   isOwn: boolean;
-}> = ({ message, isOwn }) => {
+  status?: 'sending' | 'failed';
+  onRetry?: () => void;
+}> = ({ message, isOwn, status, onRetry }) => {
+  const isFailed = status === 'failed';
   return (
     <div
       className={cn(
@@ -767,14 +816,32 @@ const MessageBubble: React.FC<{
           'rounded-2xl px-3 py-2 text-sm',
           isOwn
             ? 'bg-primary text-primary-foreground'
-            : 'bg-zinc-800 text-white'
+            : 'bg-zinc-800 text-white',
+          isFailed && 'opacity-60'
         )}
       >
         {message.body}
       </div>
-      <span className='text-[10px] text-zinc-500'>
-        {formatDistanceToNow(new Date(message.createdAt), { addSuffix: true })}
-      </span>
+      {isOwn && status === 'sending' ? (
+        <span className='flex items-center gap-1 text-[10px] text-zinc-500'>
+          <Loader2 className='h-2.5 w-2.5 animate-spin' />
+          Sending…
+        </span>
+      ) : isOwn && isFailed ? (
+        <button
+          type='button'
+          onClick={onRetry}
+          className='text-[10px] font-medium text-red-400 hover:text-red-300'
+        >
+          Not sent · Tap to retry
+        </button>
+      ) : (
+        <span className='text-[10px] text-zinc-500'>
+          {formatDistanceToNow(new Date(message.createdAt), {
+            addSuffix: true,
+          })}
+        </span>
+      )}
     </div>
   );
 };

--- a/hooks/hackathon/use-hackathon-queries.ts
+++ b/hooks/hackathon/use-hackathon-queries.ts
@@ -84,6 +84,10 @@ export const hackathonKeys = {
     ['hackathon', 'announcements', idOrSlug] as const,
   teams: (idOrSlug: string, params?: GetTeamOptions) =>
     ['hackathon', 'teams', idOrSlug, params] as const,
+  // Prefix-only form for invalidating every params-variant of `teams` in one
+  // call. `teams(slug)` returns ['hackathon','teams',slug,undefined] which is
+  // a 4-element key that does NOT prefix-match cached ['…',slug,{...params}].
+  teamsBase: (idOrSlug: string) => ['hackathon', 'teams', idOrSlug] as const,
   myTeam: (idOrSlug: string) => ['hackathon', 'myTeam', idOrSlug] as const,
   myInvitations: (idOrSlug: string, status?: string) =>
     ['hackathon', 'myInvitations', idOrSlug, status] as const,
@@ -400,7 +404,9 @@ export function useJoinTeam(slug: string) {
       joinTeam(slug, teamId, message),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: hackathonKeys.myTeam(slug) });
-      queryClient.invalidateQueries({ queryKey: hackathonKeys.teams(slug) });
+      queryClient.invalidateQueries({
+        queryKey: hackathonKeys.teamsBase(slug),
+      });
     },
   });
 }
@@ -414,7 +420,9 @@ export function useLeaveTeam(slug: string) {
     mutationFn: (teamId: string) => leaveTeam(slug, teamId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: hackathonKeys.myTeam(slug) });
-      queryClient.invalidateQueries({ queryKey: hackathonKeys.teams(slug) });
+      queryClient.invalidateQueries({
+        queryKey: hackathonKeys.teamsBase(slug),
+      });
     },
   });
 }
@@ -476,7 +484,9 @@ export function useTransferLeadership(slug: string) {
       ),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: hackathonKeys.myTeam(slug) });
-      queryClient.invalidateQueries({ queryKey: hackathonKeys.teams(slug) });
+      queryClient.invalidateQueries({
+        queryKey: hackathonKeys.teamsBase(slug),
+      });
     },
   });
 }

--- a/hooks/hackathon/use-team-posts.ts
+++ b/hooks/hackathon/use-team-posts.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { AxiosError } from 'axios';
 import { toast } from 'sonner';
+import { useQueryClient } from '@tanstack/react-query';
 import { useAuthStatus } from '@/hooks/use-auth';
 import { useAuthStore } from '@/lib/stores/auth-store';
 import {
@@ -17,6 +18,7 @@ import {
   type UpdateTeamRequest as UpdateTeamPostRequest,
   type GetTeamOptions as GetTeamPostsOptions,
 } from '@/lib/api/hackathons/teams';
+import { hackathonKeys } from '@/hooks/hackathon/use-hackathon-queries';
 import { reportError } from '@/lib/error-reporting';
 
 function getErrorMessage(err: unknown, defaultMessage: string): string {
@@ -41,6 +43,18 @@ export function useTeamPosts({
   const { isAuthenticated } = useAuthStatus();
   const { user } = useAuthStore();
   const currentUserId = user?.id;
+  const queryClient = useQueryClient();
+  // After a team mutation, the React Query–backed pages (FindTeam,
+  // MyTeamView) need to refetch — this hook's internal setState only
+  // updates this hook's instance, not the cached queries those pages read.
+  const invalidateTeamQueries = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: hackathonKeys.teamsBase(hackathonSlugOrId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: hackathonKeys.myTeam(hackathonSlugOrId),
+    });
+  }, [queryClient, hackathonSlugOrId]);
   const [posts, setPosts] = useState<TeamRecruitmentPost[]>([]);
   const [myTeam, setMyTeam] = useState<TeamRecruitmentPost | null>(null);
   const [myPosts, setMyPosts] = useState<TeamRecruitmentPost[]>([]);
@@ -168,6 +182,7 @@ export function useTeamPosts({
                   posts: [response.data!],
                 }
           );
+          invalidateTeamQueries();
           toast.success('Team post created successfully');
           return response.data;
         } else {
@@ -182,7 +197,7 @@ export function useTeamPosts({
         setIsCreating(false);
       }
     },
-    [hackathonSlugOrId, organizationId, isAuthenticated]
+    [hackathonSlugOrId, organizationId, isAuthenticated, invalidateTeamQueries]
   );
 
   const updatePost = useCallback(
@@ -215,6 +230,7 @@ export function useTeamPosts({
                 }
               : null
           );
+          invalidateTeamQueries();
           toast.success('Team post updated successfully');
           return response.data;
         } else {
@@ -229,7 +245,7 @@ export function useTeamPosts({
         setIsUpdating(false);
       }
     },
-    [hackathonSlugOrId, organizationId, isAuthenticated]
+    [hackathonSlugOrId, organizationId, isAuthenticated, invalidateTeamQueries]
   );
 
   const deletePost = useCallback(
@@ -252,6 +268,7 @@ export function useTeamPosts({
         if (response.success) {
           setPosts(prev => prev.filter(post => post.id !== postId));
           setMyPosts(prev => prev.filter(post => post.id !== postId));
+          invalidateTeamQueries();
           toast.success('Team post deleted successfully');
         } else {
           throw new Error(response.message || 'Failed to delete team post');
@@ -265,7 +282,7 @@ export function useTeamPosts({
         setIsDeleting(false);
       }
     },
-    [hackathonSlugOrId, organizationId, isAuthenticated]
+    [hackathonSlugOrId, organizationId, isAuthenticated, invalidateTeamQueries]
   );
 
   const trackContact = useCallback(

--- a/package-lock.json
+++ b/package-lock.json
@@ -12076,9 +12076,9 @@
       }
     },
     "node_modules/kysely": {
-      "version": "0.28.14",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.14.tgz",
-      "integrity": "sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==",
+      "version": "0.28.17",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.17.tgz",
+      "integrity": "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
     "react": "19.2.1",
     "react-dom": "19.2.1",
     "@types/react": "19.2.7",
-    "@types/react-dom": "19.2.3"
+    "@types/react-dom": "19.2.3",
+    "kysely": "^0.28.17"
   }
 }


### PR DESCRIPTION
## Summary

A bundle of UX fixes across hackathon team-formation, prize display, submission flow, messaging, and one security upgrade.

### Team creation (CreateTeamPostModal)
- Fix Select dropdown rendering behind the BoundlessSheet (z-50 → z-70) and switch from `defaultValue` (uncontrolled) to `value` (controlled) so the contact method picker stays responsive across selections.
- Rename **Create Team Post → Create Team**; reframe the Roles step as opt-in recruitment. Drop the forced `minRoles` requirement so users with an existing team can create a private team and invite people directly — team-size minimums are already enforced at submission time server-side.

### Team list (TeamCard)
- Hide Join + Message buttons entirely on closed teams instead of just disabling them — a closed team isn't soliciting; dead buttons were noise.

### Team list refresh (use-team-posts, use-hackathon-queries)
- Create/update/delete in the modal's custom hook never invalidated React Query cache → users had to reload to see their new team. Now invalidates `hackathon.teams` and `hackathon.myTeam`.
- `useJoinTeam` / `useLeaveTeam` / `useTransferLeadership` were calling `hackathonKeys.teams(slug)` which expands to `['hackathon','teams',slug,undefined]` — a 4-element key that does **not** prefix-match cached `['hackathon','teams',slug,{...params}]`. Added a `teamsBase` prefix helper; leaving the team (incl. solo-leader cascade-delete) now drops the MyTeamView card without a reload.

### Prizes (Overview)
- Fix the 4th-place-onwards bug where every tier past 3rd silently rendered as "3rd Place". Uses a proper ordinal helper (1st, 2nd, 3rd, 4th, …, 11th, 12th, 13th, 21st, …).

### Submission categories (SubmissionForm)
- Source the dropdown from `hackathon.categories` instead of a hardcoded generic list (Web Development / Mobile App / AI/ML / …). Fallback to the wizard's standard category set when a hackathon has none configured, so the dropdown stays usable on legacy data.

### Messaging (MessagesSheet, TetherMessage)
- **Optimistic send**: sender's message appears immediately on submit rather than after the network roundtrip. Real message replaces the temp once the API responds, deduped against realtime echo.
- **Per-message status badge**: optimistic bubbles show "Sending…" with a spinner; failed sends show "Not sent · Tap to retry" instead of vanishing. Retry reuses the same bubble position.

### Security
- Override `kysely` to `^0.28.17` to resolve GHSA-pv5w-4p9q-p3v2 (JSON-path traversal injection). Pulled in transitively via `better-auth`; the override forces the patched version without needing a `better-auth` bump.

## Backend pair
This PR ships against a parallel backend PR adding cascade cleanup on team delete (clears stale TeamInvitations + nullifies orphan submission `teamId`) and validates submitted category against `hackathon.categories`.

## Test plan
- [ ] Create team wizard: contact method dropdown opens, stays responsive across multiple selections, and submits successfully
- [ ] Skip the Roles step → private team is created; new MyTeamView card appears without page reload
- [ ] Add open roles → public team appears in list; Join/Message visible
- [ ] Closed team in list shows the CLOSED badge with no Join/Message buttons
- [ ] Solo-leader leaves team → MyTeamView card disappears without page reload; team no longer in list
- [ ] Hackathon with 8 prize tiers shows "1st Place" through "8th Place" (not "3rd Place" repeated)
- [ ] Submission category dropdown shows only categories the organizer picked; legacy hackathons with no categories show the standard fallback
- [ ] Chat: typed message appears instantly in own bubble with "Sending…" badge; turns into a normal bubble on success
- [ ] Force a chat send failure (e.g. offline): bubble fades and shows "Not sent · Tap to retry"; tapping retries
- [ ] `npm audit --omit=dev --audit-level=high` reports no high-severity vulns

🤖 Generated with [Claude Code](https://claude.com/claude-code)