### PR TITLE
feat(hackathons): owner submission visibility, team UX, organizer teams page

### DIFF
--- a/app/(landing)/hackathons/[slug]/components/tabs/contents/FindTeam.tsx
+++ b/app/(landing)/hackathons/[slug]/components/tabs/contents/FindTeam.tsx
@@ -88,7 +88,9 @@ const FindTeam = () => {
     !!hackathon?.id && hackathon.participantType !== 'INDIVIDUAL'
   );
 
-  const teams = teamsResponse?.data?.teams || [];
+  const teams = (teamsResponse?.data?.teams || []).filter(
+    t => !myTeam || t.id !== myTeam.id
+  );
 
   const handleJoin = (team: Team) => {
     setSelectedTeam(team);
@@ -98,14 +100,6 @@ const FindTeam = () => {
   if (!hackathon) return null;
 
   const isIndividualOnly = hackathon.participantType === 'INDIVIDUAL';
-
-  if (myTeam) {
-    return (
-      <TabsContent value='team-formation' className='mt-0 w-full outline-none'>
-        <MyTeamView team={myTeam} hackathonSlug={slug} />
-      </TabsContent>
-    );
-  }
 
   return (
     <TabsContent
@@ -129,9 +123,18 @@ const FindTeam = () => {
         </div>
       ) : (
         <>
+          {myTeam && (
+            <div className='space-y-4'>
+              <MyTeamView team={myTeam} hackathonSlug={slug} />
+              <div className='h-px w-full bg-white/5' />
+            </div>
+          )}
+
           <div className='flex items-center justify-between'>
             <div>
-              <h2 className='text-2xl font-bold text-white'>Open Teams</h2>
+              <h2 className='text-2xl font-bold text-white'>
+                {myTeam ? 'Other Teams' : 'Open Teams'}
+              </h2>
               <p className='mt-1 text-sm text-gray-500'>
                 Find builders to collaborate with on your project.
               </p>

--- a/app/(landing)/hackathons/[slug]/components/tabs/contents/submissions/SubmissionCard.tsx
+++ b/app/(landing)/hackathons/[slug]/components/tabs/contents/submissions/SubmissionCard.tsx
@@ -94,7 +94,7 @@ const SubmissionCard = ({ submission }: SubmissionCardProps) => {
           <img
             src={banner}
             alt={`${projectName} banner`}
-            className='h-full w-full object-cover transition-transform duration-300 group-hover:scale-105'
+            className='h-full w-full object-contain transition-transform duration-300 group-hover:scale-105'
           />
         ) : logo ? (
           // eslint-disable-next-line @next/next/no-img-element

--- a/app/(landing)/hackathons/[slug]/components/tabs/contents/teams/MyTeamView.tsx
+++ b/app/(landing)/hackathons/[slug]/components/tabs/contents/teams/MyTeamView.tsx
@@ -186,7 +186,14 @@ const MyTeamView = ({ team, hackathonSlug }: MyTeamViewProps) => {
           </div>
           <div>
             <h2 className='text-xl font-bold text-white sm:text-2xl'>
-              {team.teamName}
+              <a
+                href={`/hackathons/${hackathonSlug}/teams/${team.id}`}
+                target='_blank'
+                rel='noopener noreferrer'
+                className='hover:text-primary transition-colors'
+              >
+                {team.teamName}
+              </a>
             </h2>
             <div className='mt-1 flex flex-wrap items-center gap-2 sm:gap-3'>
               <span className='text-primary text-sm font-bold'>

--- a/app/(landing)/hackathons/[slug]/components/tabs/contents/teams/TeamCard.tsx
+++ b/app/(landing)/hackathons/[slug]/components/tabs/contents/teams/TeamCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import React, { useCallback } from 'react';
+import { useParams } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { Team, TeamMember } from '@/lib/api/hackathons/teams';
 import GroupAvatar from '@/components/avatars/GroupAvatar';
@@ -14,6 +15,16 @@ interface TeamCardProps {
 }
 
 const TeamCard = ({ team, onJoin, onMessageLeader }: TeamCardProps) => {
+  const { slug } = useParams<{ slug: string }>();
+
+  const openTeamDetails = useCallback(() => {
+    if (!slug || !team.id) return;
+    window.open(
+      `/hackathons/${slug}/teams/${team.id}`,
+      '_blank',
+      'noopener,noreferrer'
+    );
+  }, [slug, team.id]);
   const {
     teamName,
     description,
@@ -32,7 +43,18 @@ const TeamCard = ({ team, onJoin, onMessageLeader }: TeamCardProps) => {
   };
 
   return (
-    <div className='group hover:border-primary/20 flex h-full flex-col overflow-hidden rounded-2xl border border-white/5 bg-[#0A0B0D] p-8 transition-all hover:bg-[#0D0F12]'>
+    <div
+      role='link'
+      tabIndex={0}
+      onClick={openTeamDetails}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          openTeamDetails();
+        }
+      }}
+      className='group hover:border-primary/20 flex h-full cursor-pointer flex-col overflow-hidden rounded-2xl border border-white/5 bg-[#0A0B0D] p-8 transition-all hover:bg-[#0D0F12]'
+    >
       <div className='mb-6 flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between'>
         <div className='flex items-start gap-4'>
           <div className='text-primary flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-[#232B20] text-xl font-black'>
@@ -70,7 +92,10 @@ const TeamCard = ({ team, onJoin, onMessageLeader }: TeamCardProps) => {
                 variant='outline'
                 size='sm'
                 className='h-11 shrink-0 rounded-xl border-white/10 bg-white/5 px-4 text-sm font-bold text-white transition-all hover:bg-white/10'
-                onClick={e => onMessageLeader(team, e.currentTarget)}
+                onClick={e => {
+                  e.stopPropagation();
+                  onMessageLeader(team, e.currentTarget);
+                }}
                 aria-label='Message team leader'
               >
                 <MessageCircle className='mr-2 h-4 w-4' />
@@ -81,7 +106,10 @@ const TeamCard = ({ team, onJoin, onMessageLeader }: TeamCardProps) => {
               variant='outline'
               size='sm'
               className='border-primary/20 text-primary hover:bg-primary h-11 w-full rounded-xl bg-[#232B20]/30 px-6 text-sm font-bold transition-all hover:text-black sm:w-auto'
-              onClick={() => onJoin?.(team)}
+              onClick={e => {
+                e.stopPropagation();
+                onJoin?.(team);
+              }}
               disabled={memberCount >= maxSize}
             >
               Join Team

--- a/app/(landing)/hackathons/[slug]/components/tabs/index.tsx
+++ b/app/(landing)/hackathons/[slug]/components/tabs/index.tsx
@@ -14,7 +14,10 @@ import FindTeam from './contents/FindTeam';
 import SponsorsTab from './contents/SponsorsTab';
 import { useEffect, useState, useMemo } from 'react';
 import { useHackathonData } from '@/lib/providers/hackathonProvider';
-import { useHackathonAnnouncements } from '@/hooks/hackathon/use-hackathon-queries';
+import {
+  useHackathonAnnouncements,
+  useHackathonTeams,
+} from '@/hooks/hackathon/use-hackathon-queries';
 import { useCommentSystem } from '@/hooks/use-comment-system';
 import { CommentEntityType } from '@/types/comment';
 import { Megaphone } from 'lucide-react';
@@ -46,6 +49,17 @@ const HackathonTabs = ({ sidebar }: HackathonTabsProps) => {
     enabled: !!currentHackathon?.id,
   });
 
+  const participantType = currentHackathon?.participantType;
+  const isTeamHackathon =
+    participantType === 'TEAM' || participantType === 'TEAM_OR_INDIVIDUAL';
+
+  const { data: teamsCountResponse } = useHackathonTeams(
+    slug,
+    { page: 1, limit: 1 },
+    !!slug && isTeamHackathon
+  );
+  const teamsTotal = teamsCountResponse?.data?.pagination?.total ?? 0;
+
   const [activeTab, setActiveTab] = useState('overview');
 
   const hackathonTabs = useMemo(() => {
@@ -54,10 +68,6 @@ const HackathonTabs = ({ sidebar }: HackathonTabsProps) => {
     const hasResources = currentHackathon.resources?.length > 0;
     const hasWinners = !!(winners && winners.length > 0);
     const hasAnnouncements = announcements.length > 0;
-
-    const participantType = currentHackathon.participantType;
-    const isTeamHackathon =
-      participantType === 'TEAM' || participantType === 'TEAM_OR_INDIVIDUAL';
 
     const tabs = [
       { id: 'overview', label: 'Overview' },
@@ -105,6 +115,7 @@ const HackathonTabs = ({ sidebar }: HackathonTabsProps) => {
       tabs.push({
         id: 'team-formation',
         label: 'Find Team',
+        badge: teamsTotal,
       });
     }
 
@@ -159,6 +170,8 @@ const HackathonTabs = ({ sidebar }: HackathonTabsProps) => {
     announcements,
     announcementsLoading,
     generalLoading,
+    isTeamHackathon,
+    teamsTotal,
   ]);
 
   useEffect(() => {

--- a/app/(landing)/hackathons/[slug]/teams/[teamId]/page.tsx
+++ b/app/(landing)/hackathons/[slug]/teams/[teamId]/page.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import { use } from 'react';
+import Link from 'next/link';
+import { useHackathon, useTeam } from '@/hooks/hackathon/use-hackathon-queries';
+import { Button } from '@/components/ui/button';
+import BasicAvatar from '@/components/avatars/BasicAvatar';
+import {
+  ArrowLeft,
+  Calendar,
+  Crown,
+  Loader2,
+  Mail,
+  Users,
+  XCircle,
+} from 'lucide-react';
+
+export default function TeamDetailsPage({
+  params,
+}: {
+  params: Promise<{ slug: string; teamId: string }>;
+}) {
+  const { slug, teamId } = use(params);
+
+  const { data: hackathon } = useHackathon(slug);
+  const { data: team, isLoading, isError } = useTeam(slug, teamId);
+
+  const formattedCreatedAt = team?.createdAt
+    ? new Date(team.createdAt).toLocaleDateString('en-US', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+      })
+    : '';
+
+  const status = team?.isOpen ? 'OPEN' : 'CLOSED';
+
+  return (
+    <div className='min-h-screen bg-black px-5 py-5 text-white md:px-[50px] lg:px-[100px]'>
+      <div className='mx-auto max-w-[1100px] pb-16'>
+        <Link href={`/hackathons/${slug}?tab=team-formation`}>
+          <Button
+            variant='ghost'
+            className='mb-6 pl-0 text-gray-400 hover:text-white'
+          >
+            <ArrowLeft className='mr-2 h-4 w-4' />
+            Back to {hackathon?.name ?? 'Hackathon'}
+          </Button>
+        </Link>
+
+        {isLoading ? (
+          <div className='flex min-h-[400px] flex-col items-center justify-center gap-4 rounded-3xl border border-white/5 bg-[#0D0E10]'>
+            <Loader2 className='text-primary h-10 w-10 animate-spin' />
+            <p className='text-sm tracking-widest text-gray-500 uppercase'>
+              Loading team...
+            </p>
+          </div>
+        ) : isError || !team ? (
+          <div className='flex min-h-[400px] flex-col items-center justify-center gap-4 rounded-3xl border border-white/5 bg-[#0D0E10] text-center'>
+            <XCircle className='h-10 w-10 text-gray-600' />
+            <div className='space-y-1'>
+              <h2 className='text-2xl font-bold text-white'>Team not found</h2>
+              <p className='text-sm text-gray-500'>
+                This team may have been disbanded or never existed.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className='space-y-6'>
+            <div className='rounded-2xl border border-white/5 bg-[#0A0B0D] p-8'>
+              <div className='flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between'>
+                <div className='flex items-start gap-4'>
+                  <div className='text-primary flex h-16 w-16 shrink-0 items-center justify-center rounded-xl bg-[#232B20] text-2xl font-black'>
+                    {team.teamName.charAt(0).toUpperCase()}
+                  </div>
+                  <div>
+                    <h1 className='text-3xl font-bold text-white uppercase'>
+                      {team.teamName}
+                    </h1>
+                    <div className='mt-3 flex flex-wrap items-center gap-2'>
+                      <span
+                        className={
+                          team.isOpen
+                            ? 'rounded border border-[#2A3347] bg-[#1E232F]/50 px-2 py-0.5 text-[10px] font-bold tracking-wider text-[#5470B8] uppercase'
+                            : 'rounded border border-white/10 bg-white/5 px-2 py-0.5 text-[10px] font-bold tracking-wider text-gray-500 uppercase'
+                        }
+                      >
+                        {status}
+                      </span>
+                      <span className='inline-flex items-center gap-1 text-[10px] font-bold text-gray-500 uppercase'>
+                        <Users className='h-3 w-3' />
+                        {team.memberCount}/{team.maxSize} builders
+                      </span>
+                      {formattedCreatedAt && (
+                        <span className='inline-flex items-center gap-1 text-[10px] font-bold text-gray-500 uppercase'>
+                          <Calendar className='h-3 w-3' />
+                          Created {formattedCreatedAt}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {team.description && (
+                <p className='mt-6 text-base leading-relaxed text-gray-300'>
+                  {team.description}
+                </p>
+              )}
+            </div>
+
+            <div className='grid gap-6 lg:grid-cols-3'>
+              <div className='space-y-6 lg:col-span-2'>
+                <div className='rounded-2xl border border-white/5 bg-[#0A0B0D] p-6'>
+                  <h2 className='mb-4 text-[10px] font-black tracking-[0.2em] text-[#555555] uppercase'>
+                    Members
+                  </h2>
+                  <div className='space-y-3'>
+                    {team.members && team.members.length > 0 ? (
+                      team.members.map(member => {
+                        const isLeader = member.userId === team.leader?.id;
+                        const profileHref = member.username
+                          ? `/profile/${member.username}`
+                          : null;
+                        const content = (
+                          <>
+                            <div className='flex items-center gap-3'>
+                              <BasicAvatar
+                                image={member.image ?? ''}
+                                name={member.name}
+                                username={member.username ?? member.userId}
+                                truncate={false}
+                              />
+                              {isLeader && (
+                                <span className='inline-flex items-center gap-1 rounded border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-bold tracking-wider text-amber-400 uppercase'>
+                                  <Crown className='h-3 w-3' />
+                                  Leader
+                                </span>
+                              )}
+                            </div>
+                            {!isLeader && (
+                              <span className='text-[10px] font-bold tracking-wider text-gray-500 uppercase'>
+                                {member.role}
+                              </span>
+                            )}
+                          </>
+                        );
+                        return profileHref ? (
+                          <a
+                            key={member.userId}
+                            href={profileHref}
+                            target='_blank'
+                            rel='noopener noreferrer'
+                            className='flex items-center justify-between rounded-xl border border-white/5 bg-[#0D0F12] p-4 transition-colors hover:border-white/10 hover:bg-white/5'
+                          >
+                            {content}
+                          </a>
+                        ) : (
+                          <div
+                            key={member.userId}
+                            className='flex items-center justify-between rounded-xl border border-white/5 bg-[#0D0F12] p-4'
+                          >
+                            {content}
+                          </div>
+                        );
+                      })
+                    ) : (
+                      <p className='text-sm text-gray-500'>
+                        No members listed.
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                {team.lookingFor && team.lookingFor.length > 0 && (
+                  <div className='rounded-2xl border border-white/5 bg-[#0A0B0D] p-6'>
+                    <h2 className='mb-4 text-[10px] font-black tracking-[0.2em] text-[#555555] uppercase'>
+                      Roles Needed
+                    </h2>
+                    <div className='flex flex-wrap gap-2'>
+                      {team.lookingFor.map((role, idx) => (
+                        <div
+                          key={idx}
+                          className='rounded-xl border border-[#232B35] bg-[#14191F] px-4 py-2 text-sm font-bold text-[#E0E0E0]'
+                        >
+                          {role.role}
+                          {role.skills && role.skills.length > 0 && (
+                            <span className='ml-2 text-xs font-normal text-gray-500'>
+                              {role.skills.join(', ')}
+                            </span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className='space-y-6'>
+                {team.leader && (
+                  <div className='rounded-2xl border border-white/5 bg-[#0A0B0D] p-6'>
+                    <h2 className='mb-4 text-[10px] font-black tracking-[0.2em] text-[#555555] uppercase'>
+                      Team Leader
+                    </h2>
+                    {team.leader.username ? (
+                      <a
+                        href={`/profile/${team.leader.username}`}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                        className='-m-2 flex items-center gap-3 rounded-xl p-2 transition-colors hover:bg-white/5'
+                      >
+                        <BasicAvatar
+                          image={team.leader.image ?? ''}
+                          name={team.leader.name}
+                          username={team.leader.username}
+                          truncate={false}
+                        />
+                      </a>
+                    ) : (
+                      <BasicAvatar
+                        image={team.leader.image ?? ''}
+                        name={team.leader.name}
+                        username={team.leader.id}
+                        truncate={false}
+                      />
+                    )}
+                  </div>
+                )}
+
+                {team.contactInfo && (
+                  <div className='rounded-2xl border border-white/5 bg-[#0A0B0D] p-6'>
+                    <h2 className='mb-4 text-[10px] font-black tracking-[0.2em] text-[#555555] uppercase'>
+                      Contact
+                    </h2>
+                    <div className='flex items-start gap-3 text-sm text-gray-300'>
+                      <Mail className='mt-0.5 h-4 w-4 shrink-0 text-gray-500' />
+                      <span className='break-all'>{team.contactInfo}</span>
+                    </div>
+                    {team.contactMethod && (
+                      <p className='mt-2 text-[10px] font-bold tracking-wider text-gray-500 uppercase'>
+                        Via {team.contactMethod}
+                      </p>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(landing)/organizations/[id]/hackathons/[hackathonId]/participants/page.tsx
+++ b/app/(landing)/organizations/[id]/hackathons/[hackathonId]/participants/page.tsx
@@ -128,6 +128,10 @@ const ParticipantsPage: React.FC = () => {
   const [statistics, setStatistics] = useState<{
     participantsCount: number;
     submissionsCount: number;
+    soloParticipants: number;
+    totalTeams: number;
+    soloSubmissions: number;
+    teamSubmissions: number;
   } | null>(null);
   const [statisticsLoading, setStatisticsLoading] = useState(false);
 
@@ -143,10 +147,18 @@ const ParticipantsPage: React.FC = () => {
           const stats = response.data as {
             totalSubmissions?: number;
             activeParticipants?: number;
+            soloParticipants?: number;
+            totalTeams?: number;
+            soloSubmissions?: number;
+            teamSubmissions?: number;
           };
           setStatistics({
             participantsCount: stats.activeParticipants ?? 0,
             submissionsCount: stats.totalSubmissions ?? 0,
+            soloParticipants: stats.soloParticipants ?? 0,
+            totalTeams: stats.totalTeams ?? 0,
+            soloSubmissions: stats.soloSubmissions ?? 0,
+            teamSubmissions: stats.teamSubmissions ?? 0,
           });
         } catch (err) {
           reportError(err, {
@@ -277,7 +289,7 @@ const ParticipantsPage: React.FC = () => {
     <AuthGuard redirectTo='/auth?mode=signin' fallback={<Loading />}>
       <div className='bg-background min-h-screen space-y-6 p-8 text-white'>
         <div className='flex flex-col gap-6'>
-          <div className='flex gap-4'>
+          <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-4'>
             <MetricsCard
               title='Total Participants'
               value={statistics?.participantsCount ?? 0}
@@ -287,6 +299,24 @@ const ParticipantsPage: React.FC = () => {
                   : `${statistics?.participantsCount ?? 0} registered`
               }
               showTrend={true}
+            />
+            <MetricsCard
+              title='Solo Participants'
+              value={statistics?.soloParticipants ?? 0}
+              subtitle={
+                statisticsLoading
+                  ? 'Loading...'
+                  : `${statistics?.soloParticipants ?? 0} not on a team`
+              }
+            />
+            <MetricsCard
+              title='Teams'
+              value={statistics?.totalTeams ?? 0}
+              subtitle={
+                statisticsLoading
+                  ? 'Loading...'
+                  : `${statistics?.totalTeams ?? 0} formed`
+              }
             />
             <MetricsCard
               title='Total Submissions'

--- a/app/(landing)/organizations/[id]/hackathons/[hackathonId]/submissions/page.tsx
+++ b/app/(landing)/organizations/[id]/hackathons/[hackathonId]/submissions/page.tsx
@@ -11,9 +11,11 @@ import { SubmissionsManagement } from '@/components/organization/hackathons/subm
 import { authClient } from '@/lib/auth-client';
 import {
   getHackathon,
+  getHackathonStatistics,
   type Hackathon,
   type ParticipantSubmission,
 } from '@/lib/api/hackathons';
+import MetricsCard from '@/components/organization/cards/MetricsCard';
 import { reportError } from '@/lib/error-reporting';
 import { useReactTable, getCoreRowModel } from '@tanstack/react-table';
 import { DataTablePagination } from '@/components/ui/data-table-pagination';
@@ -38,6 +40,12 @@ export default function SubmissionsPage() {
 
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [hackathon, setHackathon] = useState<Hackathon | null>(null);
+  const [submissionStats, setSubmissionStats] = useState<{
+    soloSubmissions: number;
+    teamSubmissions: number;
+    totalSubmissions: number;
+  } | null>(null);
+  const [submissionStatsLoading, setSubmissionStatsLoading] = useState(false);
 
   useEffect(() => {
     if (hackathonId) {
@@ -57,6 +65,35 @@ export default function SubmissionsPage() {
       fetchHackathonDetails();
     }
   }, [hackathonId]);
+
+  useEffect(() => {
+    if (!organizationId || !hackathonId) return;
+    const loadStats = async () => {
+      setSubmissionStatsLoading(true);
+      try {
+        const res = await getHackathonStatistics(organizationId, hackathonId);
+        const stats = res.data as {
+          totalSubmissions?: number;
+          soloSubmissions?: number;
+          teamSubmissions?: number;
+        };
+        setSubmissionStats({
+          totalSubmissions: stats.totalSubmissions ?? 0,
+          soloSubmissions: stats.soloSubmissions ?? 0,
+          teamSubmissions: stats.teamSubmissions ?? 0,
+        });
+      } catch (err) {
+        reportError(err, {
+          context: 'org-submissions-fetchStats',
+          organizationId,
+          hackathonId,
+        });
+      } finally {
+        setSubmissionStatsLoading(false);
+      }
+    };
+    loadStats();
+  }, [organizationId, hackathonId]);
 
   useEffect(() => {
     const fetchSession = async () => {
@@ -142,6 +179,36 @@ export default function SubmissionsPage() {
             </div>
           ) : (
             <div className='space-y-6'>
+              <div className='grid gap-4 sm:grid-cols-3'>
+                <MetricsCard
+                  title='Total Submissions'
+                  value={submissionStats?.totalSubmissions ?? 0}
+                  subtitle={
+                    submissionStatsLoading
+                      ? 'Loading...'
+                      : `${submissionStats?.totalSubmissions ?? 0} received`
+                  }
+                />
+                <MetricsCard
+                  title='Solo Submissions'
+                  value={submissionStats?.soloSubmissions ?? 0}
+                  subtitle={
+                    submissionStatsLoading
+                      ? 'Loading...'
+                      : `${submissionStats?.soloSubmissions ?? 0} individual`
+                  }
+                />
+                <MetricsCard
+                  title='Team Submissions'
+                  value={submissionStats?.teamSubmissions ?? 0}
+                  subtitle={
+                    submissionStatsLoading
+                      ? 'Loading...'
+                      : `${submissionStats?.teamSubmissions ?? 0} from teams`
+                  }
+                />
+              </div>
+
               <SubmissionsManagement
                 submissions={allSubmissions}
                 pagination={pagination}

--- a/app/(landing)/organizations/[id]/hackathons/[hackathonId]/teams/page.tsx
+++ b/app/(landing)/organizations/[id]/hackathons/[hackathonId]/teams/page.tsx
@@ -1,0 +1,370 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import {
+  Search,
+  Users,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  Crown,
+} from 'lucide-react';
+import { useReactTable, getCoreRowModel } from '@tanstack/react-table';
+import { AuthGuard } from '@/components/auth';
+import Loading from '@/components/Loading';
+import MetricsCard from '@/components/organization/cards/MetricsCard';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { DataTablePagination } from '@/components/ui/data-table-pagination';
+import { getTeams } from '@/lib/api/hackathons/teams';
+import type { Team } from '@/lib/api/hackathons/teams';
+import { getHackathon } from '@/lib/api/hackathons';
+import { reportError } from '@/lib/error-reporting';
+import BasicAvatar from '@/components/avatars/BasicAvatar';
+
+type StatusFilter = 'all' | 'open' | 'closed';
+type SubmissionFilter = 'all' | 'submitted' | 'not_submitted';
+
+const DEFAULT_PAGE_SIZE = 10;
+const MAX_PAGE_SIZE = 50;
+
+export default function OrganizerTeamsPage() {
+  const params = useParams();
+  const organizationId = params?.id as string;
+  const hackathonId = params?.hackathonId as string;
+
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [hackathonSlug, setHackathonSlug] = useState<string>('');
+  const [loading, setLoading] = useState(false);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [submissionFilter, setSubmissionFilter] =
+    useState<SubmissionFilter>('all');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [totalPages, setTotalPages] = useState(0);
+  const [totalTeams, setTotalTeams] = useState(0);
+
+  useEffect(() => {
+    if (!hackathonId) return;
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const limit = Math.min(pageSize, MAX_PAGE_SIZE);
+        const teamsRes = await getTeams(hackathonId, {
+          page,
+          limit,
+          search: search.trim() || undefined,
+          openOnly: false,
+        });
+        if (cancelled) return;
+        setTeams(teamsRes?.data?.teams ?? []);
+        setTotalPages(teamsRes?.data?.pagination?.totalPages ?? 0);
+        setTotalTeams(teamsRes?.data?.pagination?.total ?? 0);
+      } catch (err) {
+        reportError(err, {
+          context: 'organizer-teams-load',
+          organizationId,
+          hackathonId,
+        });
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [hackathonId, organizationId, page, pageSize, search]);
+
+  useEffect(() => {
+    if (!hackathonId) return;
+    let cancelled = false;
+    const loadHackathon = async () => {
+      try {
+        const hackRes = await getHackathon(hackathonId);
+        if (!cancelled) {
+          setHackathonSlug(hackRes?.data?.slug ?? hackathonId);
+        }
+      } catch (err) {
+        reportError(err, {
+          context: 'organizer-teams-load-hackathon',
+          organizationId,
+          hackathonId,
+        });
+        if (!cancelled) setHackathonSlug(hackathonId);
+      }
+    };
+    loadHackathon();
+    return () => {
+      cancelled = true;
+    };
+  }, [hackathonId, organizationId]);
+
+  const filteredTeams = useMemo(() => {
+    return teams.filter(team => {
+      if (statusFilter === 'open' && !team.isOpen) return false;
+      if (statusFilter === 'closed' && team.isOpen) return false;
+      if (submissionFilter === 'submitted' && !team.hasSubmission) return false;
+      if (submissionFilter === 'not_submitted' && team.hasSubmission)
+        return false;
+      return true;
+    });
+  }, [teams, statusFilter, submissionFilter]);
+
+  const table = useReactTable({
+    data: teams,
+    columns: [],
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+    pageCount: totalPages,
+    state: {
+      pagination: {
+        pageIndex: page - 1,
+        pageSize,
+      },
+    },
+    onPaginationChange: updater => {
+      if (typeof updater === 'function') {
+        const next = updater({ pageIndex: page - 1, pageSize });
+        if (next.pageSize !== pageSize) {
+          setPageSize(Math.min(next.pageSize, MAX_PAGE_SIZE));
+          setPage(1);
+        } else {
+          setPage(next.pageIndex + 1);
+        }
+      }
+    },
+  });
+
+  const stats = useMemo(() => {
+    const submittedOnPage = teams.filter(t => t.hasSubmission).length;
+    const openOnPage = teams.filter(t => t.isOpen).length;
+    return {
+      total: totalTeams,
+      open: openOnPage,
+      submitted: submittedOnPage,
+      notSubmitted: teams.length - submittedOnPage,
+    };
+  }, [teams, totalTeams]);
+
+  return (
+    <AuthGuard redirectTo='/auth?mode=signin' fallback={<Loading />}>
+      <div className='min-h-screen bg-black'>
+        <div className='border-b border-gray-900 p-4'>
+          <div className='mx-auto max-w-7xl'>
+            <h1 className='text-3xl font-light tracking-tight text-white sm:text-4xl'>
+              Teams
+            </h1>
+            <p className='mt-2 text-sm text-gray-400'>
+              All teams formed for this hackathon and whether they have
+              submitted.
+            </p>
+          </div>
+        </div>
+
+        <div className='mx-auto max-w-7xl space-y-6 px-6 py-12 sm:px-8 lg:px-12'>
+          <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-4'>
+            <MetricsCard
+              title='Total Teams'
+              value={stats.total}
+              subtitle={loading ? 'Loading...' : `${stats.total} formed`}
+            />
+            <MetricsCard
+              title='Open Teams'
+              value={stats.open}
+              subtitle={
+                loading ? 'Loading...' : `${stats.open} recruiting members`
+              }
+            />
+            <MetricsCard
+              title='Submitted'
+              value={stats.submitted}
+              subtitle={
+                loading ? 'Loading...' : `${stats.submitted} have a submission`
+              }
+            />
+            <MetricsCard
+              title='Not Submitted'
+              value={stats.notSubmitted}
+              subtitle={
+                loading ? 'Loading...' : `${stats.notSubmitted} pending`
+              }
+            />
+          </div>
+
+          <div className='flex flex-col gap-3 rounded-xl border border-gray-800/50 bg-gray-900/20 p-4 backdrop-blur-sm md:flex-row md:items-center md:justify-between'>
+            <div className='relative flex-1 md:max-w-md'>
+              <Search className='pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400' />
+              <Input
+                type='text'
+                placeholder='Search by team or leader...'
+                value={search}
+                onChange={e => {
+                  setSearch(e.target.value);
+                  setPage(1);
+                }}
+                className='focus:border-primary focus:ring-primary border-gray-700/50 bg-gray-900/50 pl-10 text-white placeholder:text-gray-500'
+              />
+            </div>
+            <div className='flex flex-wrap items-center gap-2'>
+              <Select
+                value={statusFilter}
+                onValueChange={value => setStatusFilter(value as StatusFilter)}
+              >
+                <SelectTrigger className='w-[160px] border-gray-700/50 bg-gray-900/50 text-white'>
+                  <SelectValue placeholder='Status' />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value='all'>All statuses</SelectItem>
+                  <SelectItem value='open'>Open</SelectItem>
+                  <SelectItem value='closed'>Closed</SelectItem>
+                </SelectContent>
+              </Select>
+              <Select
+                value={submissionFilter}
+                onValueChange={value =>
+                  setSubmissionFilter(value as SubmissionFilter)
+                }
+              >
+                <SelectTrigger className='w-[180px] border-gray-700/50 bg-gray-900/50 text-white'>
+                  <SelectValue placeholder='Submission' />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value='all'>All submission states</SelectItem>
+                  <SelectItem value='submitted'>Submitted</SelectItem>
+                  <SelectItem value='not_submitted'>Not submitted</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {loading ? (
+            <div className='flex min-h-[400px] items-center justify-center'>
+              <div className='flex flex-col items-center gap-3'>
+                <Loader2 className='h-6 w-6 animate-spin text-gray-400' />
+                <p className='text-sm text-gray-500'>Loading teams...</p>
+              </div>
+            </div>
+          ) : filteredTeams.length === 0 ? (
+            <div className='flex flex-col items-center justify-center gap-3 rounded-xl border border-gray-800/50 bg-gray-900/20 py-16 text-center'>
+              <Users className='h-10 w-10 text-gray-700' />
+              <p className='text-base font-medium text-gray-400'>
+                {teams.length === 0
+                  ? 'No teams yet for this hackathon.'
+                  : 'No teams match the current filters.'}
+              </p>
+            </div>
+          ) : (
+            <div className='overflow-hidden rounded-xl border border-gray-800/50 bg-gray-900/20'>
+              <div className='hidden grid-cols-12 gap-4 border-b border-gray-800/50 px-4 py-3 text-[11px] font-bold tracking-wider text-gray-500 uppercase md:grid'>
+                <div className='col-span-4'>Team</div>
+                <div className='col-span-3'>Leader</div>
+                <div className='col-span-2'>Members</div>
+                <div className='col-span-2'>Submission</div>
+                <div className='col-span-1 text-right'>Status</div>
+              </div>
+              <ul>
+                {filteredTeams.map(team => {
+                  const href = `/hackathons/${hackathonSlug}/teams/${team.id}`;
+                  return (
+                    <li
+                      key={team.id}
+                      className='border-b border-gray-800/30 last:border-b-0'
+                    >
+                      <Link
+                        href={href}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                        className='grid grid-cols-12 items-center gap-4 px-4 py-4 transition-colors hover:bg-white/5'
+                      >
+                        <div className='col-span-12 md:col-span-4'>
+                          <div className='flex items-center gap-3'>
+                            <div className='text-primary flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[#232B20] text-sm font-black'>
+                              {team.teamName?.charAt(0).toUpperCase()}
+                            </div>
+                            <div className='min-w-0'>
+                              <p className='truncate font-medium text-white'>
+                                {team.teamName}
+                              </p>
+                              <p className='truncate text-xs text-gray-500'>
+                                Created{' '}
+                                {new Date(team.createdAt).toLocaleDateString()}
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                        <div className='col-span-12 md:col-span-3'>
+                          {team.leader ? (
+                            <div className='flex items-center gap-2'>
+                              <BasicAvatar
+                                image={team.leader.image ?? ''}
+                                name={team.leader.name}
+                                username={
+                                  team.leader.username ?? team.leader.id
+                                }
+                                truncate={false}
+                              />
+                              <Crown className='h-3 w-3 text-amber-400' />
+                            </div>
+                          ) : (
+                            <span className='text-sm text-gray-500'>
+                              No leader
+                            </span>
+                          )}
+                        </div>
+                        <div className='col-span-6 md:col-span-2'>
+                          <span className='inline-flex items-center gap-1 text-sm text-gray-300'>
+                            <Users className='h-3.5 w-3.5 text-gray-500' />
+                            {team.memberCount}/{team.maxSize}
+                          </span>
+                        </div>
+                        <div className='col-span-6 md:col-span-2'>
+                          {team.hasSubmission ? (
+                            <span className='inline-flex items-center gap-1.5 rounded-full border border-green-500/20 bg-green-500/10 px-2.5 py-0.5 text-[11px] font-bold tracking-wider text-green-400 uppercase'>
+                              <CheckCircle2 className='h-3 w-3' />
+                              Submitted
+                            </span>
+                          ) : (
+                            <span className='inline-flex items-center gap-1.5 rounded-full border border-gray-700 bg-gray-800/50 px-2.5 py-0.5 text-[11px] font-bold tracking-wider text-gray-400 uppercase'>
+                              <XCircle className='h-3 w-3' />
+                              Pending
+                            </span>
+                          )}
+                        </div>
+                        <div className='col-span-12 text-left md:col-span-1 md:text-right'>
+                          <span
+                            className={
+                              team.isOpen
+                                ? 'inline-flex rounded border border-[#2A3347] bg-[#1E232F]/50 px-2 py-0.5 text-[10px] font-bold tracking-wider text-[#5470B8] uppercase'
+                                : 'inline-flex rounded border border-white/10 bg-white/5 px-2 py-0.5 text-[10px] font-bold tracking-wider text-gray-500 uppercase'
+                            }
+                          >
+                            {team.isOpen ? 'Open' : 'Closed'}
+                          </span>
+                        </div>
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+
+          <div className='flex justify-end'>
+            <DataTablePagination table={table} loading={loading} />
+          </div>
+        </div>
+      </div>
+    </AuthGuard>
+  );
+}

--- a/app/me/hackathons/submissions/submission-components.tsx
+++ b/app/me/hackathons/submissions/submission-components.tsx
@@ -227,7 +227,7 @@ export function SubmissionsSheetContent({
             src={submission.hackathon?.banner || submission.logo!}
             alt={submission.projectName}
             fill
-            className='object-cover opacity-80'
+            className='object-contain opacity-80'
           />
           {submission.logo && submission.hackathon?.banner && (
             <div className='absolute bottom-3 left-4'>
@@ -236,7 +236,7 @@ export function SubmissionsSheetContent({
                   src={submission.logo}
                   alt='Project logo'
                   fill
-                  className='object-cover'
+                  className='object-contain'
                 />
               </div>
             </div>
@@ -450,7 +450,7 @@ export function TableRow({
                 src={submission.logo}
                 alt={submission.projectName}
                 fill
-                className='object-cover'
+                className='object-contain'
               />
             </div>
           ) : (

--- a/components/organization/hackathons/details/HackathonSidebar.tsx
+++ b/components/organization/hackathons/details/HackathonSidebar.tsx
@@ -3,6 +3,7 @@ import {
   Settings,
   LayoutDashboard,
   Users,
+  UsersRound,
   BarChartBig,
   Megaphone,
   FileText,
@@ -319,6 +320,16 @@ export default function HackathonSidebar({
             ? `${basePath}/submissions`
             : '#',
         description: 'View all submissions',
+        disabled: hackathonId?.startsWith('draft-'),
+      },
+      {
+        icon: UsersRound,
+        label: 'Teams',
+        href:
+          basePath !== '#' && !hackathonId?.startsWith('draft-')
+            ? `${basePath}/teams`
+            : '#',
+        description: 'View all teams',
         disabled: hackathonId?.startsWith('draft-'),
       },
       {

--- a/components/organization/hackathons/submissions/SubmissionsList.tsx
+++ b/components/organization/hackathons/submissions/SubmissionsList.tsx
@@ -16,6 +16,7 @@ import { reportError } from '@/lib/error-reporting';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { BoundlessButton } from '@/components/buttons/BoundlessButton';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import {
@@ -157,10 +158,6 @@ export function SubmissionsList({
     router.push(`/projects/${submissionId}?type=submission`);
   };
 
-  const isBeforeDeadline = hackathon?.submissionDeadline
-    ? new Date() < new Date(hackathon.submissionDeadline)
-    : false;
-
   if (submissions.length === 0 && !loading) {
     return (
       <div className='flex flex-col items-center justify-center rounded-xl border border-gray-800/50 bg-gray-900/20 py-20 text-center'>
@@ -287,49 +284,45 @@ export function SubmissionsList({
                         onClick={e => e.stopPropagation()}
                       >
                         {subData.status === 'SUBMITTED' ? (
-                          <Button
+                          <BoundlessButton
                             size='sm'
+                            variant='default'
                             onClick={e =>
                               handleReview(e, subData.id, 'SHORTLISTED')
                             }
-                            disabled={
-                              reviewingId === subData.id || isBeforeDeadline
-                            }
-                            className='flex-1 bg-green-600 text-white hover:bg-green-700'
+                            disabled={reviewingId === subData.id}
+                            className='flex-1'
                           >
                             <CheckCircle className='mr-1.5 h-3.5 w-3.5' />
                             {reviewingId === subData.id
                               ? 'Approving...'
-                              : isBeforeDeadline
-                                ? 'Before Deadline'
-                                : 'Approve'}
-                          </Button>
+                              : 'Approve'}
+                          </BoundlessButton>
                         ) : (
-                          <Button
+                          <BoundlessButton
                             size='sm'
                             variant='outline'
                             onClick={e =>
                               handleReview(e, subData.id, 'SUBMITTED')
                             }
                             disabled={reviewingId === subData.id}
-                            className='flex-1 border-yellow-600/50 text-yellow-500 hover:bg-yellow-600/10'
+                            className='flex-1'
                           >
                             <RotateCcw className='mr-1.5 h-3.5 w-3.5' />
                             {reviewingId === subData.id
                               ? 'Moving...'
                               : 'Move to Submitted'}
-                          </Button>
+                          </BoundlessButton>
                         )}
                         {onDisqualify && (
-                          <Button
+                          <BoundlessButton
                             size='sm'
-                            variant='outline'
+                            variant='destructive'
                             onClick={e => handleDisqualifyClick(e, subData.id)}
-                            className='border-red-600/50 text-red-500 hover:bg-red-600/10'
                           >
                             <Ban className='mr-1.5 h-3.5 w-3.5' />
                             Disqualify
-                          </Button>
+                          </BoundlessButton>
                         )}
                       </div>
                     )}
@@ -506,18 +499,13 @@ export function SubmissionsList({
                                   onClick={e =>
                                     handleReview(e, subData.id, 'SHORTLISTED')
                                   }
-                                  disabled={
-                                    reviewingId === subData.id ||
-                                    isBeforeDeadline
-                                  }
-                                  className={`cursor-pointer text-green-500 focus:bg-green-900/20 focus:text-green-400 ${isBeforeDeadline ? 'cursor-not-allowed opacity-50' : ''}`}
+                                  disabled={reviewingId === subData.id}
+                                  className='text-primary focus:bg-primary/10 focus:text-primary cursor-pointer'
                                 >
                                   <CheckCircle className='mr-2 h-4 w-4' />
                                   {reviewingId === subData.id
                                     ? 'Approving...'
-                                    : isBeforeDeadline
-                                      ? 'Before Deadline'
-                                      : 'Approve'}
+                                    : 'Approve'}
                                 </DropdownMenuItem>
                               ) : (
                                 <DropdownMenuItem

--- a/components/organization/hackathons/submissions/SubmissionsManagement.tsx
+++ b/components/organization/hackathons/submissions/SubmissionsManagement.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
+import { BoundlessButton } from '@/components/buttons/BoundlessButton';
 import { SubmissionsList } from './SubmissionsList';
 import { DisqualifyDialog } from './DisqualifyDialog';
 import type { ParticipantSubmission, Hackathon } from '@/lib/api/hackathons';
@@ -177,35 +178,36 @@ export function SubmissionsManagement({
               </div>
               <div className='bg-primary/20 hidden h-4 w-px sm:block' />
               <div className='flex flex-wrap items-center gap-2'>
-                <Button
+                <BoundlessButton
                   size='sm'
+                  variant='default'
                   onClick={() => handleBulkAction('SHORTLISTED')}
                   disabled={isBulkLoading}
-                  className='shrink-0 bg-green-600 text-white hover:bg-green-700'
+                  className='shrink-0'
                 >
                   <CheckCircle className='mr-1.5 h-3.5 w-3.5' />
                   Approve
-                </Button>
-                <Button
+                </BoundlessButton>
+                <BoundlessButton
                   size='sm'
                   variant='outline'
                   onClick={() => handleBulkAction('SUBMITTED')}
                   disabled={isBulkLoading}
-                  className='shrink-0 border-yellow-600/50 text-yellow-500 hover:bg-yellow-600/10'
+                  className='shrink-0'
                 >
                   <RotateCcw className='mr-1.5 h-3.5 w-3.5' />
                   Reset
-                </Button>
-                <Button
+                </BoundlessButton>
+                <BoundlessButton
                   size='sm'
-                  variant='outline'
+                  variant='destructive'
                   onClick={() => setShowBulkDisqualifyDialog(true)}
                   disabled={isBulkLoading}
-                  className='shrink-0 border-red-600/50 text-red-500 hover:bg-red-600/10'
+                  className='shrink-0'
                 >
                   <Ban className='mr-1.5 h-3.5 w-3.5' />
                   Disqualify
-                </Button>
+                </BoundlessButton>
               </div>
             </div>
           ) : (

--- a/components/project-details/project-sidebar/ProjectSidebarHeader.tsx
+++ b/components/project-details/project-sidebar/ProjectSidebarHeader.tsx
@@ -42,7 +42,7 @@ export function ProjectSidebarHeader({
             alt={project.title}
             width={80}
             height={80}
-            className='relative h-20 w-20 rounded-xl object-cover ring-2 ring-gray-800/50'
+            className='relative h-20 w-20 rounded-xl object-contain ring-2 ring-gray-800/50'
           />
         </div>
 

--- a/hooks/hackathon/use-hackathon-queries.ts
+++ b/hooks/hackathon/use-hackathon-queries.ts
@@ -91,6 +91,8 @@ export const hackathonKeys = {
   // a 4-element key that does NOT prefix-match cached ['…',slug,{...params}].
   teamsBase: (idOrSlug: string) => ['hackathon', 'teams', idOrSlug] as const,
   myTeam: (idOrSlug: string) => ['hackathon', 'myTeam', idOrSlug] as const,
+  team: (idOrSlug: string, teamId: string) =>
+    ['hackathon', 'team', idOrSlug, teamId] as const,
   myInvitations: (idOrSlug: string, status?: string) =>
     ['hackathon', 'myInvitations', idOrSlug, status] as const,
   teamInvitations: (idOrSlug: string, teamId: string, status?: string) =>
@@ -300,6 +302,20 @@ export function useHackathonTeams(
 
 // Legacy alias
 export const useTeamPosts = useHackathonTeams;
+
+/**
+ * Fetch a single team by id.
+ */
+export function useTeam(idOrSlug: string, teamId: string, enabled = true) {
+  return useQuery({
+    queryKey: hackathonKeys.team(idOrSlug, teamId),
+    queryFn: async () => {
+      const response = await getTeamDetails(idOrSlug, teamId);
+      return response.data;
+    },
+    enabled: !!idOrSlug && !!teamId && enabled,
+  });
+}
 
 /**
  * Fetch current user's team.

--- a/lib/api/hackathons/teams.ts
+++ b/lib/api/hackathons/teams.ts
@@ -50,6 +50,7 @@ export interface Team {
   organizationId?: string;
   views?: number;
   contactCount?: number;
+  hasSubmission?: boolean;
   createdAt: string;
   updatedAt: string;
   posts?: Team[];


### PR DESCRIPTION
## Summary

**Submission visibility (public submissions tab)**
- Surface the user's own submission first on the hackathon submissions tab regardless of the organizer's visibility setting. Team members (including non-leaders) also see their team's submission.

**Find Team tab UX**
- No longer replaces the whole tab with `MyTeamView` when the user has a team. MyTeamView now renders on top, with the "Other Teams" list below.
- Hides the user's own team from "Other Teams" to avoid duplication.
- Wires the team count badge on the team-formation tab.

**Team details page (new)**
- New route `/hackathons/[slug]/teams/[teamId]` with team header, members (clickable to profile), roles-needed, leader and contact cards.
- TeamCard click opens team details in a new tab.
- MyTeamView team name now links to the same page.
- Added `useTeam` hook + query key.

**Organizer submissions page**
- Replaced ad-hoc Buttons on review actions with `BoundlessButton` variants (`default` / `outline` / `destructive`) so colors come from the design system (brand primary for Approve, design-system red for Disqualify).
- Removed the "Before Deadline" gating on Approve. Pairs with the backend organizer-override change.

**Organizer participants page**
- New Solo Participants and Teams metric cards alongside Total Participants and Total Submissions.

**Organizer submissions page**
- New Total / Solo / Team Submissions metric strip sourced from the statistics endpoint.

**Organizer Teams page (new)**
- Route: `/organizations/[id]/hackathons/[hackathonId]/teams`.
- Stats (Total / Open / Submitted / Not submitted), search (server-side), status + submission filters (client-side), server-side pagination matching the participants page pattern.
- Click any row to open the team details page in a new tab.
- Adds a Teams entry to the existing organizer hackathon sidebar.

**Image fit fixes**
- SubmissionCard banner and logo overlay now use `object-contain` (banners and wordmark logos no longer cropped).
- `/me/hackathons/submissions` banner, logo overlay, and table thumbnail use `object-contain`.
- ProjectSidebarHeader logo uses `object-contain`.

**Types**
- `Team` interface gains optional `hasSubmission` flag.

## Test plan
- [ ] As a participant on a hackathon with `submissionStatusVisibility = 'ACCEPTED_SHORTLISTED'`, submit a project and confirm the card shows first on the Submissions tab.
- [ ] As a non-leader team member, confirm the team's submission card is visible to you on the Submissions tab.
- [ ] On the Find Team tab while on a team: MyTeamView at top, Other Teams below, your own team excluded from Other Teams. Tab badge shows team count.
- [ ] Click any team card → opens `/hackathons/[slug]/teams/[teamId]` in a new tab. Click a member row → profile in new tab.
- [ ] MyTeamView team name navigates to the same details page.
- [ ] Organizer submissions page: Approve button uses the mint brand color; Disqualify uses design-system red; Approve is clickable before the deadline.
- [ ] Organizer participants page shows four metric cards (Total, Solo, Teams, Total Submissions).
- [ ] Organizer submissions page shows three metric cards (Total / Solo / Team Submissions).
- [ ] Sidebar shows "Teams" between Submissions and Judging.
- [ ] Organizer Teams page: search works, filters work, pagination controls navigate, row click opens team details.
- [ ] Submission cards on the hackathon submissions tab show full banners and wordmark logos without cropping.