### PR TITLE
feat(hackathons): add "hidden until results" submission visibility mode

### DIFF
--- a/components/organization/hackathons/settings/SubmissionVisibilitySettingsTab.tsx
+++ b/components/organization/hackathons/settings/SubmissionVisibilitySettingsTab.tsx
@@ -47,7 +47,8 @@ export default function SubmissionVisibilitySettingsTab({
     resolver: zodResolver(visibilitySettingsSchema),
     defaultValues: {
       submissionVisibility: SubmissionVisibility.PUBLIC,
-      submissionStatusVisibility: SubmissionStatusVisibility.ALL,
+      submissionStatusVisibility:
+        SubmissionStatusVisibility.ACCEPTED_SHORTLISTED,
     },
   });
 
@@ -61,7 +62,7 @@ export default function SubmissionVisibilitySettingsTab({
               response.data.submissionVisibility || SubmissionVisibility.PUBLIC,
             submissionStatusVisibility:
               response.data.submissionStatusVisibility ||
-              SubmissionStatusVisibility.ALL,
+              SubmissionStatusVisibility.ACCEPTED_SHORTLISTED,
           });
         }
       } catch (error) {
@@ -181,20 +182,6 @@ export default function SubmissionVisibilitySettingsTab({
                       <FormItem className='flex items-center space-y-0 space-x-3 rounded-lg border border-gray-900 p-4'>
                         <FormControl>
                           <RadioGroupItem
-                            value={SubmissionStatusVisibility.ALL}
-                          />
-                        </FormControl>
-                        <FormLabel className='cursor-pointer font-normal text-white'>
-                          <div className='font-medium'>All Submissions</div>
-                          <div className='text-xs text-gray-400'>
-                            Show all projects (accepted, shortlisted, and
-                            rejected).
-                          </div>
-                        </FormLabel>
-                      </FormItem>
-                      <FormItem className='flex items-center space-y-0 space-x-3 rounded-lg border border-gray-900 p-4'>
-                        <FormControl>
-                          <RadioGroupItem
                             value={
                               SubmissionStatusVisibility.ACCEPTED_SHORTLISTED
                             }
@@ -202,11 +189,45 @@ export default function SubmissionVisibilitySettingsTab({
                         </FormControl>
                         <FormLabel className='cursor-pointer font-normal text-white'>
                           <div className='font-medium'>
-                            Accepted/Shortlisted Only
+                            Shortlisted only (recommended)
                           </div>
                           <div className='text-xs text-gray-400'>
-                            Only show projects that have been approved or
-                            shortlisted.
+                            Submissions stay hidden until you shortlist them.
+                            Disqualified projects are never shown.
+                          </div>
+                        </FormLabel>
+                      </FormItem>
+                      <FormItem className='flex items-center space-y-0 space-x-3 rounded-lg border border-gray-900 p-4'>
+                        <FormControl>
+                          <RadioGroupItem
+                            value={
+                              SubmissionStatusVisibility.HIDDEN_UNTIL_RESULTS
+                            }
+                          />
+                        </FormControl>
+                        <FormLabel className='cursor-pointer font-normal text-white'>
+                          <div className='font-medium'>
+                            Hidden until results are announced
+                          </div>
+                          <div className='text-xs text-gray-400'>
+                            Submissions stay hidden from everyone (except the
+                            participants who made them and your team) until you
+                            publish results. Then only shortlisted projects
+                            appear.
+                          </div>
+                        </FormLabel>
+                      </FormItem>
+                      <FormItem className='flex items-center space-y-0 space-x-3 rounded-lg border border-gray-900 p-4'>
+                        <FormControl>
+                          <RadioGroupItem
+                            value={SubmissionStatusVisibility.ALL}
+                          />
+                        </FormControl>
+                        <FormLabel className='cursor-pointer font-normal text-white'>
+                          <div className='font-medium'>All submissions</div>
+                          <div className='text-xs text-gray-400'>
+                            Every submission is visible as soon as it&apos;s
+                            made. Disqualified projects are still hidden.
                           </div>
                         </FormLabel>
                       </FormItem>

--- a/lib/api/hackathons.ts
+++ b/lib/api/hackathons.ts
@@ -32,6 +32,7 @@ export enum SubmissionVisibility {
 export enum SubmissionStatusVisibility {
   ALL = 'ALL',
   ACCEPTED_SHORTLISTED = 'ACCEPTED_SHORTLISTED',
+  HIDDEN_UNTIL_RESULTS = 'HIDDEN_UNTIL_RESULTS',
 }
 
 export enum VenueType {


### PR DESCRIPTION
## Summary

- Adds the new `HIDDEN_UNTIL_RESULTS` option (introduced server-side in [boundless-nestjs#106](https://github.com/boundlessfi/boundless-nestjs/pull/106)) to the organizer's submission visibility settings tab so organizers can keep submissions hidden from the public until results are published, after which only shortlisted projects appear.
- Fixes misleading copy on the "All submissions" option that claimed disqualified projects would be shown — they never were, and the nestjs PR makes that explicit.
- Aligns the form's initial value and API fallback with the backend default (`ACCEPTED_SHORTLISTED`, not `ALL`) so organizers don't see a misleading selection while the real value loads.

## What changed

- `lib/api/hackathons.ts`: extended `SubmissionStatusVisibility` enum with `HIDDEN_UNTIL_RESULTS`.
- `components/organization/hackathons/settings/SubmissionVisibilitySettingsTab.tsx`:
  - Added the new radio option, ordered: Shortlisted only (recommended) → Hidden until results are announced → All submissions.
  - Rewrote the descriptions to accurately describe what each mode does for public viewers.
  - Aligned default values with the backend.

## Test plan

- [ ] Open Organization → Hackathon → Settings → Submission Visibility on a hackathon you organize. Three options visible, "Shortlisted only" selected by default for a fresh hackathon.
- [ ] Pick "Hidden until results are announced", save. As an anonymous browser, visit `/hackathons/<slug>` — submissions list should be empty until you publish results.
- [ ] As the submitter, visit the same page — your own submission should remain visible regardless of mode.
- [ ] Switch back to "All submissions". Submitted projects appear immediately to the public; disqualified projects do not appear.
- [ ] `npx tsc --noEmit` passes.

## Notes

- Pairs with [boundless-nestjs#106](https://github.com/boundlessfi/boundless-nestjs/pull/106). Backend must ship first (or together) for the new enum value to be accepted by the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Hidden until results are announced" option for submission visibility settings, allowing hackathon organizers to control when submissions become visible to participants.
  * Updated submission visibility defaults to "Shortlisted only (recommended)" for improved experience.
  * Enhanced UI labels for submission visibility options with clearer, more descriptive text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/boundless/pull/555)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->