### PR TITLE
feat: submission banner; show closed teams in team list

### DIFF
--- a/app/(landing)/hackathons/[slug]/components/tabs/contents/FindTeam.tsx
+++ b/app/(landing)/hackathons/[slug]/components/tabs/contents/FindTeam.tsx
@@ -79,7 +79,11 @@ const FindTeam = () => {
       category:
         categoryFilter !== 'All Categories' ? categoryFilter : undefined,
       role: roleFilter !== 'Role' ? roleFilter : undefined,
-      openOnly: true,
+      // Show every team (open + closed). TeamCard already hides the
+      // Join / Message buttons on closed teams and surfaces a CLOSED badge,
+      // so listed closed teams act as "taken" signals without inviting
+      // a join attempt.
+      openOnly: false,
     },
     !!hackathon?.id && hackathon.participantType !== 'INDIVIDUAL'
   );

--- a/app/(landing)/hackathons/[slug]/components/tabs/contents/submissions/SubmissionCard.tsx
+++ b/app/(landing)/hackathons/[slug]/components/tabs/contents/submissions/SubmissionCard.tsx
@@ -36,6 +36,7 @@ const SubmissionCard = ({ submission }: SubmissionCardProps) => {
     teamMembers = [],
     participant,
     logo,
+    banner,
   } = submission;
 
   const router = useRouter();
@@ -88,17 +89,32 @@ const SubmissionCard = ({ submission }: SubmissionCardProps) => {
   return (
     <div className='group hover:border-primary/20 bg-background-card hover:bg-background-card-hover flex h-full flex-col overflow-hidden rounded-2xl border border-white/5 transition-all'>
       <div className='relative aspect-video w-full overflow-hidden bg-[#0D0E10]'>
-        {logo ? (
+        {banner ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={banner}
+            alt={`${projectName} banner`}
+            className='h-full w-full object-cover transition-transform duration-300 group-hover:scale-105'
+          />
+        ) : logo ? (
           // eslint-disable-next-line @next/next/no-img-element
           <img
             src={logo}
-            alt={`${projectName} banner`}
-            className='h-full w-full object-cover transition-transform duration-300 group-hover:scale-105'
+            alt={`${projectName} logo`}
+            className='h-full w-full object-contain p-8 transition-transform duration-300 group-hover:scale-105'
           />
         ) : (
           <div className='text-primary flex h-full w-full items-center justify-center bg-[#232B20]'>
             <LayoutGrid className='h-10 w-10' />
           </div>
+        )}
+        {banner && logo && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={logo}
+            alt={`${projectName} logo`}
+            className='absolute bottom-3 left-3 h-12 w-12 rounded-lg border-2 border-[#0D0E10] bg-[#0D0E10] object-cover shadow-lg'
+          />
         )}
       </div>
 

--- a/app/(landing)/hackathons/[slug]/components/tabs/contents/teams/MyTeamView.tsx
+++ b/app/(landing)/hackathons/[slug]/components/tabs/contents/teams/MyTeamView.tsx
@@ -189,11 +189,11 @@ const MyTeamView = ({ team, hackathonSlug }: MyTeamViewProps) => {
                 <div className='grid gap-4 sm:grid-cols-2'>
                   <div className='space-y-2'>
                     <label className='text-[10px] font-black tracking-[0.2em] text-[#555555] uppercase'>
-                      Email
+                      Email or Username
                     </label>
                     <input
-                      type='email'
-                      placeholder='teammate@example.com'
+                      type='text'
+                      placeholder='teammate@example.com or username'
                       value={inviteIdentifier}
                       onChange={e => {
                         setInviteIdentifier(e.target.value);

--- a/components/hackathons/submissions/SubmissionForm.tsx
+++ b/components/hackathons/submissions/SubmissionForm.tsx
@@ -90,6 +90,7 @@ const baseSubmissionSchema = z.object({
   category: z.string().min(1, 'Please select a category'),
   description: z.string().min(50, 'Description must be at least 50 characters'),
   logo: z.string().optional(),
+  banner: z.string().optional(),
   videoUrl: z
     .union([z.string().url('Please enter a valid URL'), z.literal('')])
     .optional(),
@@ -245,6 +246,8 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
   const [steps, setSteps] = useState<Step[]>(INITIAL_STEPS);
   const [logoPreview, setLogoPreview] = useState<string>('');
   const [isUploadingLogo, setIsUploadingLogo] = useState(false);
+  const [bannerPreview, setBannerPreview] = useState<string>('');
+  const [isUploadingBanner, setIsUploadingBanner] = useState(false);
   const hasAutoAdvanced = useRef(false);
 
   const { create, update, isSubmitting } = useSubmission({
@@ -274,6 +277,7 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
       category: '',
       description: '',
       logo: '',
+      banner: '',
       videoUrl: '',
       introduction: '',
       links: [],
@@ -301,6 +305,7 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
         category: initialData.category || '',
         description: initialData.description || '',
         logo: initialData.logo || '',
+        banner: initialData.banner || '',
         videoUrl: initialData.videoUrl || '',
         introduction: initialData.introduction || '',
         links: initialData.links || [],
@@ -308,6 +313,9 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
       });
       if (initialData.logo && isValidImageUrl(initialData.logo)) {
         setLogoPreview(initialData.logo);
+      }
+      if (initialData.banner && isValidImageUrl(initialData.banner)) {
+        setBannerPreview(initialData.banner);
       }
     }
   }, [open, initialData, form]);
@@ -373,6 +381,7 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
           participationType: 'INDIVIDUAL',
         });
         setLogoPreview('');
+        setBannerPreview('');
         setCurrentStep(0);
         setSteps(INITIAL_STEPS);
         hasAutoAdvanced.current = false;
@@ -428,6 +437,56 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
       setLogoPreview('');
     } finally {
       setIsUploadingLogo(false);
+    }
+  };
+
+  const handleBannerUpload = async (file: File) => {
+    if (!file.type.match(/^image\/(jpeg|jpg|png|gif|webp)$/)) {
+      toast.error('Please upload a JPEG, PNG, GIF, or WebP image');
+      return;
+    }
+
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error('File size must be less than 5MB');
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = e => {
+      const result = e.target?.result as string;
+      setBannerPreview(result);
+    };
+    reader.readAsDataURL(file);
+
+    setIsUploadingBanner(true);
+    try {
+      const uploadResult = await uploadService.uploadSingle(file, {
+        folder: 'boundless/hackathons/submissions/banners',
+        tags: ['hackathon', 'submission', 'banner'],
+        transformation: {
+          width: 1600,
+          height: 900,
+          crop: 'fill',
+          quality: 'auto',
+          format: 'auto',
+        },
+      });
+
+      if (uploadResult.success) {
+        form.setValue('banner', uploadResult.data.secure_url, {
+          shouldValidate: true,
+        });
+        toast.success('Banner uploaded successfully');
+      } else {
+        throw new Error(uploadResult.message || 'Upload failed');
+      }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Upload failed';
+      toast.error(`Failed to upload banner: ${errorMessage}`);
+      setBannerPreview('');
+    } finally {
+      setIsUploadingBanner(false);
     }
   };
 
