### PR TITLE
fix(blog): use object-cover so card and detail covers fill the frame

### DIFF
--- a/components/landing-page/blog/BlogCard.tsx
+++ b/components/landing-page/blog/BlogCard.tsx
@@ -24,7 +24,7 @@ const BlogCard = ({ post, onCardClick }: BlogCardProps) => {
             src={post.coverImage}
             alt={post.title}
             fill
-            className='object-contain transition-transform duration-500 group-hover:scale-105'
+            className='object-cover transition-transform duration-500 group-hover:scale-105'
             sizes='(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw'
           />
           {/* Gradient Overlay */}

--- a/components/landing-page/blog/BlogPostDetails.tsx
+++ b/components/landing-page/blog/BlogPostDetails.tsx
@@ -140,7 +140,7 @@ const BlogPostDetails: React.FC<BlogPostDetailsProps> = ({
                   src={post.coverImage}
                   alt={post.title}
                   fill
-                  className='rounded-lg object-contain'
+                  className='rounded-lg object-cover'
                   priority
                   sizes='(max-width: 768px) 100vw, (max-width: 1200px) 80vw, 70vw'
                 />


### PR DESCRIPTION
## Summary
- Revert the BlogCard and BlogPostDetails cover images from `object-contain` back to `object-cover` so banners fill the card/hero frame instead of letterboxing.
- The earlier switch to `object-contain` was meant to preserve the full image, but it produced dark bands around banners. With properly-sized cover images (2:1 ratio on the card, taller responsive height on the details page), `object-cover` fills the frame without visible cropping.

## Test plan
- [ ] Open `/blog` and confirm every post card's banner fills the image area edge to edge (no dark bands).
- [ ] Open the hackathon launch post and any other recent post detail page; the hero banner should fill the box without letterbox bands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Modified how blog cover images fit within their containers on blog listing and detail pages for improved visual presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/boundless/pull/558)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->