### PR TITLE
fix(submissions): correct logo cropping and remove duplicate category badge on submission card

### DIFF
--- a/app/(landing)/hackathons/[slug]/components/tabs/contents/submissions/SubmissionCard.tsx
+++ b/app/(landing)/hackathons/[slug]/components/tabs/contents/submissions/SubmissionCard.tsx
@@ -113,7 +113,7 @@ const SubmissionCard = ({ submission }: SubmissionCardProps) => {
           <img
             src={logo}
             alt={`${projectName} logo`}
-            className='absolute bottom-3 left-3 h-12 w-12 rounded-lg border-2 border-[#0D0E10] bg-[#0D0E10] object-cover shadow-lg'
+            className='absolute bottom-3 left-3 h-12 w-12 rounded-lg border-2 border-[#0D0E10] bg-[#0D0E10] object-contain shadow-lg'
           />
         )}
       </div>
@@ -130,12 +130,9 @@ const SubmissionCard = ({ submission }: SubmissionCardProps) => {
 
           {/* Tags/Categories */}
           <div className='flex flex-wrap gap-2 pt-2'>
-            <span className='text-primary rounded-md bg-[#232B20]/50 px-2.5 py-1 text-[10px] font-bold tracking-wider uppercase'>
-              {category}
-            </span>
-            {submission.category && (
-              <span className='rounded-md bg-white/5 px-2.5 py-1 text-[10px] font-bold tracking-wider text-gray-400 uppercase'>
-                {submission.category}
+            {category && (
+              <span className='text-primary rounded-md bg-[#232B20]/50 px-2.5 py-1 text-[10px] font-bold tracking-wider uppercase'>
+                {category}
               </span>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Use `object-contain` for the logo overlay on top of the banner so wordmark logos do not get cropped (was `object-cover`, which cropped the text in narrow logos).
- Remove the duplicate category badge on the explore submissions card. The same `category` field was being rendered twice, which is why two `OTHER` badges showed up side by side.

## Test plan
- [ ] Open the submissions tab on a hackathon with a wordmark logo upload. The full logo should be visible in the bottom-left overlay, no horizontal clipping.
- [ ] Confirm only one category badge renders per submission card.
- [ ] Cards with no logo + banner combo still fall back to the existing banner-only / logo-only / icon placeholder behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate category badge conditional rendering in submission cards

* **Style**
  * Updated logo image display mode to better fit container when both banner and logo are present

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/boundless/pull/549)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->