@@ -610,6 +669,11 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
           (data.logo ?? currentValues.logo) &&
           String(data.logo ?? currentValues.logo).trim() !== ''
             ? String(data.logo ?? currentValues.logo).trim()
+            : undefined,
+        banner:
+          (data.banner ?? currentValues.banner) &&
+          String(data.banner ?? currentValues.banner).trim() !== ''
+            ? String(data.banner ?? currentValues.banner).trim()
             : undefined,
         videoUrl:
           (data.videoUrl ?? currentValues.videoUrl) &&
@@ -1102,6 +1166,74 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
 
             <FormField
               control={form.control}
+              name='banner'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className='text-white'>Project Banner</FormLabel>
+                  <FormControl>
+                    <div className='space-y-4'>
+                      {bannerPreview || isValidImageUrl(field.value) ? (
+                        <div className='relative w-full overflow-hidden rounded-lg'>
+                          <Image
+                            src={bannerPreview || field.value || ''}
+                            alt='Banner preview'
+                            width={1600}
+                            height={900}
+                            className='aspect-video w-full object-cover'
+                          />
+                          <Button
+                            type='button'
+                            variant='ghost'
+                            size='sm'
+                            onClick={() => {
+                              setBannerPreview('');
+                              form.setValue('banner', '', {
+                                shouldValidate: true,
+                              });
+                            }}
+                            className='absolute top-2 right-2 h-6 w-6 rounded-full bg-red-500 p-0 hover:bg-red-600'
+                          >
+                            <X className='h-4 w-4' />
+                          </Button>
+                        </div>
+                      ) : (
+                        <label className='flex aspect-video w-full cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-700 bg-gray-800/50 hover:border-gray-600'>
+                          <input
+                            type='file'
+                            className='hidden'
+                            accept='image/jpeg,image/jpg,image/png,image/gif,image/webp'
+                            onChange={e => {
+                              const file = e.target.files?.[0];
+                              if (file) {
+                                handleBannerUpload(file);
+                              }
+                            }}
+                            disabled={isUploadingBanner}
+                          />
+                          {isUploadingBanner ? (
+                            <Loader2 className='mb-2 h-8 w-8 animate-spin text-gray-400' />
+                          ) : (
+                            <Upload className='mb-2 h-8 w-8 text-gray-400' />
+                          )}
+                          <span className='text-sm text-gray-400'>
+                            {isUploadingBanner
+                              ? 'Uploading...'
+                              : 'Click to upload or drag and drop'}
+                          </span>
+                          <span className='text-xs text-gray-500'>
+                            16:9 hero image. PNG, JPG, GIF up to 5MB.
+                          </span>
+                        </label>
+                      )}
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
               name='videoUrl'
               render={({ field }) => (
                 <FormItem>
@@ -1282,6 +1414,20 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
                       width={100}
                       height={100}
                       className='rounded-lg object-cover'
+                    />
+                  </div>
+                )}
+                {isValidImageUrl(form.watch('banner')) && (
+                  <div>
+                    <p className='mb-2 text-sm font-medium text-gray-400'>
+                      Banner
+                    </p>
+                    <Image
+                      src={form.watch('banner') || ''}
+                      alt='Banner'
+                      width={400}
+                      height={225}
+                      className='aspect-video w-full max-w-sm rounded-lg object-cover'
                     />
                   </div>
                 )}

