### PR TITLE
fix(teams): per-invite failure detail in useTeamInvite [Sprint 3 FE]

### DIFF
--- a/hooks/hackathon/use-team-invite.ts
+++ b/hooks/hackathon/use-team-invite.ts
@@ -15,13 +15,33 @@ interface UseTeamInviteOptions {
   onSuccess?: (teamId: string) => void;
 }
 
+export interface InviteResult {
+  /** Identifier (email/username/userId) the leader entered. */
+  invitee: string;
+  status: 'sent' | 'failed';
+  /** Failure reason from the backend, present when status === 'failed'. */
+  error?: string;
+}
+
 interface UseTeamInviteReturn {
   createTeamAndInvite: (
     teamData: CreateTeamPostRequest,
     invitees: string[]
-  ) => Promise<string>;
+  ) => Promise<{ teamId: string; invites: InviteResult[] }>;
   isCreatingTeam: boolean;
   error: string | null;
+}
+
+function getErrorMessage(err: unknown, fallback: string): string {
+  if (err && typeof err === 'object') {
+    const candidate =
+      (err as { response?: { data?: { message?: string } } }).response?.data
+        ?.message ?? (err as { message?: string }).message;
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate;
+    }
+  }
+  return fallback;
 }
 
 export const useTeamInvite = ({
@@ -35,7 +55,7 @@ export const useTeamInvite = ({
   const createTeamAndInvite = useCallback(
     async (
       teamData: CreateTeamPostRequest,
-      invitees: string[] // Array of user IDs or usernames
+      invitees: string[] // Array of user IDs, usernames, or emails
     ) => {
       setIsCreatingTeam(true);
       setError(null);
@@ -54,54 +74,75 @@ export const useTeamInvite = ({
 
         const newTeamId = teamResponse.data.id;
 
-        // 2. Invite Members
-        let failedInvitesCount = 0;
+        // 2. Invite members in parallel. Promise.allSettled instead of
+        //    Promise.all so a single rejection doesn't poison the rest of
+        //    the batch — we want every invite attempt to be reported.
+        const invites: InviteResult[] = [];
         if (invitees.length > 0) {
-          const results = await Promise.all(
-            invitees.map(async invitee => {
-              try {
-                const res = await inviteUserToTeam(
-                  hackathonSlugOrId,
-                  newTeamId,
-                  {
-                    inviteeIdentifier: invitee,
-                    message: 'Join my team for the hackathon!',
-                  }
-                );
-
-                if (!res.success) {
-                  reportMessage(
-                    `Failed to invite ${invitee}: ${res.message}`,
-                    'warning'
-                  );
-                }
-                return res;
-              } catch (err) {
-                reportError(err, { context: 'team-invite', invitee });
-                return null;
-              }
-            })
+          const settled = await Promise.allSettled(
+            invitees.map(invitee =>
+              inviteUserToTeam(hackathonSlugOrId, newTeamId, {
+                inviteeIdentifier: invitee,
+                message: 'Join my team for the hackathon!',
+              }).then(res => ({ invitee, res }))
+            )
           );
-          failedInvitesCount = results.filter(
-            res => !res || !res.success
-          ).length;
+
+          for (let i = 0; i < settled.length; i += 1) {
+            const result = settled[i];
+            const invitee = invitees[i];
+            if (result.status === 'fulfilled') {
+              const { res } = result.value;
+              if (res?.success) {
+                invites.push({ invitee, status: 'sent' });
+              } else {
+                const reason = res?.message ?? 'Invite failed';
+                reportMessage(
+                  `Failed to invite ${invitee}: ${reason}`,
+                  'warning'
+                );
+                invites.push({ invitee, status: 'failed', error: reason });
+              }
+            } else {
+              const reason = getErrorMessage(result.reason, 'Invite failed');
+              reportError(result.reason, { context: 'team-invite', invitee });
+              invites.push({ invitee, status: 'failed', error: reason });
+            }
+          }
         }
 
-        if (failedInvitesCount === 0) {
-          toast.success('Team created successfully!');
+        const failed = invites.filter(i => i.status === 'failed');
+
+        if (failed.length === 0) {
+          toast.success('Team created — all invites sent.');
           onSuccess?.(newTeamId);
         } else {
-          const message =
-            failedInvitesCount === invitees.length
-              ? `Team created, but all ${failedInvitesCount} invites failed to send.`
-              : `Team created, but ${failedInvitesCount} of ${invitees.length} invites failed.`;
-          toast.error(message);
+          // Surface WHO failed and WHY, not just the count. The leader
+          // needs both pieces to decide whether to fix the address and
+          // retry, or invite a different person via MyTeamView.
+          const summary =
+            failed.length === invitees.length
+              ? `Team created, but all ${failed.length} invites failed.`
+              : `Team created. ${invites.length - failed.length} of ${invites.length} invites sent.`;
+          // Cap the description so very large failure lists don't dominate
+          // the screen; the rest is in the returned `invites` array for the
+          // caller to render properly.
+          const detail = failed
+            .slice(0, 5)
+            .map(f => `• ${f.invitee}: ${f.error ?? 'unknown error'}`)
+            .join('\n');
+          const more =
+            failed.length > 5 ? `\n…and ${failed.length - 5} more` : '';
+          toast.error(summary, { description: `${detail}${more}` });
+          // Still call onSuccess: the team exists, the modal should close
+          // and the leader can re-invite via MyTeamView using the returned
+          // `invites` list as a starting point.
+          onSuccess?.(newTeamId);
         }
 
-        return newTeamId;
+        return { teamId: newTeamId, invites };
       } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : 'Failed to create team';
+        const errorMessage = getErrorMessage(err, 'Failed to create team');
         setError(errorMessage);
         toast.error(errorMessage);
         throw err;


### PR DESCRIPTION
## Summary

Frontend half of Sprint 3. Pairs with [boundless-nestjs#97](https://github.com/boundlessfi/boundless-nestjs/pull/97) (atomic team-member adds), but ships independently — no compile-time dependency.

## Why

\`createTeamAndInvite\` swallowed individual invite failures behind a count: \"Team created, but 2 of 5 invites failed.\" The leader had no way to tell WHICH 2 failed or WHY. They had to:

1. Remember the order they typed people in
2. Cross-reference against the empty MyTeamView
3. Guess

If they got it wrong they'd silently re-invite an already-pending person and confuse them with a duplicate notification.

## What changed

\`hooks/hackathon/use-team-invite.ts\`:

- Switched from \`Promise.all\` (with per-invite \`try/catch\` + null-fallback) to \`Promise.allSettled\` — cleaner control flow, no possibility of one rejection poisoning the rest of the batch.
- Now collects a typed \`InviteResult[]\` with \`{ invitee, status, error }\`.
- Failure toast shows the first 5 failures by name with their backend error messages, e.g.:

  > **Team created. 3 of 5 invites sent.**
  > • alice@example.com: User not found
  > • bob: Pending invitation already exists
  > • charlie@x: Hackathon participant cap reached

- Returns \`{ teamId, invites }\` instead of just \`teamId\` so callers can render their own retry UI from the failure list (only consumer is \`SubmissionForm\`, which currently has \`useTeamInvite\` as an unused import — no migration needed).

## Why no rollback

Audit item #4 originally suggested rolling back the team if invites partially failed. Rejected that approach: the team is a valid 1-person artifact (the leader is in it), and the leader can re-invite via MyTeamView using the returned failure list as a starting point. Auto-deleting on partial failure would lose the leader's typed name/description and force them to start over — worse UX for what's almost always a recoverable issue (typo in an email).

## Test plan

- [ ] Create team with 5 valid invitees → toast \"Team created — all invites sent.\"
- [ ] Create team with mix of valid + bogus invitees → toast shows per-line error for the failures
- [ ] Create team with all-bogus invitees → toast says all N invites failed; team still exists in MyTeamView
- [ ] Leader re-invites the failed addresses via MyTeamView → works (Sprint 1's cache invalidation surfaces the new invites immediately)

## Sprint roadmap

- Sprint 1: #540
- Sprint 2 BE: boundless-nestjs#96
- Sprint 2 FE: #541
- **Sprint 3 BE:** boundless-nestjs#97
- **Sprint 3 FE (this):** invite failure detail
- Sprint 4: Submission ↔ team alignment
- Sprint 5: Polish

