### PR TITLE
fix(auth): prefill signup email when arriving from an invitation link

### DIFF
--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -14,6 +14,10 @@ export default function AuthPage() {
 
   const modeParam = searchParams.get('mode');
   const invitation = searchParams.get('invitation');
+  // Email-invite links to unregistered users carry ?email=... so the signup
+  // form can prefill. Without this, the user has to retype the address the
+  // invitation was just sent to.
+  const prefillEmail = searchParams.get('email');
 
   const getModeFromQuery = (mode: string | null): 'signin' | 'signup' => {
     if (mode === 'signup') return 'signup';
@@ -61,6 +65,7 @@ export default function AuthPage() {
                   <SignupWrapper
                     setLoadingState={setLoadingState}
                     invitation={invitation}
+                    defaultEmail={prefillEmail}
                   />
                 )}
               </div>

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -39,6 +39,12 @@ const formSchema = z.object({
 interface SignupFormProps {
   onLoadingChange?: (isLoading: boolean) => void;
   invitation?: string | null;
+  /**
+   * Prefills the email field. Comes through the URL as `?email=...` —
+   * email-invite links to unregistered users carry it so the invitee
+   * doesn't have to retype the address the invitation was sent to.
+   */
+  defaultEmail?: string | null;
   onGoogleSignIn?: () => void;
   lastMethod?: string | null;
 }
@@ -46,6 +52,7 @@ interface SignupFormProps {
 const SignupForm = ({
   onLoadingChange,
   invitation,
+  defaultEmail,
   onGoogleSignIn,
   lastMethod,
 }: SignupFormProps) => {
@@ -55,7 +62,7 @@ const SignupForm = ({
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      email: '',
+      email: defaultEmail ?? '',
       firstName: '',
       lastName: '',
       password: '',

--- a/components/auth/SignupWrapper.tsx
+++ b/components/auth/SignupWrapper.tsx
@@ -8,9 +8,11 @@ import { authClient } from '@/lib/auth-client';
 const SignupWrapper = ({
   setLoadingState,
   invitation,
+  defaultEmail,
 }: {
   setLoadingState: (isLoading: boolean) => void;
   invitation?: string | null;
+  defaultEmail?: string | null;
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [lastMethod, setLastMethod] = useState<string | null>(null);
@@ -67,6 +69,7 @@ const SignupWrapper = ({
     <SignupForm
       onLoadingChange={setIsLoading}
       invitation={invitation}
+      defaultEmail={defaultEmail}
       onGoogleSignIn={handleGoogleSignIn}
       lastMethod={lastMethod}
     />


### PR DESCRIPTION
## Summary

Email-invite links to unregistered users carry \`?email=...\` in the URL (see \`EmailSenderService.sendTeamInvitation\`), but \`app/auth/page.tsx\` was only reading \`?mode\` and \`?invitation\`. The email field rendered empty and users had to retype the address the invite was just sent to — small papercut, but exactly the kind of friction that makes people drop off mid-signup.

Threads the param down: \`AuthPage\` reads \`searchParams.get('email')\`, \`SignupWrapper\` takes a \`defaultEmail\` prop, \`SignupForm\` uses it as react-hook-form's email \`defaultValue\`. No behavior change when the param is absent.

## Independent of the rest

No backend or other-PR dependency. Touches only auth pages. Safe to merge alone.

## Test path

1. Trigger a team invite to a brand-new email via the leader's MyTeamView
2. Open the email, click the link
3. Signup page loads with the email field pre-filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)