--- a/lib/api/hackathons.ts
+++ b/lib/api/hackathons.ts
@@ -746,6 +746,7 @@ export interface ExploreSubmissionsResponse {
   category: string;
   description: string;
   logo?: string | null;
+  banner?: string | null;
   videoUrl?: string | null;
   introduction?: string | null;
   links?: Array<{ type: string; url: string }>;
@@ -856,6 +857,7 @@ export interface CreateSubmissionRequest {
   category: string;
   description: string;
   logo?: string;
+  banner?: string;
   videoUrl?: string;
   introduction?: string;
   links: Array<{ type: string; url: string; description?: string }>;


### PR DESCRIPTION
## Summary

Two commits on top of current production.

### 1. Invite-by field accepts email or username (label + input type)
Stranded from PR #535 — the invite-form input was still typed \`email\` with an email-shaped placeholder even though the backend accepts \`email | username | id\`. Switched to:

- Label: \`Email or Username\`
- Placeholder: \`teammate@example.com or username\`
- \`type=text\` (no strict email validation)

### 2. Submission banner upload, render, and closed-team visibility

**Submission wizard ([SubmissionForm.tsx](components/hackathons/submissions/SubmissionForm.tsx))**
- Added an optional banner field next to the existing logo upload. Same upload pattern, transformation tuned for 16:9 hero artwork (1600x900 fill via Cloudinary). Preview, replace, and remove all mirror the logo flow.
- Schema, defaults, \`initialData\` hydration, review-step preview, and the submit body all extended for banner.

**Submission card ([SubmissionCard.tsx](app/(landing)/hackathons/[slug]/components/tabs/contents/submissions/SubmissionCard.tsx))**
- Banner is the hero when present.
- Falls back to a centered logo when only logo is set.
- LayoutGrid placeholder when neither is set.
- When both are present, banner stays as hero and logo is overlaid as a small bottom-left badge with a dark border.

**Submission API type ([hackathons.ts](lib/api/hackathons.ts))**
- \`ExploreSubmissionsResponse.banner\` and \`CreateSubmissionRequest.banner\` added as optional fields.

**Closed teams visible ([FindTeam.tsx](app/(landing)/hackathons/[slug]/components/tabs/contents/FindTeam.tsx))**
- Was passing \`openOnly:true\`, so closed teams disappeared from the team list. They now show up alongside open teams. \`TeamCard\` already hides Join + Message buttons on closed teams and surfaces a \`CLOSED\` badge, so listed closed teams act as "taken" signals without inviting a join attempt.

## Backend pair
[boundless-nestjs#95](https://github.com/boundlessfi/boundless-nestjs/pull/95) — adds the \`banner\` column, threads it through DTOs / service / repository, and fixes the "team name required" failure on TEAM submissions by deriving \`teamName\` / \`teamMembers\` from the user's actual team.

## Test plan
- [ ] Open MyTeamView invite form — label reads "Email or Username", placeholder reads "teammate@example.com or username"; both registered email and registered username succeed
- [ ] Submission wizard: upload a banner — preview shows, replace works, remove works; submit and confirm banner persists
- [ ] Submission wizard: leave banner empty — submit succeeds without banner
- [ ] Submission card with banner + logo → banner as hero, logo as bottom-left badge
- [ ] Submission card with logo only → logo centered with padding (not stretched)
- [ ] Submission card with neither → LayoutGrid placeholder
- [ ] Team-formation tab: closed teams now appear alongside open teams with the CLOSED badge and no Join / Message buttons