### PR TITLE
fix(invitations): tighter states + correct auth redirects on accept/reject pages [Sprint 5]

### DIFF
--- a/app/(landing)/hackathons/[slug]/team-invitations/[token]/accept/page.tsx
+++ b/app/(landing)/hackathons/[slug]/team-invitations/[token]/accept/page.tsx
@@ -24,6 +24,8 @@ import {
 } from '@/components/ui/card';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 
+const REDIRECT_DELAY_MS = 1500;
+
 const AcceptTeamInvitationPage = () => {
   const params = useParams();
   const searchParams = useSearchParams();
@@ -37,7 +39,7 @@ const AcceptTeamInvitationPage = () => {
 
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [successTeamName, setSuccessTeamName] = useState<string>('');
+  const [errorStatus, setErrorStatus] = useState<number | null>(null);
   const [successHackathonName, setSuccessHackathonName] = useState<string>('');
   const [autoEnrolled, setAutoEnrolled] = useState(false);
   const [showAcceptButton, setShowAcceptButton] = useState(false);
@@ -48,21 +50,23 @@ const AcceptTeamInvitationPage = () => {
       return;
     }
 
-    // If user is authenticated, show accept button
     if (isAuthenticated && !authLoading) {
       setShowAcceptButton(true);
     }
 
-    // If user is not authenticated and not loading, redirect to auth
     if (!isAuthenticated && !authLoading) {
       redirectToAuth();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAuthenticated, authLoading, invitationToken]);
 
-  const redirectToAuth = () => {
-    const redirectUrl = `/hackathons/${hackathonSlug}/team-invitations/${invitationToken}/accept`;
-    const authUrl = `/auth?mode=signin&redirect=${encodeURIComponent(redirectUrl)}`;
-    router.push(authUrl);
+  const redirectToAuth = (mode: 'signin' | 'signup' = 'signin') => {
+    // The rest of the app uses `callbackUrl`, not `redirect`. Match it so
+    // the auth page actually honors where we want to send the user back.
+    const callbackUrl = `/hackathons/${hackathonSlug}/team-invitations/${invitationToken}/accept`;
+    router.push(
+      `/auth?mode=${mode}&callbackUrl=${encodeURIComponent(callbackUrl)}`
+    );
   };
 
   const handleAcceptInvitation = async () => {
@@ -70,6 +74,7 @@ const AcceptTeamInvitationPage = () => {
 
     setIsProcessing(true);
     setError(null);
+    setErrorStatus(null);
 
     try {
       const response = await acceptTeamInvitation(
@@ -78,39 +83,55 @@ const AcceptTeamInvitationPage = () => {
       );
 
       if (response.success) {
-        setSuccessTeamName(response.data?.teamId || 'the team');
-        setSuccessHackathonName(response.data?.hackathon?.name || '');
+        const hackathonName =
+          response.data?.hackathon?.name ||
+          response.data?.invitation?.hackathon?.name ||
+          '';
+        setSuccessHackathonName(hackathonName);
         setAutoEnrolled(!!response.data?.autoEnrolled);
-        // Use the slug from the response if available, otherwise go to hackathons list
-        const finalSlug = response.data?.invitation?.hackathon?.slug;
+
         toast.success(
-          response.data?.autoEnrolled
-            ? `Joined ${response.data?.hackathon?.name ?? 'the hackathon'} and the team!`
+          response.data?.autoEnrolled && hackathonName
+            ? `Joined ${hackathonName} and the team!`
             : 'Successfully joined the team!'
         );
-        setTimeout(() => {
-          if (finalSlug) {
-            router.push(`/hackathons/${finalSlug}?tab=team-formation`);
-          } else {
-            router.push('/hackathons');
-          }
-        }, 2000);
-      }
-    } catch (err: any) {
-      const errorMessage = err?.message || 'Failed to accept invitation';
-      setError(errorMessage);
 
-      if (err?.status === 403) {
-        if (errorMessage.includes('different email address')) {
+        // Prefer the slug from the response, fall back to the slug in the
+        // URL (we know it's correct), then finally the hackathons list.
+        const finalSlug =
+          response.data?.invitation?.hackathon?.slug || hackathonSlug;
+        setTimeout(() => {
+          router.push(
+            finalSlug
+              ? `/hackathons/${finalSlug}?tab=team-formation`
+              : '/hackathons'
+          );
+        }, REDIRECT_DELAY_MS);
+      }
+    } catch (err: unknown) {
+      const errorObj = err as {
+        message?: string;
+        status?: number;
+        response?: { status?: number };
+      };
+      const errorMessage = errorObj?.message || 'Failed to accept invitation';
+      const status = errorObj?.status ?? errorObj?.response?.status ?? null;
+      setError(errorMessage);
+      setErrorStatus(status);
+
+      // Status-specific toasts. The error card below has the full copy and
+      // the right action button — toast is a quick attention grab.
+      if (status === 403) {
+        if (errorMessage.toLowerCase().includes('different email')) {
           toast.error('This invitation was sent to a different email address');
         } else {
           toast.error('Authentication required');
           redirectToAuth();
         }
-      } else if (err?.status === 404) {
+      } else if (status === 404) {
         toast.error('Invitation not found or has expired');
-      } else if (err?.status === 409) {
-        toast.error('You are already a member of this team');
+      } else if (status === 409) {
+        toast.error("You're already on this team");
       } else {
         toast.error(errorMessage);
       }
@@ -137,7 +158,7 @@ const AcceptTeamInvitationPage = () => {
     );
   }
 
-  if (showAcceptButton && !error && !successTeamName) {
+  if (showAcceptButton && !error && !successHackathonName) {
     return (
       <div className='bg-background flex min-h-screen items-center justify-center p-4'>
         <Card className='border-border bg-card w-full max-w-md shadow-lg'>
@@ -194,14 +215,21 @@ const AcceptTeamInvitationPage = () => {
   }
 
   if (error && !isProcessing) {
-    const isWrongEmail = error.includes('different email address');
-    const isAlreadyMember = error.includes('already a member');
+    const isWrongEmail =
+      errorStatus === 403 && error.toLowerCase().includes('different email');
+    const isAlreadyMember =
+      errorStatus === 409 || error.toLowerCase().includes('already');
+    const isNotFound = errorStatus === 404;
 
     return (
       <div className='bg-background flex min-h-screen items-center justify-center p-4'>
         <Card className='border-border bg-card w-full max-w-md shadow-lg'>
           <CardHeader className='text-center'>
-            <div className='bg-destructive/10 mx-auto mb-4 flex h-20 w-20 items-center justify-center rounded-full'>
+            <div
+              className={`mx-auto mb-4 flex h-20 w-20 items-center justify-center rounded-full ${
+                isAlreadyMember ? 'bg-primary/10' : 'bg-destructive/10'
+              }`}
+            >
               {isAlreadyMember ? (
                 <CheckCircle2 className='text-primary h-10 w-10' />
               ) : (
@@ -209,7 +237,13 @@ const AcceptTeamInvitationPage = () => {
               )}
             </div>
             <CardTitle className='text-2xl'>
-              {isAlreadyMember ? 'Already a Member' : 'Unable to Join'}
+              {isAlreadyMember
+                ? "You're already on this team"
+                : isNotFound
+                  ? 'Invitation not found'
+                  : isWrongEmail
+                    ? 'Wrong account'
+                    : 'Unable to Join'}
             </CardTitle>
             <CardDescription>{error}</CardDescription>
           </CardHeader>
@@ -217,70 +251,94 @@ const AcceptTeamInvitationPage = () => {
             {isWrongEmail && (
               <Alert variant='destructive'>
                 <Mail className='h-4 w-4' />
-                <AlertTitle>Wrong Account</AlertTitle>
+                <AlertTitle>Sign in with the invited email</AlertTitle>
                 <AlertDescription>
-                  Please sign in with the email address this invitation was sent
-                  to.
+                  This invitation was sent to a different email address than the
+                  one you're signed in with. Sign out, then sign back in with
+                  the email the invitation was sent to.
+                </AlertDescription>
+              </Alert>
+            )}
+            {isNotFound && (
+              <Alert variant='destructive'>
+                <AlertCircle className='h-4 w-4' />
+                <AlertTitle>Expired or revoked</AlertTitle>
+                <AlertDescription>
+                  Invitations expire after 7 days. Ask the team leader to send
+                  you a fresh one.
                 </AlertDescription>
               </Alert>
             )}
           </CardContent>
           <CardFooter className='flex flex-col gap-3'>
-            {isWrongEmail ? (
-              <>
-                <Button
-                  className='w-full'
-                  onClick={() => {
-                    const redirectUrl = `/hackathons/${hackathonSlug}/team-invitations/${invitationToken}/accept`;
-                    router.push(
-                      `/auth?mode=signup&redirect=${encodeURIComponent(redirectUrl)}`
-                    );
-                  }}
-                >
-                  Switch Account
-                </Button>
-                <Button
-                  variant='outline'
-                  className='w-full'
-                  onClick={() => router.push('/hackathons')}
-                >
-                  Back to Hackathons
-                </Button>
-              </>
-            ) : (
+            {isWrongEmail && (
+              // Signin (not signup) — they already have an account, they
+              // just need to switch to the right one.
               <Button
                 className='w-full'
-                onClick={() => router.push('/hackathons')}
+                onClick={() => redirectToAuth('signin')}
               >
-                Back to Hackathons
+                Switch Account
               </Button>
             )}
+            {isAlreadyMember && (
+              <Button
+                className='w-full'
+                onClick={() =>
+                  router.push(`/hackathons/${hackathonSlug}?tab=team-formation`)
+                }
+              >
+                View Team
+              </Button>
+            )}
+            <Button
+              variant={isWrongEmail || isAlreadyMember ? 'outline' : 'default'}
+              className='w-full'
+              onClick={() => router.push(`/hackathons/${hackathonSlug}`)}
+            >
+              Back to Hackathon
+            </Button>
           </CardFooter>
         </Card>
       </div>
     );
   }
 
-  if (successTeamName) {
+  if (successHackathonName || (!error && !showAcceptButton && !authLoading)) {
+    // Render the success card if we got a hackathon name back, or as a
+    // generic fallback if no other state matches (defensive — should be
+    // rare since the auth/error/accept-button branches above cover most
+    // paths, but stops the page rendering blank if response shape shifts).
+    const showingSuccess = !!successHackathonName;
     return (
       <div className='bg-background flex min-h-screen items-center justify-center p-4'>
         <Card className='border-border bg-card w-full max-w-md shadow-lg'>
           <CardHeader className='text-center'>
             <div className='bg-primary/10 mx-auto mb-4 flex h-20 w-20 items-center justify-center rounded-full'>
-              <CheckCircle2 className='text-primary h-10 w-10' />
+              {showingSuccess ? (
+                <CheckCircle2 className='text-primary h-10 w-10' />
+              ) : (
+                <Loader2 className='text-primary h-10 w-10 animate-spin' />
+              )}
             </div>
-            <CardTitle className='text-2xl'>Welcome!</CardTitle>
+            <CardTitle className='text-2xl'>
+              {showingSuccess ? 'Welcome!' : 'Loading...'}
+            </CardTitle>
             <CardDescription>
-              {autoEnrolled && successHackathonName
-                ? `You've joined ${successHackathonName} and ${successTeamName}. Redirecting...`
-                : `You've successfully joined ${successTeamName}. Redirecting...`}
+              {showingSuccess
+                ? autoEnrolled
+                  ? `You've joined ${successHackathonName} and the team. Redirecting...`
+                  : `You've successfully joined the team in ${successHackathonName}. Redirecting...`
+                : 'Preparing your invitation.'}
             </CardDescription>
           </CardHeader>
-          <CardContent>
-            <div className='bg-secondary h-1 w-full overflow-hidden rounded-full'>
-              <div className='bg-primary h-full w-full animate-[loading_2s_ease-in-out]' />
-            </div>
-          </CardContent>
+          {showingSuccess && (
+            <CardContent>
+              <div className='bg-secondary h-1 w-full overflow-hidden rounded-full'>
+                <div className='bg-primary h-full w-full animate-[loading_1.5s_ease-in-out]' />
+              </div>
+            </CardContent>
+          )}
         </Card>
       </div>
     );

--- a/app/(landing)/hackathons/[slug]/team-invitations/[token]/reject/page.tsx
+++ b/app/(landing)/hackathons/[slug]/team-invitations/[token]/reject/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
-import { Users, AlertCircle, Loader2, XCircle } from 'lucide-react';
+import { AlertCircle, Loader2, XCircle, CheckCircle2 } from 'lucide-react';
 import { useAuthStatus } from '@/hooks/use-auth';
 import { rejectTeamInvitation } from '@/lib/api/hackathons';
 import { toast } from 'sonner';
@@ -14,6 +14,8 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+
+const REDIRECT_DELAY_MS = 1500;
 
 const RejectTeamInvitationPage = () => {
   const params = useParams();
@@ -28,6 +30,7 @@ const RejectTeamInvitationPage = () => {
 
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [errorStatus, setErrorStatus] = useState<number | null>(null);
   const [success, setSuccess] = useState(false);
 
   useEffect(() => {
@@ -39,12 +42,17 @@ const RejectTeamInvitationPage = () => {
     if (!isAuthenticated && !authLoading) {
       redirectToAuth();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAuthenticated, authLoading, invitationToken]);
 
   const redirectToAuth = () => {
-    const currentUrl = window.location.href;
-    const encodedRedirect = encodeURIComponent(currentUrl);
-    router.push(`/auth/login?redirect=${encodedRedirect}`);
+    // Match the rest of the app: /auth?mode=signin&callbackUrl=...
+    // (the previous /auth/login?redirect=... was a non-existent route and
+    // got the user stuck.)
+    const callbackUrl = `/hackathons/${hackathonSlug}/team-invitations/${invitationToken}/reject`;
+    router.push(
+      `/auth?mode=signin&callbackUrl=${encodeURIComponent(callbackUrl)}`
+    );
   };
 
   const handleReject = async () => {
@@ -52,6 +60,7 @@ const RejectTeamInvitationPage = () => {
 
     setIsProcessing(true);
     setError(null);
+    setErrorStatus(null);
 
     try {
       const response = await rejectTeamInvitation(
@@ -61,26 +70,32 @@ const RejectTeamInvitationPage = () => {
 
       if (response.success) {
         setSuccess(true);
-        // Use the slug from the response if available, otherwise go to hackathons list
-        const finalSlug = response.data?.invitation?.hackathon?.slug;
+        const finalSlug =
+          response.data?.invitation?.hackathon?.slug || hackathonSlug;
         toast.success('Invitation declined');
         setTimeout(() => {
-          if (finalSlug) {
-            router.push(`/hackathons/${finalSlug}`);
-          } else {
-            router.push('/hackathons');
-          }
-        }, 2000);
+          router.push(finalSlug ? `/hackathons/${finalSlug}` : '/hackathons');
+        }, REDIRECT_DELAY_MS);
       }
-    } catch (err: any) {
-      const errorMessage = err?.message || 'Failed to decline invitation';
+    } catch (err: unknown) {
+      const errorObj = err as {
+        message?: string;
+        status?: number;
+        response?: { status?: number };
+      };
+      const errorMessage = errorObj?.message || 'Failed to decline invitation';
+      const status = errorObj?.status ?? errorObj?.response?.status ?? null;
       setError(errorMessage);
+      setErrorStatus(status);
 
-      if (err?.status === 403) {
+      if (status === 403) {
         toast.error('Authentication required');
         redirectToAuth();
-      } else if (err?.status === 404) {
+      } else if (status === 404) {
         toast.error('Invitation not found or has expired');
+      } else if (status === 400 && /already/i.test(errorMessage)) {
+        // Backend uses 400 for "Invitation has already been {accepted|rejected|expired}"
+        toast.error(errorMessage);
       } else {
         toast.error(errorMessage);
       }
@@ -108,24 +123,39 @@ const RejectTeamInvitationPage = () => {
   }
 
   if (error && !success) {
+    const isAlreadyResponded = errorStatus === 400 && /already/i.test(error);
+    const isNotFound = errorStatus === 404;
+
     return (
       <div className='bg-background flex min-h-screen items-center justify-center p-4'>
         <Card className='border-border bg-card w-full max-w-md shadow-lg'>
           <CardHeader className='text-center'>
-            <div className='bg-destructive/10 mx-auto mb-4 flex h-20 w-20 items-center justify-center rounded-full'>
-              <AlertCircle className='text-destructive h-10 w-10' />
+            <div
+              className={`mx-auto mb-4 flex h-20 w-20 items-center justify-center rounded-full ${
+                isAlreadyResponded ? 'bg-muted' : 'bg-destructive/10'
+              }`}
+            >
+              {isAlreadyResponded ? (
+                <CheckCircle2 className='text-muted-foreground h-10 w-10' />
+              ) : (
+                <AlertCircle className='text-destructive h-10 w-10' />
+              )}
             </div>
-            <CardTitle className='text-destructive text-2xl'>
-              Unable to Process
+            <CardTitle className='text-2xl'>
+              {isAlreadyResponded
+                ? 'Already Responded'
+                : isNotFound
+                  ? 'Invitation Not Found'
+                  : 'Unable to Process'}
             </CardTitle>
             <CardDescription>{error}</CardDescription>
           </CardHeader>
           <CardFooter>
             <Button
               className='w-full'
-              onClick={() => router.push('/hackathons')}
+              onClick={() => router.push(`/hackathons/${hackathonSlug}`)}
             >
-              Return to Hackathons
+              Back to Hackathon
             </Button>
           </CardFooter>
         </Card>
@@ -147,8 +177,8 @@ const RejectTeamInvitationPage = () => {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <div className='flex justify-center'>
-              <Loader2 className='text-primary h-6 w-6 animate-spin' />
+            <div className='bg-secondary h-1 w-full overflow-hidden rounded-full'>
+              <div className='bg-primary h-full w-full animate-[loading_1.5s_ease-in-out]' />
             </div>
           </CardContent>
         </Card>
@@ -191,7 +221,7 @@ const RejectTeamInvitationPage = () => {
           <Button
             variant='ghost'
             className='w-full'
-            onClick={() => router.push('/hackathons')}
+            onClick={() => router.push(`/hackathons/${hackathonSlug}`)}
             disabled={isProcessing}
           >
             Cancel


### PR DESCRIPTION
## Summary

Final sprint of the team-flow audit. Polishes the standalone invitation accept/reject pages — they had real correctness issues hiding under decent-looking UI.

## What was broken

### Accept page
1. **Success copy showed the team's cryptic ID, not a name.** Backend doesn't return team name in the accept response, so the page rendered \"You've successfully joined team_1234567_abc.\"
2. **Auth redirect used `?redirect=`** but the rest of the app uses `?callbackUrl=`. Auth page wasn't honoring the param so users got stranded after sign-in.
3. **\"Wrong account\" → Switch Account** button pointed to `mode=signup`. They already have an account; they need `mode=signin`.
4. **Cancel button went to `/hackathons` (root list)** instead of back to the hackathon they were on.
5. **Status code was only read from `err.status`** — our axios client also exposes it as `err.response.status`, so the status-specific branches didn't fire.

### Reject page
6. **Auth redirect went to `/auth/login?redirect=...`** — that route doesn't exist in this app. Users hit a 404.
7. **No specific handling for \"already responded\"** — backend returns 400 with \"Invitation has already been {accepted|rejected|expired}\" but the page treated it as a generic error.
8. **Same cancel-to-/hackathons issue.**

## Fixes

**Accept** ([app/.../accept/page.tsx](boundless/app/(landing)/hackathons/[slug]/team-invitations/[token]/accept/page.tsx))
- Success copy uses hackathon name (which IS in the response): \"You've successfully joined the team in {hackathonName}.\"
- Auth redirect helper now takes a `mode` arg and uses `?mode={mode}&callbackUrl=...` matching the app pattern.
- Switch Account uses `mode=signin`.
- Error card differentiates 404 (expired/revoked, with \"ask the team leader for a fresh invite\" copy), 409 (already on team, with a \"View Team\" CTA into the team-formation tab), 403 (wrong email, with sign-out-and-back-in guidance).
- Status read from `err.status ?? err.response?.status`.
- Cancel/back goes to `/hackathons/{slug}`.

**Reject** ([app/.../reject/page.tsx](boundless/app/(landing)/hackathons/[slug]/team-invitations/[token]/reject/page.tsx))
- Auth redirect uses `/auth?mode=signin&callbackUrl=...`.
- New \"Already Responded\" branch with muted styling for the 400-already case.
- Same `err.response.status` fix and `/hackathons/{slug}` back-button target.

Both pages: redirect delay tightened from 2s to 1.5s.

## Audit roadmap done ✅

| # | Item | Where |
|---|---|---|
| 1 | Kick member endpoint | Sprint 2 |
| 2 | Disband team endpoint | Sprint 2 |
| 3 | Stale myTeam after mutations | Sprint 1 |
| 4 | useTeamInvite partial-failure detail | Sprint 3 FE |
| 5 | Atomic invite acceptance | Sprint 3 BE |
| 6 | Team size validation on creation | Sprint 2 (already covered) |
| 7 | Submission snapshot vs live (UI clarity) | Sprint 4 BE (DTO docs) |
| 8 | Old leader after transferLeadership | Sprint 2 / sidebar already gates by `isLeader` |
| 9 | updateTeam controller leader check | Service-level check is sufficient — skipped |
| 10 | Cap accept against hackathon.teamMax | Sprint 2 BE |
| 11 | Submission DTO contract | Sprint 4 BE |
| 12 | Defensive response-shape unwrapping | Sprint 1 |
| 13 | Closed-team isOpen on direct join | Already enforced — audit was wrong |
| 14 | Orphaned submissionTab.tsx | Sprint 1 |
| 15 | Team.members type | Sprint 1 |
| 16 | **Invitation page states (this PR)** | Sprint 5 |
| 17 | teamMin/teamMax on Hackathon type | Already in place |
| 18 | Better email-invite for unregistered | pre-Sprint-4 PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)