### PR TITLE
feat(hackathons): track-based prize structure + submission polish + tracks UI

### DIFF
--- a/app/(landing)/hackathons/[slug]/components/sidebar/PoolAndAction.tsx
+++ b/app/(landing)/hackathons/[slug]/components/sidebar/PoolAndAction.tsx
@@ -11,6 +11,7 @@ import {
   AlertCircle,
 } from 'lucide-react';
 import { useHackathonData } from '@/lib/providers/hackathonProvider';
+import { useHackathonTracks } from '@/hooks/hackathon/use-hackathon-queries';
 import { useOptionalAuth } from '@/hooks/use-auth';
 import { useRequireAuthForAction } from '@/hooks/use-require-auth-for-action';
 import { useSubmission } from '@/hooks/hackathon/use-submission';
@@ -79,6 +80,18 @@ export default function PoolAndAction() {
   } = useHackathonData();
   const hackathonError = error;
   const isDataLoading = loading || !hackathon;
+
+  // Load tracks when the hackathon uses a tracked structure so the prize
+  // list can label TRACK tiers by the actual track name instead of
+  // falling through to a generic "4th/5th Place" auto-label.
+  const tracksEnabled =
+    hackathon?.prizeStructure === 'OVERALL_AND_TRACKS' ||
+    hackathon?.prizeStructure === 'TRACKS_ONLY';
+  const { data: hackathonTracks = [] } = useHackathonTracks(
+    slug,
+    tracksEnabled
+  );
+  const trackById = new Map(hackathonTracks.map(t => [t.id, t] as const));
   const participants = hackathon?.participants || [];
   const deadline = hackathon?.submissionDeadline;
   const startDate = hackathon?.startDate;
@@ -240,30 +253,70 @@ export default function PoolAndAction() {
           </div>
         </div>
 
-        {hackathon && hackathon.prizeTiers.length > 0 && (
-          <div className='relative mb-5 ml-1'>
-            <div className='bg-primary/30 absolute top-2 bottom-2 left-[5px] w-[2px]' />
-            <div className='flex flex-col gap-3'>
-              {hackathon.prizeTiers.map((tier, i) => (
-                <div key={tier.id ?? i} className='flex items-start gap-4'>
-                  <span className='bg-primary relative z-10 mt-[5px] h-3 w-3 shrink-0 rounded-full ring-4 ring-[#11230F]' />
-                  <div>
-                    <p className='text-xs text-gray-500'>
-                      {tier.name ??
-                        `${i + 1}${['st', 'nd', 'rd'][i] ?? 'th'} Place`}
-                    </p>
-                    <p className='text-base font-bold text-white'>
-                      {Number(tier.prizeAmount ?? 0).toLocaleString()}{' '}
-                      <span className='font-medium text-gray-400'>
-                        {tier.currency ?? currency}
-                      </span>
-                    </p>
-                  </div>
+        {hackathon &&
+          hackathon.prizeTiers.length > 0 &&
+          (() => {
+            // Walk the tiers once, but keep a separate counter for
+            // OVERALL placements so the "1st/2nd/3rd" labels stay
+            // accurate even when track tiers are interleaved. Track
+            // tiers get the actual track name (looked up via trackId)
+            // and a "TRACK" prefix so the sidebar matches what the
+            // organizer set up in Rewards.
+            let overallIdx = 0;
+            return (
+              <div className='relative mb-5 ml-1'>
+                <div className='bg-primary/30 absolute top-2 bottom-2 left-[5px] w-[2px]' />
+                <div className='flex flex-col gap-3'>
+                  {hackathon.prizeTiers.map((tier, i) => {
+                    const isTrack = tier.kind === 'TRACK';
+                    const track =
+                      isTrack && tier.trackId
+                        ? trackById.get(tier.trackId)
+                        : undefined;
+                    let label: string;
+                    if (isTrack) {
+                      label = track?.name ?? tier.name ?? 'Track';
+                    } else {
+                      const place = overallIdx;
+                      overallIdx += 1;
+                      label =
+                        tier.name ??
+                        `${place + 1}${['st', 'nd', 'rd'][place] ?? 'th'} Place`;
+                    }
+                    return (
+                      <div
+                        key={tier.id ?? i}
+                        className='flex items-start gap-4'
+                      >
+                        <span
+                          className={cn(
+                            'relative z-10 mt-[5px] h-3 w-3 shrink-0 rounded-full ring-4 ring-[#11230F]',
+                            isTrack ? 'bg-primary/60' : 'bg-primary'
+                          )}
+                        />
+                        <div>
+                          <p className='text-xs text-gray-500'>
+                            {isTrack && (
+                              <span className='text-primary/80 mr-1 text-[9px] font-bold tracking-widest uppercase'>
+                                Track ·
+                              </span>
+                            )}
+                            {label}
+                          </p>
+                          <p className='text-base font-bold text-white'>
+                            {Number(tier.prizeAmount ?? 0).toLocaleString()}{' '}
+                            <span className='font-medium text-gray-400'>
+                              {tier.currency ?? currency}
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
-              ))}
-            </div>
-          </div>
-        )}
+              </div>
+            );
+          })()}
 
         <div className='mb-5 flex items-stretch gap-0 overflow-hidden rounded-xl border border-[#252628] bg-[#191B1E]'>
           <div className='flex flex-1 flex-col gap-0.5 px-4 py-3'>

--- a/app/(landing)/hackathons/[slug]/components/tabs/contents/Overview.tsx
+++ b/app/(landing)/hackathons/[slug]/components/tabs/contents/Overview.tsx
@@ -1,9 +1,19 @@
 'use client';
 
 import { useParams } from 'next/navigation';
-import { useHackathon } from '@/hooks/hackathon/use-hackathon-queries';
+import {
+  useHackathon,
+  useHackathonTracks,
+} from '@/hooks/hackathon/use-hackathon-queries';
 import { TabsContent } from '@/components/ui/tabs';
-import { Info, Target, Clock, Trophy, ChevronRight } from 'lucide-react';
+import {
+  Info,
+  Target,
+  Clock,
+  Trophy,
+  ChevronRight,
+  Layers,
+} from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 
@@ -19,6 +29,17 @@ function getOrdinal(n: number) {
 const Overview = () => {
   const { slug } = useParams<{ slug: string }>();
   const { data: hackathon } = useHackathon(slug);
+  // Only fetch tracks once we know the hackathon uses a tracked structure.
+  // Avoids an extra network call on every overview render for legacy
+  // overall-only hackathons.
+  const tracksEnabled =
+    hackathon?.prizeStructure === 'OVERALL_AND_TRACKS' ||
+    hackathon?.prizeStructure === 'TRACKS_ONLY';
+  const { data: hackathonTracks = [] } = useHackathonTracks(
+    slug,
+    tracksEnabled
+  );
+  const trackById = new Map(hackathonTracks.map(t => [t.id, t] as const));
 
   const { styledContent, loading: markdownLoading } = useMarkdown(
     hackathon?.description || '',
@@ -218,61 +239,138 @@ const Overview = () => {
       </section>
 
       {/* Prizes Section */}
-      <section className='space-y-6'>
-        <div className='flex items-center gap-2'>
-          <h2 className='text-xl font-bold text-white'>Prizes</h2>
-        </div>
-        <div className='grid grid-cols-1 gap-6 md:grid-cols-3'>
-          {hackathon.prizeTiers.map((tier, i) => (
-            <div
-              key={i}
-              className={cn(
-                'relative flex flex-col items-center rounded-2xl border bg-[#141517] p-8 text-center transition-all',
-                i === 0
-                  ? 'border-primary/30 ring-primary/20 ring-1'
-                  : 'border-white/5'
-              )}
-            >
-              {i === 0 && (
-                <Badge className='bg-primary absolute -top-3 left-1/2 -translate-x-1/2 px-3 py-0.5 text-[10px] font-bold text-black uppercase'>
-                  Top Tier
-                </Badge>
-              )}
+      {(() => {
+        // Partition tiers into overall vs track. Tiers without an
+        // explicit kind are treated as OVERALL for backward compat with
+        // hackathons created before the track structure landed.
+        const overallTiers = hackathon.prizeTiers.filter(
+          t => !t.kind || t.kind === 'OVERALL'
+        );
+        const trackTiers = hackathon.prizeTiers.filter(t => t.kind === 'TRACK');
 
-              <div className='mb-4 flex h-14 w-14 items-center justify-center rounded-full border border-white/10 bg-white/5'>
-                <Trophy
-                  className={cn(
-                    'h-7 w-7',
-                    i === 0
-                      ? 'text-primary'
-                      : i === 1
-                        ? 'text-blue-400'
-                        : 'text-gray-400'
-                  )}
-                />
+        return (
+          <section className='space-y-8'>
+            {overallTiers.length > 0 && (
+              <div className='space-y-6'>
+                <div className='flex items-center gap-2'>
+                  <h2 className='text-xl font-bold text-white'>
+                    {trackTiers.length > 0 ? 'Overall Prizes' : 'Prizes'}
+                  </h2>
+                </div>
+                <div className='grid grid-cols-1 gap-6 md:grid-cols-3'>
+                  {overallTiers.map((tier, i) => (
+                    <div
+                      key={tier.id ?? `overall-${i}`}
+                      className={cn(
+                        'relative flex flex-col items-center rounded-2xl border bg-[#141517] p-8 text-center transition-all',
+                        i === 0
+                          ? 'border-primary/30 ring-primary/20 ring-1'
+                          : 'border-white/5'
+                      )}
+                    >
+                      {i === 0 && (
+                        <Badge className='bg-primary absolute -top-3 left-1/2 -translate-x-1/2 px-3 py-0.5 text-[10px] font-bold text-black uppercase'>
+                          Top Tier
+                        </Badge>
+                      )}
+
+                      <div className='mb-4 flex h-14 w-14 items-center justify-center rounded-full border border-white/10 bg-white/5'>
+                        <Trophy
+                          className={cn(
+                            'h-7 w-7',
+                            i === 0
+                              ? 'text-primary'
+                              : i === 1
+                                ? 'text-blue-400'
+                                : 'text-gray-400'
+                          )}
+                        />
+                      </div>
+
+                      <h3 className='text-sm font-semibold text-gray-400'>
+                        {tier.name || `${getOrdinal(i + 1)} Place`}
+                      </h3>
+                      <div className='my-2 flex items-baseline gap-1'>
+                        <span className='text-3xl font-black text-white'>
+                          {Number(tier.prizeAmount).toLocaleString()}
+                        </span>
+                        <span className='text-lg font-bold text-gray-500 uppercase'>
+                          {tier.currency || 'USDC'}
+                        </span>
+                      </div>
+
+                      {tier.description && (
+                        <p className='mt-4 text-xs leading-relaxed text-gray-500'>
+                          {tier.description}
+                        </p>
+                      )}
+                    </div>
+                  ))}
+                </div>
               </div>
+            )}
 
-              <h3 className='text-sm font-semibold text-gray-400'>
-                {tier.name || `${getOrdinal(i + 1)} Place`}
-              </h3>
-              <div className='my-2 flex items-baseline gap-1'>
-                <span className='text-3xl font-black text-white'>
-                  {Number(tier.prizeAmount).toLocaleString()}
-                </span>
-                <span className='text-lg font-bold text-gray-500 uppercase'>
-                  {tier.currency || 'USDC'}
-                </span>
-              </div>
-
-              {tier.description && (
-                <p className='mt-4 text-xs leading-relaxed text-gray-500'>
-                  {tier.description}
+            {trackTiers.length > 0 && (
+              <div className='space-y-6'>
+                <div className='flex items-center gap-2'>
+                  <Layers className='text-primary h-5 w-5' />
+                  <h2 className='text-xl font-bold text-white'>Track Prizes</h2>
+                </div>
+                <p className='text-sm text-gray-400'>
+                  Category prizes alongside the overall placements. Pick the
+                  tracks you want your submission considered for when you
+                  submit.
                 </p>
-              )}
-            </div>
-          ))}
-        </div>
-      </section>
+                <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3'>
+                  {trackTiers.map((tier, i) => {
+                    const track = tier.trackId
+                      ? trackById.get(tier.trackId)
+                      : undefined;
+                    return (
+                      <div
+                        key={tier.id ?? `track-${i}`}
+                        className='relative flex flex-col rounded-2xl border border-white/5 bg-[#141517] p-6 transition-all hover:border-white/10'
+                      >
+                        <div className='mb-3 flex items-start justify-between gap-2'>
+                          <Badge
+                            variant='outline'
+                            className='border-primary/40 text-primary'
+                          >
+                            {track?.name ?? tier.name ?? 'Track'}
+                          </Badge>
+                          {track?.type && (
+                            <span className='text-[10px] tracking-widest text-gray-500 uppercase'>
+                              {track.type}
+                            </span>
+                          )}
+                        </div>
+                        <div className='mb-2 flex items-baseline gap-1'>
+                          <span className='text-2xl font-black text-white'>
+                            {Number(tier.prizeAmount).toLocaleString()}
+                          </span>
+                          <span className='text-sm font-bold text-gray-500 uppercase'>
+                            {tier.currency || 'USDC'}
+                          </span>
+                        </div>
+                        {(track?.description || tier.description) && (
+                          <p className='text-xs leading-relaxed text-gray-500'>
+                            {track?.description || tier.description}
+                          </p>
+                        )}
+                        {!track && tier.trackId && (
+                          <p className='mt-2 text-[10px] text-amber-400/70'>
+                            Track details loading…
+                          </p>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </section>
+        );
+      })()}
 
       <SponsorsSection
         slug={slug}

--- a/app/(landing)/hackathons/[slug]/components/tabs/contents/Winners.tsx
+++ b/app/(landing)/hackathons/[slug]/components/tabs/contents/Winners.tsx
@@ -6,12 +6,17 @@ import { MainStageHeader } from './winners/MainStageHeader';
 import { TopWinnerCard } from './winners/TopWinnerCard';
 import { PodiumWinnerCard } from './winners/PodiumWinnerCard';
 import { GeneralWinnerCard } from './winners/GeneralWinnerCard';
-import { Trophy } from 'lucide-react';
+import { Trophy, Layers } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
 
 const Winners = () => {
-  const { currentHackathon, winners, submissions } = useHackathonData();
+  const { currentHackathon, winners, trackWinners, submissions } =
+    useHackathonData();
 
-  if (!winners || winners.length === 0) {
+  const hasOverall = winners && winners.length > 0;
+  const hasTracks = trackWinners && trackWinners.length > 0;
+
+  if (!hasOverall && !hasTracks) {
     return (
       <TabsContent value='winners' className='mt-0 w-full outline-none'>
         <div className='mt-8 rounded-3xl border border-white/5 bg-[#0A0A0A] py-24 text-center'>
@@ -86,6 +91,55 @@ const Winners = () => {
                     submission={getSubmission(winner.submissionId)}
                   />
                 ))}
+              </div>
+            </div>
+          )}
+
+          {hasTracks && (
+            <div className='mt-8'>
+              <div className='mb-6 flex items-center gap-3'>
+                <div className='h-px flex-1 bg-white/5' />
+                <span className='flex items-center gap-1.5 text-[10px] font-bold tracking-widest text-white/30 uppercase'>
+                  <Layers className='h-3 w-3' />
+                  Track Prizes
+                </span>
+                <div className='h-px flex-1 bg-white/5' />
+              </div>
+
+              <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3'>
+                {trackWinners!.map(tw => {
+                  // Adapt the track-winner shape to the GeneralWinnerCard
+                  // contract: it expects a `winner` with rank + projectName +
+                  // logo + participants + prize + submissionId. We feed
+                  // wonRank as the rank so the card renders sanely; the
+                  // surrounding Badge labels which track this is for.
+                  const adapted = {
+                    rank: tw.wonRank,
+                    projectName: tw.projectName,
+                    logo: tw.logo ?? '',
+                    teamName: tw.teamName,
+                    participants: tw.participants,
+                    prize: tw.prize,
+                    submissionId: tw.submissionId,
+                  };
+                  return (
+                    <div
+                      key={`${tw.submissionId}-${tw.track.id}`}
+                      className='space-y-2'
+                    >
+                      <Badge
+                        variant='outline'
+                        className='border-primary/40 text-primary'
+                      >
+                        {tw.track.name}
+                      </Badge>
+                      <GeneralWinnerCard
+                        winner={adapted}
+                        submission={getSubmission(tw.submissionId)}
+                      />
+                    </div>
+                  );
+                })}
               </div>
             </div>
           )}

--- a/app/(landing)/hackathons/[slug]/components/tabs/index.tsx
+++ b/app/(landing)/hackathons/[slug]/components/tabs/index.tsx
@@ -32,6 +32,7 @@ const HackathonTabs = ({ sidebar }: HackathonTabsProps) => {
   const {
     currentHackathon,
     winners,
+    trackWinners,
     exploreSubmissionsTotal,
     loading: generalLoading,
   } = useHackathonData();
@@ -52,7 +53,10 @@ const HackathonTabs = ({ sidebar }: HackathonTabsProps) => {
     if (!currentHackathon) return [];
     const hasParticipants = currentHackathon._count?.participants > 0;
     const hasResources = currentHackathon.resources?.length > 0;
-    const hasWinners = !!(winners && winners.length > 0);
+    const hasWinners = !!(
+      (winners && winners.length > 0) ||
+      (trackWinners && trackWinners.length > 0)
+    );
     const hasAnnouncements = announcements.length > 0;
 
     const participantType = currentHackathon.participantType;
@@ -112,7 +116,7 @@ const HackathonTabs = ({ sidebar }: HackathonTabsProps) => {
       tabs.push({
         id: 'winners',
         label: 'Winners',
-        badge: winners.length,
+        badge: (winners?.length ?? 0) + (trackWinners?.length ?? 0),
       });
     }
 
@@ -154,6 +158,7 @@ const HackathonTabs = ({ sidebar }: HackathonTabsProps) => {
   }, [
     currentHackathon,
     winners,
+    trackWinners,
     exploreSubmissionsTotal,
     discussionComments.pagination.totalItems,
     announcements,

--- a/app/(landing)/organizations/[id]/hackathons/[hackathonId]/settings/page.tsx
+++ b/app/(landing)/organizations/[id]/hackathons/[hackathonId]/settings/page.tsx
@@ -14,6 +14,7 @@ import {
   Sliders,
   Eye,
   HandCoins,
+  Layers,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { api } from '@/lib/api/api';
@@ -27,6 +28,7 @@ import CollaborationSettingsTab from '@/components/organization/hackathons/setti
 import AdvancedSettingsTab from '@/components/organization/hackathons/settings/AdvancedSettingsTab';
 import SubmissionVisibilitySettingsTab from '@/components/organization/hackathons/settings/SubmissionVisibilitySettingsTab';
 import PartnersSettingsTab from '@/components/organization/hackathons/settings/PartnersSettingsTab';
+import TracksSettingsTab from '@/components/organization/hackathons/settings/TracksSettingsTab';
 import { AuthGuard } from '@/components/auth';
 import Loading from '@/components/Loading';
 
@@ -232,6 +234,10 @@ export default function SettingsPage() {
                       <Trophy className='h-4 w-4' />
                       Rewards
                     </TabsTrigger>
+                    <TabsTrigger value='tracks' className={tabTriggerClassName}>
+                      <Layers className='h-4 w-4' />
+                      Tracks
+                    </TabsTrigger>
                     <TabsTrigger
                       value='collaboration'
                       className={tabTriggerClassName}
@@ -314,11 +320,24 @@ export default function SettingsPage() {
               <RewardsSettingsTab
                 organizationId={organizationId}
                 hackathonId={hackathonId}
-                initialData={{ prizeTiers: hackathon?.prizeTiers || [] } as any}
+                initialData={
+                  {
+                    prizeTiers: hackathon?.prizeTiers || [],
+                    prizeStructure: hackathon?.prizeStructure,
+                    tracksMaxPerSubmission: hackathon?.tracksMaxPerSubmission,
+                  } as any
+                }
                 onSave={async data => {
                   await handleSave('Rewards', data);
                 }}
                 isLoading={isSaving}
+              />
+            </TabsContent>
+
+            <TabsContent value='tracks' className='mt-0'>
+              <TracksSettingsTab
+                organizationId={organizationId}
+                hackathonId={hackathonId}
               />
             </TabsContent>
 

--- a/components/hackathons/submissions/SubmissionDetailModal.tsx
+++ b/components/hackathons/submissions/SubmissionDetailModal.tsx
@@ -217,13 +217,152 @@ export function SubmissionDetailModal({
               </div>
             )}
 
+            {/* Tagline — short pitch shown above the long description. */}
+            {(() => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const tagline = (submission as any).tagline as string | undefined;
+              return tagline ? (
+                <p className='text-base text-gray-200 italic'>
+                  &ldquo;{tagline}&rdquo;
+                </p>
+              ) : null;
+            })()}
+
+            {/* Screenshots gallery (up to 5). Renders as a horizontal
+                scroll on mobile, a row of thumbnails on desktop. */}
+            {(() => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const screenshots = ((submission as any).screenshots ??
+                []) as string[];
+              return screenshots.length > 0 ? (
+                <div>
+                  <h3 className='mb-2 text-lg font-semibold'>Screenshots</h3>
+                  <div className='flex gap-3 overflow-x-auto pb-2'>
+                    {screenshots.map((src, i) => (
+                      <a
+                        key={`${src}-${i}`}
+                        href={src}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                        className='shrink-0'
+                      >
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          src={src}
+                          alt={`Screenshot ${i + 1}`}
+                          className='h-40 rounded-md border border-gray-700 object-cover transition-opacity hover:opacity-90'
+                        />
+                      </a>
+                    ))}
+                  </div>
+                </div>
+              ) : null;
+            })()}
+
             {/* Description */}
             <div>
               <h3 className='mb-2 text-lg font-semibold'>Description</h3>
-              <p className='text-gray-300'>{submission.description}</p>
+              <p className='whitespace-pre-wrap text-gray-300'>
+                {submission.description}
+              </p>
             </div>
 
-            {/* Introduction */}
+            {/* Per-track answers — only for tracks where the organizer
+                set a prompt / custom questions / required artifacts and
+                the submitter filled at least one in. We index by
+                trackId so the section header gets the track name. */}
+            {(() => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const entries = ((submission as any).trackEntries ??
+                []) as Array<{
+                trackId: string;
+                trackName: string;
+                trackAnswers?: {
+                  promptAnswer?: string;
+                  customAnswers?: Record<string, string>;
+                  artifacts?: Record<string, string>;
+                };
+              }>;
+              const withAnswers = entries.filter(e => {
+                const a = e.trackAnswers;
+                if (!a) return false;
+                return !!(
+                  a.promptAnswer?.trim() ||
+                  Object.values(a.customAnswers ?? {}).some(v => v?.trim?.()) ||
+                  Object.values(a.artifacts ?? {}).some(v => v?.trim?.())
+                );
+              });
+              if (withAnswers.length === 0) return null;
+              return (
+                <div className='space-y-4'>
+                  <h3 className='text-lg font-semibold'>Track answers</h3>
+                  {withAnswers.map(e => (
+                    <div
+                      key={e.trackId}
+                      className='space-y-2 rounded-md border border-gray-700 bg-gray-900/40 p-3'
+                    >
+                      <p className='text-sm font-medium text-white'>
+                        {e.trackName}
+                      </p>
+                      {e.trackAnswers?.promptAnswer && (
+                        <p className='text-sm whitespace-pre-wrap text-gray-300'>
+                          {e.trackAnswers.promptAnswer}
+                        </p>
+                      )}
+                      {Object.entries(e.trackAnswers?.customAnswers ?? {})
+                        .filter(([, v]) => v && v.trim().length > 0)
+                        .map(([qid, value]) => (
+                          <div key={qid} className='text-sm'>
+                            <p className='text-xs text-gray-400'>{qid}</p>
+                            <p className='whitespace-pre-wrap text-gray-200'>
+                              {value}
+                            </p>
+                          </div>
+                        ))}
+                      {Object.entries(e.trackAnswers?.artifacts ?? {})
+                        .filter(([, v]) => v && v.trim().length > 0)
+                        .map(([aid, url]) => (
+                          <div key={aid} className='text-sm'>
+                            <p className='text-xs text-gray-400'>{aid}</p>
+                            <a
+                              href={url}
+                              target='_blank'
+                              rel='noopener noreferrer'
+                              className='text-primary break-all hover:underline'
+                            >
+                              {url}
+                            </a>
+                          </div>
+                        ))}
+                    </div>
+                  ))}
+                </div>
+              );
+            })()}
+
+            {/* Built with — tech-stack chips, hidden when empty. */}
+            {(() => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const builtWith = ((submission as any).builtWith ??
+                []) as string[];
+              return builtWith.length > 0 ? (
+                <div>
+                  <h3 className='mb-2 text-lg font-semibold'>Built with</h3>
+                  <div className='flex flex-wrap gap-2'>
+                    {builtWith.map((tag, i) => (
+                      <span
+                        key={`${tag}-${i}`}
+                        className='rounded-md border border-gray-700 bg-gray-900/40 px-2 py-1 text-xs text-gray-200'
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ) : null;
+            })()}
+
+            {/* Introduction (legacy field — keep for backward compat) */}
             {submission.introduction && (
               <div>
                 <h3 className='mb-2 text-lg font-semibold'>Introduction</h3>
@@ -271,7 +410,7 @@ export function SubmissionDetailModal({
             <Separator className='bg-gray-700' />
 
             {/* Footer Info */}
-            <div className='flex items-center gap-6 text-sm text-gray-400'>
+            <div className='flex flex-wrap items-center gap-6 text-sm text-gray-400'>
               <div className='flex items-center gap-2'>
                 <Calendar className='h-4 w-4' />
                 <span>
@@ -292,6 +431,17 @@ export function SubmissionDetailModal({
                   comments
                 </span>
               </div>
+              {(() => {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const license = (submission as any).license as
+                  | string
+                  | undefined;
+                return license ? (
+                  <span className='rounded border border-gray-700 px-2 py-0.5 text-xs tracking-wide uppercase'>
+                    License · {license}
+                  </span>
+                ) : null;
+              })()}
             </div>
 
             {/* Disqualification Reason */}

--- a/components/hackathons/submissions/SubmissionForm.tsx
+++ b/components/hackathons/submissions/SubmissionForm.tsx
@@ -42,6 +42,7 @@ import {
   type SubmissionFormData,
 } from '@/hooks/hackathon/use-submission';
 import { useHackathonData } from '@/lib/providers/hackathonProvider';
+import { listTracks, type HackathonTrack } from '@/lib/api/hackathons/tracks';
 import { toast } from 'sonner';
 import {
   Loader2,
@@ -83,6 +84,16 @@ const teamMemberSchema = z
     path: ['email'],
   });
 
+const LICENSE_OPTIONS = [
+  'MIT',
+  'Apache-2.0',
+  'GPL-3.0',
+  'BSD-3',
+  'PROPRIETARY',
+  'OTHER',
+] as const;
+type License = (typeof LICENSE_OPTIONS)[number];
+
 const baseSubmissionSchema = z.object({
   projectName: z.string().min(3, 'Project name must be at least 3 characters'),
   category: z.string().min(1, 'Please select a category'),
@@ -105,6 +116,42 @@ const baseSubmissionSchema = z.object({
   participationType: z.enum(['INDIVIDUAL', 'TEAM']),
   teamName: z.string().optional(),
   teamMembers: z.array(teamMemberSchema).optional(),
+  /** Track ids the submitter has opted into. Capped client-side by
+   *  hackathon.tracksMaxPerSubmission; the backend re-validates. */
+  trackIds: z.array(z.string()).optional(),
+  /** Track-specific answers, keyed by trackId (Phase B). The backend
+   *  validates required fields against each track's customization. */
+  trackAnswers: z
+    .record(
+      z.string(),
+      z.object({
+        promptAnswer: z.string().max(2000).optional(),
+        customAnswers: z.record(z.string(), z.string()).optional(),
+        artifacts: z.record(z.string(), z.string()).optional(),
+      })
+    )
+    .optional(),
+
+  // ── Phase A submission polish ──
+  tagline: z
+    .string()
+    .max(200, 'Tagline must be 200 characters or fewer')
+    .optional(),
+  builtWith: z
+    .array(z.string().max(40, 'Tag must be 40 characters or fewer'))
+    .max(20, 'Up to 20 tags')
+    .optional(),
+  screenshots: z
+    .array(z.string().url('Each screenshot must be a valid URL'))
+    .max(5, 'Up to 5 screenshots')
+    .optional(),
+  license: z
+    .enum(LICENSE_OPTIONS as unknown as [License, ...License[]])
+    .optional(),
+  // codeAttested is enforced at submit time (see onSubmit) rather than
+  // here so the user can move between steps without the schema blocking
+  // them. The Review step UI wires it as a required gate.
+  codeAttested: z.boolean().optional(),
 });
 
 const createSubmissionSchema = (requireDemoVideo: boolean) =>
@@ -208,6 +255,37 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
   const { user } = useAuthStatus();
 
   const requireGithub = currentHackathon?.requireGithub ?? false;
+
+  // ── Tracks ────────────────────────────────────────────────────────────
+  // Best-effort load — if the endpoint fails the form falls back to
+  // overall-only and the submission still goes through.
+  const [availableTracks, setAvailableTracks] = useState<HackathonTrack[]>([]);
+  const trackCap = currentHackathon?.tracksMaxPerSubmission ?? 3;
+  const prizeStructure = currentHackathon?.prizeStructure ?? 'OVERALL_ONLY';
+  const tracksEnabled = prizeStructure !== 'OVERALL_ONLY';
+
+  useEffect(() => {
+    if (!hackathonSlugOrId || !tracksEnabled) {
+      setAvailableTracks([]);
+      return;
+    }
+    let cancelled = false;
+    listTracks(hackathonSlugOrId)
+      .then(rows => {
+        if (!cancelled) {
+          // Only OPT_IN tracks need a pick — OPEN tracks auto-include
+          // every submission, so showing them in a checkbox group would
+          // just confuse submitters.
+          setAvailableTracks(rows.filter(t => t.eligibility === 'OPT_IN'));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setAvailableTracks([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [hackathonSlugOrId, tracksEnabled]);
   const requireDemoVideo = currentHackathon?.requireDemoVideo ?? false;
   const requireOtherLinks = currentHackathon?.requireOtherLinks ?? false;
 
@@ -277,6 +355,13 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
       participationType: 'INDIVIDUAL',
       teamName: '',
       teamMembers: [],
+      trackIds: [],
+      trackAnswers: {},
+      tagline: '',
+      builtWith: [],
+      screenshots: [],
+      license: undefined,
+      codeAttested: false,
     },
   });
 
@@ -293,6 +378,8 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
   // Initialize form when modal opens with data
   useEffect(() => {
     if (open && initialData) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const raw = initialData as any;
       form.reset({
         projectName: initialData.projectName || '',
         category: initialData.category || '',
@@ -303,6 +390,52 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
         introduction: initialData.introduction || '',
         links: initialData.links || [],
         participationType: initialData.participationType || 'INDIVIDUAL',
+        trackIds:
+          raw.trackIds ??
+          ((raw.trackEntries ?? []) as Array<{ trackId: string }>).map(
+            e => e.trackId
+          ),
+        // Reconstruct trackAnswers from trackEntries the backend returns
+        // on reload. The shape is { [trackId]: TrackAnswer }.
+        trackAnswers: ((): Record<
+          string,
+          {
+            promptAnswer?: string;
+            customAnswers?: Record<string, string>;
+            artifacts?: Record<string, string>;
+          }
+        > => {
+          const entries = (raw.trackEntries ?? []) as Array<{
+            trackId: string;
+            trackAnswers?: {
+              promptAnswer?: string;
+              customAnswers?: Record<string, string>;
+              artifacts?: Record<string, string>;
+            };
+          }>;
+          const out: Record<
+            string,
+            {
+              promptAnswer?: string;
+              customAnswers?: Record<string, string>;
+              artifacts?: Record<string, string>;
+            }
+          > = {};
+          for (const e of entries) {
+            if (e.trackAnswers && typeof e.trackAnswers === 'object') {
+              out[e.trackId] = e.trackAnswers;
+            }
+          }
+          return out;
+        })(),
+        tagline: raw.tagline ?? '',
+        builtWith: raw.builtWith ?? [],
+        screenshots: raw.screenshots ?? [],
+        license: raw.license,
+        // The attestation timestamp coming back from the server gets
+        // mapped to the boolean form field; reloading a previously
+        // attested submission keeps the box checked.
+        codeAttested: !!raw.codeAttestedAt || !!raw.codeAttested,
       });
       if (initialData.logo && isValidImageUrl(initialData.logo)) {
         setLogoPreview(initialData.logo);
@@ -784,6 +917,65 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
                 }))
             : [],
         participationType: data.participationType || 'INDIVIDUAL',
+        trackIds:
+          (data.trackIds ?? currentValues.trackIds)?.filter(
+            (id): id is string => typeof id === 'string' && id.length > 0
+          ) ?? undefined,
+        // Pull per-track answers only for the tracks that are
+        // currently selected. Stale entries from de-selected tracks
+        // get dropped so the backend doesn't store dangling answers.
+        trackAnswers: (():
+          | Record<
+              string,
+              {
+                promptAnswer?: string;
+                customAnswers?: Record<string, string>;
+                artifacts?: Record<string, string>;
+              }
+            >
+          | undefined => {
+          const picked = data.trackIds ?? currentValues.trackIds ?? [];
+          const all = (data.trackAnswers ??
+            currentValues.trackAnswers ??
+            {}) as Record<
+            string,
+            {
+              promptAnswer?: string;
+              customAnswers?: Record<string, string>;
+              artifacts?: Record<string, string>;
+            }
+          >;
+          if (picked.length === 0) return undefined;
+          const next: Record<
+            string,
+            {
+              promptAnswer?: string;
+              customAnswers?: Record<string, string>;
+              artifacts?: Record<string, string>;
+            }
+          > = {};
+          for (const id of picked) {
+            if (typeof id !== 'string' || !id) continue;
+            if (all[id]) next[id] = all[id];
+          }
+          return Object.keys(next).length > 0 ? next : undefined;
+        })(),
+        // ── Phase A submission polish ─ string fields default to undefined
+        // (not empty string) so the backend update path doesn't clobber
+        // existing values with empties.
+        tagline:
+          (data.tagline ?? currentValues.tagline)?.toString().trim() ||
+          undefined,
+        builtWith:
+          (data.builtWith ?? currentValues.builtWith)
+            ?.map(t => t.trim())
+            .filter(t => t.length > 0) ?? undefined,
+        screenshots:
+          (data.screenshots ?? currentValues.screenshots)
+            ?.map(u => u.trim())
+            .filter(u => u.length > 0) ?? undefined,
+        license: data.license ?? currentValues.license ?? undefined,
+        codeAttested: data.codeAttested ?? currentValues.codeAttested ?? false,
       };
 
       const isValid = await form.trigger([
@@ -860,6 +1052,34 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
 
       const participationType = safeData.participationType || 'INDIVIDUAL';
       const teamId = participationType === 'TEAM' ? myTeam?.id : undefined;
+
+      // Gate the compliance fields on NEW submissions only.
+      //
+      // For an existing submission (`submissionId` is set), license +
+      // attestation are optional so participants who submitted before
+      // the Phase A polish rolled out aren't blocked from editing
+      // other fields like videoUrl or screenshots. They CAN fill in
+      // the new fields if they want — the form still shows them and
+      // the data round-trips.
+      //
+      // The schema marks both fields optional, so we enforce the gate
+      // here (at the moment of submit) instead of letting zod block
+      // step navigation.
+      const isNewSubmission = !submissionId;
+      if (isNewSubmission && !safeData.license) {
+        toast.error('Pick a license on the Review step before submitting.');
+        setCurrentStep(3);
+        updateStepState(3, 'active');
+        return;
+      }
+      if (isNewSubmission && !safeData.codeAttested) {
+        toast.error(
+          'Please confirm the code is original or properly attributed on the Review step.'
+        );
+        setCurrentStep(3);
+        updateStepState(3, 'active');
+        return;
+      }
 
       // Team submissions always go through a real team. handleNext blocks
       // advancing past step 0 if participationType is TEAM but myTeam is
@@ -1121,6 +1341,40 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
 
             <FormField
               control={form.control}
+              name='tagline'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className='text-white'>
+                    Tagline{' '}
+                    <span className='text-xs font-normal text-gray-500'>
+                      (one-line pitch, up to 200 chars)
+                    </span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder='Trustless escrow for one-time freelance gigs on Stellar.'
+                      maxLength={200}
+                      className='border-gray-700 bg-gray-800/50 text-white placeholder:text-gray-500'
+                      value={field.value || ''}
+                      onChange={field.onChange}
+                      onBlur={field.onBlur}
+                      name={field.name}
+                      ref={field.ref}
+                    />
+                  </FormControl>
+                  <FormDescription className='text-gray-400'>
+                    Shown on hackathon cards, sidebar, and the judge queue.
+                    {field.value
+                      ? ` ${field.value.length} / 200`
+                      : ' Optional but strongly recommended.'}
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
               name='category'
               render={({ field }) => (
                 <FormItem>
@@ -1184,6 +1438,283 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
                 </FormItem>
               )}
             />
+
+            {tracksEnabled && availableTracks.length > 0 && (
+              <FormField
+                control={form.control}
+                name='trackIds'
+                render={({ field }) => {
+                  const value: string[] = field.value ?? [];
+                  const toggle = (id: string) => {
+                    if (value.includes(id)) {
+                      field.onChange(value.filter(v => v !== id));
+                    } else {
+                      if (value.length >= trackCap) {
+                        toast.error(
+                          `You can enter at most ${trackCap} track${
+                            trackCap === 1 ? '' : 's'
+                          }.`
+                        );
+                        return;
+                      }
+                      field.onChange([...value, id]);
+                    }
+                  };
+                  return (
+                    <FormItem>
+                      <FormLabel className='text-white'>
+                        Tracks{' '}
+                        <span className='text-xs font-normal text-gray-500'>
+                          (optional, up to {trackCap})
+                        </span>
+                      </FormLabel>
+                      <FormDescription className='text-gray-400'>
+                        Pick the tracks your project should be considered for.
+                        Overall placements always apply; tracks unlock
+                        additional category prizes.
+                      </FormDescription>
+                      <div className='space-y-2'>
+                        {availableTracks.map(track => {
+                          const checked = value.includes(track.id);
+                          return (
+                            <label
+                              key={track.id}
+                              className={`flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors ${
+                                checked
+                                  ? 'border-primary bg-primary/10'
+                                  : 'border-gray-800 bg-gray-900/40 hover:border-gray-700'
+                              }`}
+                            >
+                              <input
+                                type='checkbox'
+                                checked={checked}
+                                onChange={() => toggle(track.id)}
+                                className='accent-primary mt-1 h-4 w-4'
+                              />
+                              <div className='flex-1'>
+                                <div className='flex items-center gap-2'>
+                                  <span className='text-sm font-medium text-white'>
+                                    {track.name}
+                                  </span>
+                                  {track.type && (
+                                    <Badge
+                                      variant='outline'
+                                      className='text-xs'
+                                    >
+                                      {track.type}
+                                    </Badge>
+                                  )}
+                                </div>
+                                {track.description && (
+                                  <p className='mt-1 text-xs text-gray-400'>
+                                    {track.description}
+                                  </p>
+                                )}
+                              </div>
+                            </label>
+                          );
+                        })}
+                      </div>
+                      {value.length > 0 && (
+                        <p className='mt-2 text-xs text-gray-500'>
+                          {value.length} of {trackCap} selected
+                        </p>
+                      )}
+                      <FormMessage />
+                    </FormItem>
+                  );
+                }}
+              />
+            )}
+
+            {/* Per-track answer collection (Phase B). Renders one card
+                per selected track, with the track's prompt, custom
+                questions, and required artifacts inline. The form
+                field is a single nested object so the value naturally
+                round-trips through react-hook-form. */}
+            {tracksEnabled &&
+              availableTracks.length > 0 &&
+              (() => {
+                const picked =
+                  (form.watch('trackIds') as string[] | undefined) ?? [];
+                const tracksById = new Map(
+                  availableTracks.map(t => [t.id, t] as const)
+                );
+                const relevant = picked
+                  .map(id => tracksById.get(id))
+                  .filter((t): t is (typeof availableTracks)[number] => !!t)
+                  .filter(
+                    t =>
+                      !!t.prompt ||
+                      (t.customQuestions && t.customQuestions.length > 0) ||
+                      (t.requiredArtifacts && t.requiredArtifacts.length > 0)
+                  );
+                if (relevant.length === 0) return null;
+                return (
+                  <FormField
+                    control={form.control}
+                    name='trackAnswers'
+                    render={({ field }) => {
+                      const value =
+                        (field.value as
+                          | Record<
+                              string,
+                              {
+                                promptAnswer?: string;
+                                customAnswers?: Record<string, string>;
+                                artifacts?: Record<string, string>;
+                              }
+                            >
+                          | undefined) ?? {};
+                      const setAnswer = (
+                        trackId: string,
+                        patch: Partial<{
+                          promptAnswer: string;
+                          customAnswers: Record<string, string>;
+                          artifacts: Record<string, string>;
+                        }>
+                      ) => {
+                        const prev = value[trackId] ?? {};
+                        field.onChange({
+                          ...value,
+                          [trackId]: { ...prev, ...patch },
+                        });
+                      };
+                      return (
+                        <FormItem className='space-y-3'>
+                          <FormLabel className='text-white'>
+                            Track answers{' '}
+                            <span className='text-xs font-normal text-gray-500'>
+                              ({relevant.length} of your selected{' '}
+                              {relevant.length === 1 ? 'track' : 'tracks'} needs
+                              more info)
+                            </span>
+                          </FormLabel>
+                          {relevant.map(track => {
+                            const answer = value[track.id] ?? {};
+                            return (
+                              <div
+                                key={track.id}
+                                className='space-y-3 rounded-md border border-gray-800 bg-gray-900/40 p-4'
+                              >
+                                <p className='text-sm font-semibold text-white'>
+                                  {track.name}
+                                </p>
+                                {track.prompt && (
+                                  <div className='space-y-1'>
+                                    <label className='text-xs font-medium text-gray-300'>
+                                      {track.prompt}{' '}
+                                      <span className='text-red-400'>*</span>
+                                    </label>
+                                    <Textarea
+                                      value={answer.promptAnswer ?? ''}
+                                      maxLength={2000}
+                                      onChange={e =>
+                                        setAnswer(track.id, {
+                                          promptAnswer: e.target.value,
+                                        })
+                                      }
+                                      placeholder='Your answer...'
+                                      className='min-h-[80px] border-gray-700 bg-gray-800/50 text-white placeholder:text-gray-500'
+                                    />
+                                  </div>
+                                )}
+                                {(track.customQuestions ?? []).map(q => {
+                                  const v = answer.customAnswers?.[q.id] ?? '';
+                                  const onChange = (val: string) =>
+                                    setAnswer(track.id, {
+                                      customAnswers: {
+                                        ...(answer.customAnswers ?? {}),
+                                        [q.id]: val,
+                                      },
+                                    });
+                                  return (
+                                    <div key={q.id} className='space-y-1'>
+                                      <label className='text-xs font-medium text-gray-300'>
+                                        {q.label}
+                                        {q.required && (
+                                          <span className='text-red-400'>
+                                            {' '}
+                                            *
+                                          </span>
+                                        )}
+                                      </label>
+                                      {q.type === 'long' ? (
+                                        <Textarea
+                                          value={v}
+                                          maxLength={q.maxLength ?? 1000}
+                                          onChange={e =>
+                                            onChange(e.target.value)
+                                          }
+                                          className='min-h-[60px] border-gray-700 bg-gray-800/50 text-white placeholder:text-gray-500'
+                                        />
+                                      ) : (
+                                        <Input
+                                          type={
+                                            q.type === 'url' ? 'url' : 'text'
+                                          }
+                                          value={v}
+                                          maxLength={
+                                            q.maxLength ??
+                                            (q.type === 'url' ? 500 : 200)
+                                          }
+                                          onChange={e =>
+                                            onChange(e.target.value)
+                                          }
+                                          placeholder={
+                                            q.type === 'url'
+                                              ? 'https://...'
+                                              : ''
+                                          }
+                                          className='border-gray-700 bg-gray-800/50 text-white placeholder:text-gray-500'
+                                        />
+                                      )}
+                                    </div>
+                                  );
+                                })}
+                                {(track.requiredArtifacts ?? []).map(a => {
+                                  const v = answer.artifacts?.[a.id] ?? '';
+                                  return (
+                                    <div key={a.id} className='space-y-1'>
+                                      <label className='text-xs font-medium text-gray-300'>
+                                        {a.label}{' '}
+                                        <span className='text-[10px] tracking-widest text-gray-500 uppercase'>
+                                          {a.type}
+                                        </span>
+                                        {a.required && (
+                                          <span className='text-red-400'>
+                                            {' '}
+                                            *
+                                          </span>
+                                        )}
+                                      </label>
+                                      <Input
+                                        type='url'
+                                        value={v}
+                                        maxLength={500}
+                                        onChange={e =>
+                                          setAnswer(track.id, {
+                                            artifacts: {
+                                              ...(answer.artifacts ?? {}),
+                                              [a.id]: e.target.value,
+                                            },
+                                          })
+                                        }
+                                        placeholder='https://...'
+                                        className='border-gray-700 bg-gray-800/50 text-white placeholder:text-gray-500'
+                                      />
+                                    </div>
+                                  );
+                                })}
+                              </div>
+                            );
+                          })}
+                        </FormItem>
+                      );
+                    }}
+                  />
+                );
+              })()}
           </div>
         );
 
@@ -1357,6 +1888,162 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
                         )}
                       </div>
                     </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                );
+              }}
+            />
+
+            <FormField
+              control={form.control}
+              name='screenshots'
+              render={({ field }) => {
+                const value: string[] = field.value ?? [];
+                const setAt = (i: number, v: string) => {
+                  const next = value.slice();
+                  next[i] = v;
+                  field.onChange(next.filter(u => u !== undefined));
+                };
+                const remove = (i: number) =>
+                  field.onChange(value.filter((_, j) => j !== i));
+                const add = () => {
+                  if (value.length >= 5) return;
+                  field.onChange([...value, '']);
+                };
+                return (
+                  <FormItem>
+                    <FormLabel className='text-white'>
+                      Screenshots{' '}
+                      <span className='text-xs font-normal text-gray-500'>
+                        (up to 5, public image URLs)
+                      </span>
+                    </FormLabel>
+                    <div className='space-y-2'>
+                      {value.map((url, i) => (
+                        <div
+                          key={`screenshot-${i}`}
+                          className='flex items-center gap-2'
+                        >
+                          <Input
+                            placeholder='https://...'
+                            value={url}
+                            onChange={e => setAt(i, e.target.value)}
+                            className='border-gray-700 bg-gray-800/50 text-white placeholder:text-gray-500'
+                          />
+                          <Button
+                            type='button'
+                            variant='ghost'
+                            size='sm'
+                            onClick={() => remove(i)}
+                            className='text-red-400 hover:bg-red-500/20'
+                            aria-label='Remove screenshot'
+                          >
+                            <X className='h-4 w-4' />
+                          </Button>
+                        </div>
+                      ))}
+                      {value.length < 5 && (
+                        <Button
+                          type='button'
+                          variant='outline'
+                          size='sm'
+                          onClick={add}
+                          className='border-gray-700'
+                        >
+                          + Add screenshot
+                        </Button>
+                      )}
+                    </div>
+                    <FormDescription className='text-gray-400'>
+                      First screenshot is used as the hero image on judge /
+                      public views.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                );
+              }}
+            />
+
+            <FormField
+              control={form.control}
+              name='builtWith'
+              render={({ field }) => {
+                const value: string[] = field.value ?? [];
+                const [draft, setDraft] = [
+                  // useState-like inline; the parent component owns the
+                  // input through field state instead of an extra hook.
+                  // Keeping the chip-list lean — Enter or comma adds.
+                  '' as string,
+                  (_: string) => {},
+                ];
+                void setDraft;
+                void draft;
+                const addRaw = (raw: string) => {
+                  const tags = raw
+                    .split(',')
+                    .map(t => t.trim())
+                    .filter(t => t.length > 0 && t.length <= 40);
+                  if (tags.length === 0) return;
+                  const next = Array.from(new Set([...value, ...tags])).slice(
+                    0,
+                    20
+                  );
+                  field.onChange(next);
+                };
+                const remove = (i: number) =>
+                  field.onChange(value.filter((_, j) => j !== i));
+                return (
+                  <FormItem>
+                    <FormLabel className='text-white'>
+                      Built with{' '}
+                      <span className='text-xs font-normal text-gray-500'>
+                        (tech stack tags, up to 20)
+                      </span>
+                    </FormLabel>
+                    <div className='space-y-2'>
+                      {value.length > 0 && (
+                        <div className='flex flex-wrap gap-2'>
+                          {value.map((tag, i) => (
+                            <Badge
+                              key={`${tag}-${i}`}
+                              variant='outline'
+                              className='gap-1 border-gray-700 text-white'
+                            >
+                              {tag}
+                              <button
+                                type='button'
+                                onClick={() => remove(i)}
+                                className='ml-1 rounded-full p-0.5 text-gray-400 hover:bg-gray-700 hover:text-white'
+                                aria-label={`Remove ${tag}`}
+                              >
+                                <X className='h-3 w-3' />
+                              </button>
+                            </Badge>
+                          ))}
+                        </div>
+                      )}
+                      <Input
+                        placeholder='Soroban, Stellar SDK, Next.js — comma or Enter to add'
+                        className='border-gray-700 bg-gray-800/50 text-white placeholder:text-gray-500'
+                        onKeyDown={e => {
+                          const target = e.currentTarget;
+                          if (e.key === 'Enter' || e.key === ',') {
+                            e.preventDefault();
+                            addRaw(target.value);
+                            target.value = '';
+                          }
+                        }}
+                        onBlur={e => {
+                          if (e.currentTarget.value.trim()) {
+                            addRaw(e.currentTarget.value);
+                            e.currentTarget.value = '';
+                          }
+                        }}
+                      />
+                    </div>
+                    <FormDescription className='text-gray-400'>
+                      {value.length} / 20 tags
+                    </FormDescription>
                     <FormMessage />
                   </FormItem>
                 );
@@ -1540,6 +2227,48 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
                   </p>
                   <p className='text-white'>{form.watch('description')}</p>
                 </div>
+                {tracksEnabled &&
+                  (() => {
+                    const picked =
+                      (form.watch('trackIds') as string[] | undefined) ?? [];
+                    if (picked.length === 0) {
+                      return (
+                        <div>
+                          <p className='text-sm font-medium text-gray-400'>
+                            Tracks
+                          </p>
+                          <p className='text-sm text-gray-500'>
+                            None — your submission will be considered for
+                            overall placements only.
+                          </p>
+                        </div>
+                      );
+                    }
+                    const byId = new Map(
+                      availableTracks.map(t => [t.id, t] as const)
+                    );
+                    return (
+                      <div>
+                        <p className='text-sm font-medium text-gray-400'>
+                          Tracks
+                        </p>
+                        <div className='mt-1 flex flex-wrap gap-2'>
+                          {picked.map(id => {
+                            const t = byId.get(id);
+                            return (
+                              <Badge
+                                key={id}
+                                variant='outline'
+                                className='text-white'
+                              >
+                                {t?.name ?? id}
+                              </Badge>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    );
+                  })()}
                 {(() => {
                   const reviewLogo =
                     (isValidImageUrl(form.watch('logo'))
@@ -1632,6 +2361,99 @@ const SubmissionFormContent: React.FC<SubmissionFormContentProps> = ({
                   </div>
                 )}
               </div>
+            </div>
+
+            {/* Compliance.
+                - NEW submissions: license + attestation are required.
+                  Submit is hard-gated client-side and the asterisks
+                  show on the labels.
+                - Existing submissions (created before Phase A): both
+                  fields are optional, the asterisks hide, and submit
+                  isn't blocked. Filling them in still works and the
+                  data round-trips. */}
+            <div className='space-y-4 rounded-lg border border-gray-700 bg-gray-800/50 p-6'>
+              <h3 className='text-lg font-semibold text-white'>
+                License & attestation
+                {submissionId && (
+                  <span className='ml-2 text-xs font-normal text-gray-400'>
+                    (optional for existing submissions)
+                  </span>
+                )}
+              </h3>
+              <FormField
+                control={form.control}
+                name='license'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className='text-white'>
+                      License{' '}
+                      {!submissionId && <span className='text-red-400'>*</span>}
+                    </FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value ?? ''}
+                    >
+                      <FormControl>
+                        <SelectTrigger className='border-gray-700 bg-gray-900/50 text-white'>
+                          <SelectValue placeholder='Pick a license' />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent className='border-gray-700 bg-gray-800 text-white'>
+                        {LICENSE_OPTIONS.map(opt => (
+                          <SelectItem key={opt} value={opt}>
+                            {opt === 'PROPRIETARY'
+                              ? 'Proprietary / All rights reserved'
+                              : opt === 'OTHER'
+                                ? 'Other (specify in description)'
+                                : opt}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormDescription className='text-gray-400'>
+                      The license your code ships under. Pick MIT or Apache-2.0
+                      if you want maximum compatibility.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name='codeAttested'
+                render={({ field }) => (
+                  <FormItem>
+                    <label className='flex cursor-pointer items-start gap-3 rounded-md border border-gray-700 bg-gray-900/40 p-3'>
+                      <input
+                        type='checkbox'
+                        checked={!!field.value}
+                        onChange={e => field.onChange(e.target.checked)}
+                        className='accent-primary mt-0.5 h-4 w-4'
+                      />
+                      <div className='flex-1'>
+                        <p className='text-sm font-medium text-white'>
+                          I confirm the code is original or properly attributed.
+                          {!submissionId && (
+                            <>
+                              {' '}
+                              <span className='text-red-400'>*</span>
+                            </>
+                          )}
+                        </p>
+                        <p className='mt-0.5 text-xs text-gray-400'>
+                          Any third-party libraries, assets, or pre-existing
+                          work used in this project are either
+                          MIT/Apache-compatible or have explicit credit in your
+                          README. The organizer may audit this before paying out
+                          prizes.
+                        </p>
+                      </div>
+                    </label>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
             </div>
           </div>
         );

--- a/components/hackathons/winners/WinnersTab.tsx
+++ b/components/hackathons/winners/WinnersTab.tsx
@@ -3,8 +3,8 @@
 import React from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { HackathonWinner } from '@/lib/api/hackathons';
-import { Trophy, ArrowUpRight } from 'lucide-react';
+import { HackathonWinner, HackathonTrackWinner } from '@/lib/api/hackathons';
+import { Trophy, ArrowUpRight, Layers } from 'lucide-react';
 import { motion } from 'motion/react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
@@ -22,11 +22,17 @@ import {
 
 interface WinnersTabProps {
   winners: HackathonWinner[];
+  /** Track-based winners (Best UI/UX, Best Technical, etc.). Empty when
+   *  the hackathon uses OVERALL_ONLY prize structure. */
+  trackWinners?: HackathonTrackWinner[];
   hackathonSlug?: string; // Intentionally retained for API consistency/future use
 }
 
-export const WinnersTab = ({ winners }: WinnersTabProps) => {
-  if (!winners || winners.length === 0) {
+export const WinnersTab = ({ winners, trackWinners }: WinnersTabProps) => {
+  const hasOverall = winners && winners.length > 0;
+  const hasTracks = trackWinners && trackWinners.length > 0;
+
+  if (!hasOverall && !hasTracks) {
     return (
       <div className='flex min-h-[400px] flex-col items-center justify-center text-center'>
         <Trophy className='mb-4 h-16 w-16 text-white/20' />
@@ -42,7 +48,7 @@ export const WinnersTab = ({ winners }: WinnersTabProps) => {
   }
 
   // Sort by rank
-  const sortedWinners = [...winners].sort((a, b) => a.rank - b.rank);
+  const sortedWinners = [...(winners ?? [])].sort((a, b) => a.rank - b.rank);
 
   // Split into podium (1-3) and others
   const podiumWinners = sortedWinners.filter(w => w.rank <= 3);
@@ -99,7 +105,117 @@ export const WinnersTab = ({ winners }: WinnersTabProps) => {
           ))}
         </div>
       )}
+
+      {/* Track Winners */}
+      {hasTracks && (
+        <div className='space-y-6'>
+          <div className='flex items-center gap-2'>
+            <Layers className='text-primary h-5 w-5' />
+            <h3 className='text-xl font-semibold text-white'>Track Winners</h3>
+          </div>
+          <div className='grid gap-6 sm:grid-cols-2 lg:grid-cols-3'>
+            {trackWinners!.map(trackWinner => (
+              <TrackWinnerCard
+                key={`${trackWinner.submissionId}-${trackWinner.track.id}`}
+                trackWinner={trackWinner}
+              />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
+  );
+};
+
+const TrackWinnerCard = ({
+  trackWinner,
+}: {
+  trackWinner: HackathonTrackWinner;
+}) => {
+  const projectUrl = trackWinner.submissionId
+    ? `/projects/${trackWinner.submissionId}?type=submission`
+    : null;
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.4 }}
+      className='bg-background-card relative w-full overflow-hidden rounded-xl border border-white/5 p-5 transition-all duration-300 hover:border-white/10'
+    >
+      <div className='mb-3 flex flex-wrap items-center justify-center gap-2'>
+        <Badge variant='outline' className='text-primary border-primary/40'>
+          {trackWinner.track.name}
+        </Badge>
+        {trackWinner.prize && (
+          <div className='flex items-center gap-1.5 rounded-full border border-[#2775CA]/20 bg-[#2775CA]/10 px-3 py-1'>
+            <Trophy className='h-4 w-4 text-yellow-500' />
+            <span className='text-xs font-bold text-white uppercase'>
+              {(() => {
+                const match = trackWinner.prize.match(
+                  /^(?:USDC)?\s*(\d+(?:\.\d+)?)\s*(?:USDC)?$/i
+                );
+                return match ? `${match[1]} USDC` : trackWinner.prize;
+              })()}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className='mb-4 flex flex-col items-center justify-center gap-3'>
+        <div className='flex -space-x-3'>
+          {trackWinner.participants.map((p, i) => {
+            const profileUrl = p.username ? `/profile/${p.username}` : null;
+            const AvatarElement = (
+              <Avatar
+                className={cn(
+                  'border-background h-14 w-14 border-2 shadow-xl',
+                  profileUrl ? 'transition-transform hover:scale-105' : ''
+                )}
+              >
+                <AvatarImage src={p.avatar} alt={p.username || 'Participant'} />
+                <AvatarFallback className='bg-gray-800 text-base text-white uppercase'>
+                  {p.username?.charAt(0) || '?'}
+                </AvatarFallback>
+              </Avatar>
+            );
+            return profileUrl ? (
+              <Link
+                key={`${p.username}-${i}`}
+                href={profileUrl}
+                className='z-[1]'
+              >
+                {AvatarElement}
+              </Link>
+            ) : (
+              <div key={`${p.username}-${i}`} className='z-[1]'>
+                {AvatarElement}
+              </div>
+            );
+          })}
+        </div>
+        {trackWinner.teamName && (
+          <p className='text-sm text-gray-400'>{trackWinner.teamName}</p>
+        )}
+      </div>
+
+      {projectUrl ? (
+        <Link href={projectUrl}>
+          <div className='flex items-center justify-between rounded-lg border border-gray-900 bg-black/20 p-2 transition-colors hover:bg-black/40'>
+            <p className='line-clamp-1 text-sm font-medium text-white'>
+              {trackWinner.projectName}
+            </p>
+            <ArrowUpRight className='h-4 w-4 text-gray-500' />
+          </div>
+        </Link>
+      ) : (
+        <div className='rounded-lg border border-gray-900 bg-black/20 p-2'>
+          <p className='line-clamp-1 text-sm font-medium text-white'>
+            {trackWinner.projectName}
+          </p>
+        </div>
+      )}
+    </motion.div>
   );
 };
 

--- a/components/organization/hackathons/new/NewHackathonTab.tsx
+++ b/components/organization/hackathons/new/NewHackathonTab.tsx
@@ -261,6 +261,8 @@ export default function NewHackathonTab({
               onSave={saveRewardsStep}
               initialData={stepData.rewards}
               isLoading={loadingStates.rewards}
+              organizationId={derivedOrgId}
+              hackathonId={draftId ?? undefined}
             />
           </TabsContent>
 

--- a/components/organization/hackathons/new/tabs/RewardsTab.tsx
+++ b/components/organization/hackathons/new/tabs/RewardsTab.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useMemo, useEffect, useRef } from 'react';
+import React, {
+  useState,
+  useMemo,
+  useEffect,
+  useRef,
+  useCallback,
+} from 'react';
 import { BoundlessButton } from '@/components/buttons';
 import { toast } from 'sonner';
 import {
@@ -63,6 +69,15 @@ import {
   useSortable,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { listOrganizerTracks } from '@/lib/api/hackathons/tracks';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import TracksSettingsTab from '@/components/organization/hackathons/settings/TracksSettingsTab';
 
 interface RewardsTabProps {
   onContinue?: () => void;
@@ -72,6 +87,10 @@ interface RewardsTabProps {
   /** Required to call the financial preview dry-run endpoint */
   organizationId?: string;
   hackathonId?: string;
+  /** Tracks the organizer has created. Passed in so the parent can keep
+   *  ownership of the fetch + react-query / refresh logic.
+   *  Defaults to [] which collapses the track UI back to overall-only. */
+  availableTracks?: TrackOption[];
 }
 
 const PRIZE_PRESETS = {
@@ -138,6 +157,17 @@ interface PrizeTierProps {
   canRemove: boolean;
   control: Control<RewardsFormData>;
   totalTiers: number;
+  /** Tracks the organizer has created on this hackathon. */
+  availableTracks: TrackOption[];
+  /** When true, tier kind picker + track binding UI is visible. */
+  tracksEnabled: boolean;
+}
+
+export interface TrackOption {
+  id: string;
+  name: string;
+  slug: string;
+  isArchived: boolean;
 }
 
 // ─── Sortable Prize Tier ─────────────────────────────────────────────────────
@@ -148,6 +178,8 @@ const PrizeTierComponent = ({
   canRemove,
   control,
   totalTiers,
+  availableTracks,
+  tracksEnabled,
 }: PrizeTierProps) => {
   const {
     attributes,
@@ -260,6 +292,75 @@ const PrizeTierComponent = ({
               </FormItem>
             )}
           />
+
+          {/* Tier kind + track binding (only when structure includes tracks) */}
+          {tracksEnabled && (
+            <div className='grid gap-3 rounded-md border border-zinc-800 bg-zinc-950/40 p-3 md:grid-cols-2'>
+              <FormField
+                control={control}
+                name={`prizeTiers.${index}.kind`}
+                render={({ field }) => (
+                  <FormItem className='space-y-1'>
+                    <label className='text-xs font-medium text-zinc-400'>
+                      Tier kind
+                    </label>
+                    <FormControl>
+                      <select
+                        value={field.value ?? 'OVERALL'}
+                        onChange={e => {
+                          const next = e.target.value as 'OVERALL' | 'TRACK';
+                          field.onChange(next);
+                        }}
+                        className='h-9 w-full rounded-md border border-zinc-800 bg-zinc-900/50 px-2 text-sm text-white'
+                      >
+                        <option value='OVERALL'>Overall placement</option>
+                        <option value='TRACK'>Track</option>
+                      </select>
+                    </FormControl>
+                    <FormMessage className='text-xs text-red-500' />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={control}
+                name={`prizeTiers.${index}.trackId`}
+                render={({ field }) => {
+                  const isTrack =
+                    (tier?.kind as string | undefined) === 'TRACK';
+                  return (
+                    <FormItem className='space-y-1'>
+                      <label className='text-xs font-medium text-zinc-400'>
+                        Track
+                      </label>
+                      <FormControl>
+                        <select
+                          value={field.value ?? ''}
+                          onChange={e =>
+                            field.onChange(e.target.value || undefined)
+                          }
+                          disabled={!isTrack}
+                          className='h-9 w-full rounded-md border border-zinc-800 bg-zinc-900/50 px-2 text-sm text-white disabled:opacity-50'
+                        >
+                          <option value=''>
+                            {isTrack ? 'Select a track…' : '—'}
+                          </option>
+                          {availableTracks
+                            .filter(t => !t.isArchived || t.id === field.value)
+                            .map(t => (
+                              <option key={t.id} value={t.id}>
+                                {t.name}
+                                {t.isArchived ? ' (archived)' : ''}
+                              </option>
+                            ))}
+                        </select>
+                      </FormControl>
+                      <FormMessage className='text-xs text-red-500' />
+                    </FormItem>
+                  );
+                }}
+              />
+            </div>
+          )}
         </div>
 
         {/* Delete Button */}
@@ -602,7 +703,37 @@ export default function RewardsTab({
   isLoading = false,
   organizationId,
   hackathonId,
+  availableTracks: availableTracksProp,
 }: RewardsTabProps) {
+  // Tracks state. When the parent passes `availableTracks` we honor it
+  // and skip the internal fetch (settings page already maintains its own
+  // list). Otherwise we fetch + manage tracks ourselves so the new-
+  // hackathon wizard works without parent plumbing.
+  const [internalTracks, setInternalTracks] = useState<TrackOption[]>([]);
+  const availableTracks = availableTracksProp ?? internalTracks;
+  const refetchTracks = useCallback(async () => {
+    if (availableTracksProp) return; // parent owns this state
+    if (!organizationId || !hackathonId) return;
+    try {
+      const rows = await listOrganizerTracks(organizationId, hackathonId);
+      setInternalTracks(
+        rows.map(r => ({
+          id: r.id,
+          name: r.name,
+          slug: r.slug,
+          isArchived: r.isArchived,
+        }))
+      );
+    } catch {
+      // Best-effort: track UI degrades gracefully if the call fails.
+      setInternalTracks([]);
+    }
+  }, [availableTracksProp, organizationId, hackathonId]);
+  useEffect(() => {
+    refetchTracks();
+  }, [refetchTracks]);
+  const [manageTracksOpen, setManageTracksOpen] = useState(false);
+
   const [showPresets, setShowPresets] = useState(false);
   const [pendingPreset, setPendingPreset] = useState<
     keyof typeof PRIZE_PRESETS | null
@@ -633,15 +764,25 @@ export default function RewardsTab({
     if (initialData?.prizeTiers?.length) {
       return {
         ...initialData,
-        prizeTiers: initialData.prizeTiers.map((tier, idx) => ({
-          id: (tier as any).id || `tier-init-${idx}-${Date.now()}`,
-          place: tier.place || `${PLACE_LABELS[idx] || `${idx + 1}th`} Place`,
-          prizeAmount: String(tier.prizeAmount ?? '0'),
-          description: tier.description || '',
-          currency: tier.currency || 'USDC',
-          rank: Number(tier.rank ?? idx + 1),
-          passMark: Number((tier as any).passMark ?? 0),
-        })),
+        prizeTiers: initialData.prizeTiers.map((tier, idx) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const raw = tier as any;
+          return {
+            id: raw.id || `tier-init-${idx}-${Date.now()}`,
+            place: tier.place || `${PLACE_LABELS[idx] || `${idx + 1}th`} Place`,
+            prizeAmount: String(tier.prizeAmount ?? '0'),
+            description: tier.description || '',
+            currency: tier.currency || 'USDC',
+            rank: Number(tier.rank ?? idx + 1),
+            passMark: Number(raw.passMark ?? 0),
+            // Preserve track-binding fields when reloading a saved
+            // draft — without these the per-tier track picker shows
+            // blank even though the structure picker remembers the
+            // organizer's choice.
+            ...(raw.kind !== undefined && { kind: raw.kind }),
+            ...(raw.trackId !== undefined && { trackId: raw.trackId }),
+          };
+        }),
       };
     }
     return {
@@ -889,6 +1030,39 @@ export default function RewardsTab({
     form.formState.errors.prizeTiers?.message ||
     (form.formState.errors.prizeTiers?.root as any)?.message;
 
+  // Live structure picker value drives:
+  // - Whether per-tier kind/track UI is shown.
+  // - Whether the schema's superRefine rejects mismatched tiers.
+  const prizeStructure = useWatch({
+    control: form.control,
+    name: 'prizeStructure',
+    defaultValue: 'OVERALL_ONLY',
+  });
+  const tracksEnabled =
+    prizeStructure === 'OVERALL_AND_TRACKS' || prizeStructure === 'TRACKS_ONLY';
+  const hasTracks = availableTracks.some(t => !t.isArchived);
+
+  // Detect "tracks created but no tier is bound to them" — the most
+  // common reason the public page shows zero track prizes. Surfaces a
+  // banner with a direct CTA so organizers don't have to guess what
+  // step they missed.
+  const watchedTiers = useWatch({
+    control: form.control,
+    name: 'prizeTiers',
+    defaultValue: form.getValues('prizeTiers') || [],
+  });
+  const hasAnyTrackTier = (watchedTiers ?? []).some(t => t?.kind === 'TRACK');
+  const showTracksUnboundBanner =
+    tracksEnabled && hasTracks && !hasAnyTrackTier;
+  const boundTrackIds = new Set(
+    (watchedTiers ?? [])
+      .filter(t => t?.kind === 'TRACK' && t?.trackId)
+      .map(t => t!.trackId as string)
+  );
+  const unboundActiveTracks = availableTracks.filter(
+    t => !t.isArchived && !boundTrackIds.has(t.id)
+  );
+
   return (
     <Form {...form}>
       {/* onSubmit is intentionally preventDefault — submission goes through handleContinueClick → AlertDialog confirm */}
@@ -900,6 +1074,156 @@ export default function RewardsTab({
             Set up prizes and drag to reorder winners
           </p>
         </div>
+
+        {/* Prize structure picker */}
+        <FormField
+          control={form.control}
+          name='prizeStructure'
+          render={({ field }) => (
+            <FormItem>
+              <div className='flex flex-col gap-3 rounded-lg border border-zinc-800 bg-zinc-900/30 p-4'>
+                <div className='flex items-start justify-between gap-3'>
+                  <div>
+                    <p className='text-sm font-medium text-white'>
+                      Prize structure
+                    </p>
+                    <p className='mt-0.5 text-xs text-zinc-500'>
+                      Overall only is the legacy default. Switch to Overall +
+                      Tracks for things like Best UI/UX alongside 1st/2nd/3rd.
+                    </p>
+                  </div>
+                  {organizationId && hackathonId && tracksEnabled && (
+                    <Button
+                      type='button'
+                      variant='outline'
+                      size='sm'
+                      onClick={() => setManageTracksOpen(true)}
+                      className='shrink-0'
+                    >
+                      <Plus className='h-3.5 w-3.5' />
+                      {hasTracks ? 'Manage tracks' : 'Add tracks'}
+                    </Button>
+                  )}
+                </div>
+                <div className='grid gap-2 md:grid-cols-3'>
+                  {(
+                    [
+                      {
+                        value: 'OVERALL_ONLY',
+                        title: 'Overall only',
+                        hint: '1st, 2nd, 3rd. No tracks.',
+                      },
+                      {
+                        value: 'OVERALL_AND_TRACKS',
+                        title: 'Overall + Tracks',
+                        hint: 'Top placements + category prizes.',
+                      },
+                      {
+                        value: 'TRACKS_ONLY',
+                        title: 'Tracks only',
+                        hint: 'Every prize is a track.',
+                      },
+                    ] as const
+                  ).map(opt => {
+                    const active =
+                      (field.value ?? 'OVERALL_ONLY') === opt.value;
+                    return (
+                      <button
+                        key={opt.value}
+                        type='button'
+                        onClick={() => field.onChange(opt.value)}
+                        className={cn(
+                          'rounded-lg border p-3 text-left transition-colors',
+                          active
+                            ? 'border-primary bg-primary/10'
+                            : 'border-zinc-800 bg-zinc-950/30 hover:border-zinc-700'
+                        )}
+                      >
+                        <p
+                          className={cn(
+                            'text-sm font-medium',
+                            active ? 'text-primary' : 'text-white'
+                          )}
+                        >
+                          {opt.title}
+                        </p>
+                        <p className='mt-0.5 text-xs text-zinc-500'>
+                          {opt.hint}
+                        </p>
+                      </button>
+                    );
+                  })}
+                </div>
+                {tracksEnabled && !hasTracks && (
+                  <p className='flex items-center gap-2 rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-300'>
+                    <Info className='h-3.5 w-3.5' />
+                    {organizationId && hackathonId
+                      ? 'No tracks created yet. Click "Add tracks" to create them, then bind tiers to each one below.'
+                      : 'No tracks created yet. Create tracks in the Tracks tab first, then come back here to bind tiers to them.'}
+                  </p>
+                )}
+                {tracksEnabled && hasTracks && (
+                  <p className='text-xs text-zinc-500'>
+                    {availableTracks.filter(t => !t.isArchived).length} active
+                    track
+                    {availableTracks.filter(t => !t.isArchived).length === 1
+                      ? ''
+                      : 's'}{' '}
+                    available. Mark a tier&apos;s kind as &ldquo;Track&rdquo;
+                    below to bind it.
+                  </p>
+                )}
+                <FormMessage className='text-xs text-red-500' />
+              </div>
+            </FormItem>
+          )}
+        />
+
+        {/* Tracks-unbound warning. Common case: organizer set the
+            structure + created tracks, but forgot to mark any tier's
+            kind as TRACK. Without this banner the public page shows
+            zero track prizes and the cause isn't obvious. */}
+        {showTracksUnboundBanner && (
+          <div className='flex flex-col gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4'>
+            <div className='flex items-start gap-3'>
+              <Info className='mt-0.5 h-5 w-5 shrink-0 text-amber-400' />
+              <div className='space-y-1'>
+                <p className='text-sm font-medium text-amber-200'>
+                  Tracks created but no prize is bound to them
+                </p>
+                <p className='text-xs text-amber-300/80'>
+                  You have{' '}
+                  <span className='font-semibold'>
+                    {availableTracks.filter(t => !t.isArchived).length} track
+                    {availableTracks.filter(t => !t.isArchived).length === 1
+                      ? ''
+                      : 's'}
+                  </span>{' '}
+                  set up, but none of your prize tiers below is marked as a
+                  Track. The public hackathon page will show only your overall
+                  placements. To award a track prize:
+                </p>
+                <ol className='list-decimal pl-4 text-xs text-amber-300/80'>
+                  <li>
+                    Pick a prize tier you want to be a track prize (or click
+                    &ldquo;Add Prize Tier&rdquo; for a new one).
+                  </li>
+                  <li>
+                    Change its <strong>Tier kind</strong> dropdown to{' '}
+                    <strong>Track</strong>.
+                  </li>
+                  <li>
+                    Pick the track from the dropdown next to it. Save when done.
+                  </li>
+                </ol>
+                <p className='pt-1 text-[11px] text-amber-300/60'>
+                  Tracks still waiting for a tier:{' '}
+                  {unboundActiveTracks.map(t => t.name).join(', ')}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Summary Card */}
         <PrizeSummary
@@ -1006,12 +1330,14 @@ export default function RewardsTab({
               {fields.map((tier, index) => (
                 <PrizeTierComponent
                   key={tier.id}
-                  tier={tier}
+                  tier={prizeTiers[index] ?? tier}
                   index={index}
                   onRemove={handleRemove}
                   canRemove={fields.length > 1}
                   control={form.control}
                   totalTiers={fields.length}
+                  availableTracks={availableTracks}
+                  tracksEnabled={tracksEnabled}
                 />
               ))}
             </SortableContext>
@@ -1073,6 +1399,40 @@ export default function RewardsTab({
           </BoundlessButton>
         </div>
       </form>
+
+      {/* Inline tracks management. Renders the same CRUD UX as the
+          settings-page Tracks tab inside a dialog so organizers can
+          create tracks from the new-hackathon wizard or from the
+          Rewards step without leaving context. */}
+      {organizationId && hackathonId && (
+        <Dialog
+          open={manageTracksOpen}
+          onOpenChange={open => {
+            setManageTracksOpen(open);
+            if (!open) {
+              // Re-fetch on close so the structure picker / per-tier
+              // dropdown reflects whatever the organizer did inside.
+              refetchTracks();
+            }
+          }}
+        >
+          <DialogContent className='max-w-3xl border-zinc-800 bg-zinc-950 p-0 text-white'>
+            <DialogHeader className='px-6 pt-6'>
+              <DialogTitle>Manage tracks</DialogTitle>
+              <DialogDescription>
+                Create, rename, or archive the tracks this hackathon awards
+                prizes for. Tier bindings below update automatically.
+              </DialogDescription>
+            </DialogHeader>
+            <div className='max-h-[70vh] overflow-y-auto px-6 pb-6'>
+              <TracksSettingsTab
+                organizationId={organizationId}
+                hackathonId={hackathonId}
+              />
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
 
       {/* ── Confirmation AlertDialog ── */}
       <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>

--- a/components/organization/hackathons/new/tabs/schemas/rewardsSchema.ts
+++ b/components/organization/hackathons/new/tabs/schemas/rewardsSchema.ts
@@ -1,25 +1,92 @@
 import { z } from 'zod';
 
-export const prizeTierSchema = z.object({
-  id: z.string(),
-  place: z.string().trim().min(1, 'Place is required'),
-  prizeAmount: z
-    .string()
-    .refine(
-      v => !isNaN(parseFloat(v)) && parseFloat(v) >= 0,
-      'Please enter a valid prize amount'
-    ),
-  description: z.string().optional(),
-  currency: z.string().optional().default('USDC'),
-  rank: z.number().int().min(1),
-  passMark: z.number().min(0).max(100),
-});
+export const prizeStructureSchema = z.enum([
+  'OVERALL_ONLY',
+  'OVERALL_AND_TRACKS',
+  'TRACKS_ONLY',
+]);
+export type PrizeStructure = z.infer<typeof prizeStructureSchema>;
 
-export const rewardsSchema = z.object({
-  prizeTiers: z
-    .array(prizeTierSchema)
-    .min(1, 'At least one prize tier is required'),
-});
+export const prizeTierKindSchema = z.enum(['OVERALL', 'TRACK']);
+export type PrizeTierKind = z.infer<typeof prizeTierKindSchema>;
+
+export const prizeTierSchema = z
+  .object({
+    id: z.string(),
+    place: z.string().trim().min(1, 'Place is required'),
+    prizeAmount: z
+      .string()
+      .refine(
+        v => !isNaN(parseFloat(v)) && parseFloat(v) >= 0,
+        'Please enter a valid prize amount'
+      ),
+    description: z.string().optional(),
+    currency: z.string().optional().default('USDC'),
+    rank: z.number().int().min(1),
+    passMark: z.number().min(0).max(100),
+    // Optional for backward compatibility — tiers without `kind` are
+    // treated as OVERALL by the backend.
+    kind: prizeTierKindSchema.optional(),
+    // Required when kind=TRACK. References a HackathonTrack on the same
+    // hackathon (organizer creates these in the Tracks tab).
+    trackId: z.string().optional(),
+  })
+  .superRefine((tier, ctx) => {
+    if (tier.kind === 'TRACK' && !tier.trackId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['trackId'],
+        message: 'Pick a track for this tier',
+      });
+    }
+    if (tier.kind !== 'TRACK' && tier.trackId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['trackId'],
+        message: 'Remove the track link or set tier kind to TRACK',
+      });
+    }
+  });
+
+export const rewardsSchema = z
+  .object({
+    prizeTiers: z
+      .array(prizeTierSchema)
+      .min(1, 'At least one prize tier is required'),
+    prizeStructure: prizeStructureSchema.optional(),
+    tracksMaxPerSubmission: z.number().int().min(1).max(20).optional(),
+  })
+  .superRefine((data, ctx) => {
+    const structure = data.prizeStructure ?? 'OVERALL_ONLY';
+    const hasTrackTier = data.prizeTiers.some(t => t.kind === 'TRACK');
+    const hasOverallTier = data.prizeTiers.some(
+      t => !t.kind || t.kind === 'OVERALL'
+    );
+    if (structure === 'OVERALL_ONLY' && hasTrackTier) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['prizeStructure'],
+        message:
+          'Switch the structure to Overall + Tracks (or Tracks only) when any tier is a track.',
+      });
+    }
+    if (structure === 'TRACKS_ONLY' && hasOverallTier) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['prizeTiers'],
+        message:
+          'Tracks-only mode requires every tier to be a track. Mark the overall tiers as tracks or switch structure.',
+      });
+    }
+    if (structure === 'OVERALL_AND_TRACKS' && !hasTrackTier) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['prizeTiers'],
+        message:
+          'Add at least one track tier — or switch back to Overall only.',
+      });
+    }
+  });
 
 export type PrizeTier = z.infer<typeof prizeTierSchema>;
 export type RewardsFormData = z.input<typeof rewardsSchema>;

--- a/components/organization/hackathons/settings/SubmissionVisibilitySettingsTab.tsx
+++ b/components/organization/hackathons/settings/SubmissionVisibilitySettingsTab.tsx
@@ -47,7 +47,8 @@ export default function SubmissionVisibilitySettingsTab({
     resolver: zodResolver(visibilitySettingsSchema),
     defaultValues: {
       submissionVisibility: SubmissionVisibility.PUBLIC,
-      submissionStatusVisibility: SubmissionStatusVisibility.ALL,
+      submissionStatusVisibility:
+        SubmissionStatusVisibility.ACCEPTED_SHORTLISTED,
     },
   });
 
@@ -61,7 +62,7 @@ export default function SubmissionVisibilitySettingsTab({
               response.data.submissionVisibility || SubmissionVisibility.PUBLIC,
             submissionStatusVisibility:
               response.data.submissionStatusVisibility ||
-              SubmissionStatusVisibility.ALL,
+              SubmissionStatusVisibility.ACCEPTED_SHORTLISTED,
           });
         }
       } catch (error) {
@@ -181,20 +182,6 @@ export default function SubmissionVisibilitySettingsTab({
                       <FormItem className='flex items-center space-y-0 space-x-3 rounded-lg border border-gray-900 p-4'>
                         <FormControl>
                           <RadioGroupItem
-                            value={SubmissionStatusVisibility.ALL}
-                          />
-                        </FormControl>
-                        <FormLabel className='cursor-pointer font-normal text-white'>
-                          <div className='font-medium'>All Submissions</div>
-                          <div className='text-xs text-gray-400'>
-                            Show all projects (accepted, shortlisted, and
-                            rejected).
-                          </div>
-                        </FormLabel>
-                      </FormItem>
-                      <FormItem className='flex items-center space-y-0 space-x-3 rounded-lg border border-gray-900 p-4'>
-                        <FormControl>
-                          <RadioGroupItem
                             value={
                               SubmissionStatusVisibility.ACCEPTED_SHORTLISTED
                             }
@@ -202,11 +189,45 @@ export default function SubmissionVisibilitySettingsTab({
                         </FormControl>
                         <FormLabel className='cursor-pointer font-normal text-white'>
                           <div className='font-medium'>
-                            Accepted/Shortlisted Only
+                            Shortlisted only (recommended)
                           </div>
                           <div className='text-xs text-gray-400'>
-                            Only show projects that have been approved or
-                            shortlisted.
+                            Submissions stay hidden until you shortlist them.
+                            Disqualified projects are never shown.
+                          </div>
+                        </FormLabel>
+                      </FormItem>
+                      <FormItem className='flex items-center space-y-0 space-x-3 rounded-lg border border-gray-900 p-4'>
+                        <FormControl>
+                          <RadioGroupItem
+                            value={
+                              SubmissionStatusVisibility.HIDDEN_UNTIL_RESULTS
+                            }
+                          />
+                        </FormControl>
+                        <FormLabel className='cursor-pointer font-normal text-white'>
+                          <div className='font-medium'>
+                            Hidden until results are announced
+                          </div>
+                          <div className='text-xs text-gray-400'>
+                            Submissions stay hidden from everyone (except the
+                            participants who made them and your team) until you
+                            publish results. Then only shortlisted projects
+                            appear.
+                          </div>
+                        </FormLabel>
+                      </FormItem>
+                      <FormItem className='flex items-center space-y-0 space-x-3 rounded-lg border border-gray-900 p-4'>
+                        <FormControl>
+                          <RadioGroupItem
+                            value={SubmissionStatusVisibility.ALL}
+                          />
+                        </FormControl>
+                        <FormLabel className='cursor-pointer font-normal text-white'>
+                          <div className='font-medium'>All submissions</div>
+                          <div className='text-xs text-gray-400'>
+                            Every submission is visible as soon as it&apos;s
+                            made. Disqualified projects are still hidden.
                           </div>
                         </FormLabel>
                       </FormItem>

--- a/components/organization/hackathons/settings/TracksSettingsTab.tsx
+++ b/components/organization/hackathons/settings/TracksSettingsTab.tsx
@@ -1,0 +1,931 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  Loader2,
+  Plus,
+  Pencil,
+  Trash2,
+  ArchiveRestore,
+  Users,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  bulkOptInAllSubmissions,
+  createTrack,
+  deleteTrack,
+  listOrganizerTracks,
+  updateTrack,
+  type CreateTrackRequest,
+  type HackathonTrack,
+  type TrackCustomQuestion,
+  type TrackEligibility,
+  type TrackRequiredArtifact,
+} from '@/lib/api/hackathons/tracks';
+import { extractApiErrorMessage } from '@/lib/api/api';
+
+interface TracksSettingsTabProps {
+  organizationId: string;
+  hackathonId: string;
+}
+
+const TRACK_TYPE_OPTIONS = [
+  { value: 'skill', label: 'Skill (e.g. Best UI/UX)' },
+  { value: 'technology', label: 'Technology (e.g. Best Use of X)' },
+  { value: 'theme', label: 'Theme (e.g. DeFi)' },
+  { value: 'special', label: 'Special Award' },
+] as const;
+
+const ELIGIBILITY_OPTIONS: Array<{
+  value: TrackEligibility;
+  label: string;
+  hint: string;
+}> = [
+  {
+    value: 'OPT_IN',
+    label: 'Opt-in',
+    hint: 'Submitters explicitly enter this track.',
+  },
+  {
+    value: 'OPEN',
+    label: 'Open',
+    hint: 'Every submission is auto-eligible. No opt-in row needed.',
+  },
+];
+
+interface TrackFormState {
+  id?: string;
+  name: string;
+  slug: string;
+  description: string;
+  type: string;
+  eligibility: TrackEligibility;
+  displayOrder: number;
+  // Phase B customization
+  prompt: string;
+  customQuestions: TrackCustomQuestion[];
+  requiredArtifacts: TrackRequiredArtifact[];
+}
+
+const emptyForm = (next: HackathonTrack[] = []): TrackFormState => ({
+  name: '',
+  slug: '',
+  description: '',
+  type: 'skill',
+  eligibility: 'OPT_IN',
+  // Default to (max existing + 10) so the new row lands at the end of the list.
+  displayOrder:
+    next.length > 0 ? Math.max(...next.map(t => t.displayOrder)) + 10 : 10,
+  prompt: '',
+  customQuestions: [],
+  requiredArtifacts: [],
+});
+
+// Generate a stable id used inside customQuestions / requiredArtifacts.
+// Doesn't need to be a real cuid; uniqueness within the track is enough.
+const tinyId = () =>
+  `q-${Math.random().toString(36).slice(2, 8)}${Date.now().toString(36).slice(-3)}`;
+
+export default function TracksSettingsTab({
+  organizationId,
+  hackathonId,
+}: TracksSettingsTabProps) {
+  const [tracks, setTracks] = useState<HackathonTrack[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [form, setForm] = useState<TrackFormState>(emptyForm());
+  const [confirmDelete, setConfirmDelete] = useState<HackathonTrack | null>(
+    null
+  );
+  // Retrofit dialog state. Populated when the organizer clicks the
+  // "Opt in all submissions" action — we confirm before firing the
+  // endpoint because it can touch every submission for the hackathon.
+  const [confirmBulkOptIn, setConfirmBulkOptIn] =
+    useState<HackathonTrack | null>(null);
+  const [bulkOptInBusy, setBulkOptInBusy] = useState(false);
+
+  const fetchTracks = useCallback(async () => {
+    setLoading(true);
+    try {
+      const rows = await listOrganizerTracks(organizationId, hackathonId);
+      setTracks(rows);
+    } catch (err) {
+      toast.error(extractApiErrorMessage(err) ?? 'Failed to load tracks');
+    } finally {
+      setLoading(false);
+    }
+  }, [organizationId, hackathonId]);
+
+  useEffect(() => {
+    fetchTracks();
+  }, [fetchTracks]);
+
+  const openCreate = () => {
+    setForm(emptyForm(tracks));
+    setDialogOpen(true);
+  };
+
+  const openEdit = (track: HackathonTrack) => {
+    setForm({
+      id: track.id,
+      name: track.name,
+      slug: track.slug,
+      description: track.description ?? '',
+      type: track.type ?? '',
+      eligibility: track.eligibility,
+      displayOrder: track.displayOrder,
+      prompt: track.prompt ?? '',
+      customQuestions: track.customQuestions ?? [],
+      requiredArtifacts: track.requiredArtifacts ?? [],
+    });
+    setDialogOpen(true);
+  };
+
+  const closeDialog = () => {
+    if (saving) return;
+    setDialogOpen(false);
+  };
+
+  const handleSave = async () => {
+    if (!form.name.trim()) {
+      toast.error('Track name is required');
+      return;
+    }
+    setSaving(true);
+    try {
+      // Strip blank labels before sending — leftover empty rows from
+      // accidental "Add" clicks shouldn't reach the backend.
+      const cleanedQuestions = form.customQuestions
+        .map(q => ({ ...q, label: q.label.trim() }))
+        .filter(q => q.label.length > 0);
+      const cleanedArtifacts = form.requiredArtifacts
+        .map(a => ({ ...a, label: a.label.trim() }))
+        .filter(a => a.label.length > 0);
+      if (form.id) {
+        const updated = await updateTrack(
+          organizationId,
+          hackathonId,
+          form.id,
+          {
+            name: form.name.trim(),
+            slug: form.slug.trim() || undefined,
+            description: form.description.trim() || undefined,
+            type: form.type || undefined,
+            eligibility: form.eligibility,
+            displayOrder: form.displayOrder,
+            prompt: form.prompt.trim() || undefined,
+            customQuestions: cleanedQuestions,
+            requiredArtifacts: cleanedArtifacts,
+          }
+        );
+        setTracks(prev =>
+          prev.map(t => (t.id === updated.id ? { ...t, ...updated } : t))
+        );
+        toast.success('Track updated');
+      } else {
+        const payload: CreateTrackRequest = {
+          name: form.name.trim(),
+          slug: form.slug.trim() || undefined,
+          description: form.description.trim() || undefined,
+          type: form.type || undefined,
+          eligibility: form.eligibility,
+          displayOrder: form.displayOrder,
+          prompt: form.prompt.trim() || undefined,
+          customQuestions: cleanedQuestions,
+          requiredArtifacts: cleanedArtifacts,
+        };
+        const created = await createTrack(organizationId, hackathonId, payload);
+        setTracks(prev =>
+          [...prev, created].sort((a, b) => a.displayOrder - b.displayOrder)
+        );
+        toast.success('Track created');
+      }
+      setDialogOpen(false);
+    } catch (err) {
+      toast.error(extractApiErrorMessage(err) ?? 'Failed to save track');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (track: HackathonTrack) => {
+    setSaving(true);
+    try {
+      await deleteTrack(organizationId, hackathonId, track.id);
+      // The backend hard-deletes when there are no entries, or archives.
+      // Re-fetch so the table reflects whichever happened.
+      await fetchTracks();
+      toast.success(
+        track.entryCount > 0
+          ? 'Track archived (had submissions)'
+          : 'Track deleted'
+      );
+    } catch (err) {
+      toast.error(extractApiErrorMessage(err) ?? 'Failed to delete track');
+    } finally {
+      setSaving(false);
+      setConfirmDelete(null);
+    }
+  };
+
+  const handleUnarchive = async (track: HackathonTrack) => {
+    setSaving(true);
+    try {
+      const updated = await updateTrack(organizationId, hackathonId, track.id, {
+        isArchived: false,
+      });
+      setTracks(prev =>
+        prev.map(t => (t.id === updated.id ? { ...t, ...updated } : t))
+      );
+      toast.success('Track restored');
+    } catch (err) {
+      toast.error(extractApiErrorMessage(err) ?? 'Failed to restore track');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleBulkOptIn = async (track: HackathonTrack) => {
+    setBulkOptInBusy(true);
+    try {
+      const result = await bulkOptInAllSubmissions(
+        organizationId,
+        hackathonId,
+        track.id
+      );
+      const parts: string[] = [];
+      if (result.added > 0) {
+        parts.push(
+          `${result.added} submission${result.added === 1 ? '' : 's'} added`
+        );
+      }
+      if (result.alreadyOptedIn > 0) {
+        parts.push(`${result.alreadyOptedIn} already in`);
+      }
+      if (result.skippedDisqualified > 0) {
+        parts.push(`${result.skippedDisqualified} disqualified skipped`);
+      }
+      const summary =
+        parts.length > 0 ? parts.join(' · ') : 'No changes needed';
+      toast.success(
+        `${result.trackName}: ${summary}${
+          result.newCap
+            ? ` · Per-submission cap raised to ${result.newCap}`
+            : ''
+        }`
+      );
+      // Refetch so the entryCount column reflects the new state.
+      await fetchTracks();
+    } catch (err) {
+      toast.error(extractApiErrorMessage(err) ?? 'Bulk opt-in failed');
+    } finally {
+      setBulkOptInBusy(false);
+      setConfirmBulkOptIn(null);
+    }
+  };
+
+  return (
+    <div className='bg-background-card rounded-xl border border-gray-900 p-6'>
+      <div className='mb-6 flex items-start justify-between gap-4'>
+        <div>
+          <h2 className='text-xl font-semibold text-white'>Tracks</h2>
+          <p className='mt-1 text-sm text-gray-400'>
+            Categorical prizes alongside overall placements (e.g. Best UI/UX,
+            Best Technical). Submitters opt into tracks at submission time;
+            winners are picked from each track&apos;s opted-in pool.
+          </p>
+        </div>
+        <Button onClick={openCreate} className='shrink-0'>
+          <Plus className='h-4 w-4' />
+          New track
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className='flex justify-center py-12'>
+          <Loader2 className='text-primary h-6 w-6 animate-spin' />
+        </div>
+      ) : tracks.length === 0 ? (
+        <div className='rounded-lg border border-dashed border-gray-800 px-6 py-12 text-center'>
+          <p className='text-sm text-gray-400'>
+            No tracks yet. Create one to unlock track-based prizes in the
+            Rewards tab.
+          </p>
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead>Eligibility</TableHead>
+              <TableHead className='text-right'>Entries</TableHead>
+              <TableHead className='text-right'>Order</TableHead>
+              <TableHead className='w-[120px] text-right'>Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {tracks.map(track => (
+              <TableRow
+                key={track.id}
+                className={track.isArchived ? 'opacity-60' : undefined}
+              >
+                <TableCell>
+                  <div className='font-medium text-white'>
+                    {track.name}
+                    {track.isArchived && (
+                      <Badge variant='outline' className='ml-2'>
+                        Archived
+                      </Badge>
+                    )}
+                  </div>
+                  <div className='text-xs text-gray-500'>/{track.slug}</div>
+                  {track.description && (
+                    <div className='mt-1 line-clamp-2 text-xs text-gray-400'>
+                      {track.description}
+                    </div>
+                  )}
+                </TableCell>
+                <TableCell className='text-sm text-gray-400'>
+                  {track.type ?? '—'}
+                </TableCell>
+                <TableCell>
+                  <Badge
+                    variant={
+                      track.eligibility === 'OPT_IN' ? 'default' : 'secondary'
+                    }
+                  >
+                    {track.eligibility === 'OPT_IN' ? 'Opt-in' : 'Open'}
+                  </Badge>
+                </TableCell>
+                <TableCell className='text-right text-gray-300 tabular-nums'>
+                  {track.entryCount}
+                </TableCell>
+                <TableCell className='text-right text-gray-400 tabular-nums'>
+                  {track.displayOrder}
+                </TableCell>
+                <TableCell>
+                  <div className='flex justify-end gap-1'>
+                    {/* Bulk opt-in: retrofit tool for hackathons where
+                        submissions already exist before tracks were
+                        added. Hidden for archived tracks and OPEN
+                        tracks (which auto-include everyone). */}
+                    {!track.isArchived && track.eligibility === 'OPT_IN' && (
+                      <Button
+                        size='icon'
+                        variant='ghost'
+                        onClick={() => setConfirmBulkOptIn(track)}
+                        disabled={saving || bulkOptInBusy}
+                        title='Opt in all existing submissions'
+                      >
+                        <Users className='h-4 w-4' />
+                      </Button>
+                    )}
+                    {track.isArchived ? (
+                      <Button
+                        size='icon'
+                        variant='ghost'
+                        onClick={() => handleUnarchive(track)}
+                        disabled={saving}
+                        title='Restore'
+                      >
+                        <ArchiveRestore className='h-4 w-4' />
+                      </Button>
+                    ) : (
+                      <Button
+                        size='icon'
+                        variant='ghost'
+                        onClick={() => openEdit(track)}
+                        disabled={saving}
+                        title='Edit'
+                      >
+                        <Pencil className='h-4 w-4' />
+                      </Button>
+                    )}
+                    <Button
+                      size='icon'
+                      variant='ghost'
+                      onClick={() => setConfirmDelete(track)}
+                      disabled={saving || track.isArchived}
+                      title='Delete'
+                    >
+                      <Trash2 className='h-4 w-4 text-red-500' />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <Dialog open={dialogOpen} onOpenChange={o => !o && closeDialog()}>
+        <DialogContent className='max-h-[85vh] max-w-2xl overflow-y-auto'>
+          <DialogHeader>
+            <DialogTitle>{form.id ? 'Edit track' : 'New track'}</DialogTitle>
+            <DialogDescription>
+              {form.id
+                ? 'Renaming a track keeps every existing entry attached.'
+                : 'Tracks show up in the submission form once participants can submit. You can rename, reorder, or archive later.'}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className='space-y-4'>
+            <div className='space-y-2'>
+              <Label htmlFor='track-name'>Name</Label>
+              <Input
+                id='track-name'
+                value={form.name}
+                onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+                placeholder='Best UI/UX'
+                maxLength={80}
+              />
+            </div>
+
+            <div className='space-y-2'>
+              <Label htmlFor='track-slug'>Slug</Label>
+              <Input
+                id='track-slug'
+                value={form.slug}
+                onChange={e => setForm(f => ({ ...f, slug: e.target.value }))}
+                placeholder='best-ui-ux (auto-generated if blank)'
+                maxLength={40}
+              />
+              <p className='text-xs text-gray-500'>
+                Lowercase letters, digits, hyphens. Used in URLs and stays
+                stable when you rename.
+              </p>
+            </div>
+
+            <div className='space-y-2'>
+              <Label htmlFor='track-description'>Description</Label>
+              <Textarea
+                id='track-description'
+                value={form.description}
+                onChange={e =>
+                  setForm(f => ({ ...f, description: e.target.value }))
+                }
+                placeholder='What does this track reward?'
+                maxLength={500}
+                rows={3}
+              />
+            </div>
+
+            <div className='grid grid-cols-2 gap-4'>
+              <div className='space-y-2'>
+                <Label>Type</Label>
+                <Select
+                  value={form.type || 'skill'}
+                  onValueChange={v => setForm(f => ({ ...f, type: v }))}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {TRACK_TYPE_OPTIONS.map(opt => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className='space-y-2'>
+                <Label htmlFor='track-order'>Display order</Label>
+                <Input
+                  id='track-order'
+                  type='number'
+                  min={0}
+                  value={form.displayOrder}
+                  onChange={e =>
+                    setForm(f => ({
+                      ...f,
+                      displayOrder: Number.isFinite(Number(e.target.value))
+                        ? Number(e.target.value)
+                        : 0,
+                    }))
+                  }
+                />
+              </div>
+            </div>
+
+            <div className='space-y-2'>
+              <Label>Eligibility</Label>
+              <Select
+                value={form.eligibility}
+                onValueChange={v =>
+                  setForm(f => ({
+                    ...f,
+                    eligibility: v as TrackEligibility,
+                  }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {ELIGIBILITY_OPTIONS.map(opt => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className='text-xs text-gray-500'>
+                {
+                  ELIGIBILITY_OPTIONS.find(o => o.value === form.eligibility)
+                    ?.hint
+                }
+              </p>
+            </div>
+
+            {/* Phase B per-track customization ------------------------- */}
+            <div className='space-y-2 border-t border-gray-800 pt-4'>
+              <Label htmlFor='track-prompt'>
+                Prompt{' '}
+                <span className='text-xs font-normal text-gray-500'>
+                  (optional, single open question)
+                </span>
+              </Label>
+              <Textarea
+                id='track-prompt'
+                value={form.prompt}
+                onChange={e => setForm(f => ({ ...f, prompt: e.target.value }))}
+                placeholder='Why does this project fit Best UI/UX?'
+                maxLength={500}
+                rows={2}
+              />
+              <p className='text-xs text-gray-500'>
+                Shown on the submission form when a submitter opts into this
+                track. When set, an answer is required.
+              </p>
+            </div>
+
+            <div className='space-y-2'>
+              <div className='flex items-center justify-between'>
+                <Label>Custom questions</Label>
+                <Button
+                  type='button'
+                  variant='outline'
+                  size='sm'
+                  onClick={() =>
+                    setForm(f => ({
+                      ...f,
+                      customQuestions: [
+                        ...f.customQuestions,
+                        {
+                          id: tinyId(),
+                          label: '',
+                          type: 'short',
+                          required: false,
+                        },
+                      ],
+                    }))
+                  }
+                >
+                  <Plus className='h-3.5 w-3.5' />
+                  Add question
+                </Button>
+              </div>
+              {form.customQuestions.length === 0 && (
+                <p className='text-xs text-gray-500'>
+                  No custom questions. Add one if you want sponsors / judges to
+                  see specific info per submission.
+                </p>
+              )}
+              {form.customQuestions.map((q, idx) => (
+                <div
+                  key={q.id}
+                  className='space-y-2 rounded-md border border-gray-800 bg-gray-900/40 p-3'
+                >
+                  <Input
+                    placeholder='Question label (e.g. "Primary audience")'
+                    value={q.label}
+                    maxLength={200}
+                    onChange={e =>
+                      setForm(f => ({
+                        ...f,
+                        customQuestions: f.customQuestions.map((qq, i) =>
+                          i === idx ? { ...qq, label: e.target.value } : qq
+                        ),
+                      }))
+                    }
+                  />
+                  <div className='grid grid-cols-3 gap-2'>
+                    <Select
+                      value={q.type}
+                      onValueChange={v =>
+                        setForm(f => ({
+                          ...f,
+                          customQuestions: f.customQuestions.map((qq, i) =>
+                            i === idx
+                              ? {
+                                  ...qq,
+                                  type: v as TrackCustomQuestion['type'],
+                                }
+                              : qq
+                          ),
+                        }))
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value='short'>Short text</SelectItem>
+                        <SelectItem value='long'>Long text</SelectItem>
+                        <SelectItem value='url'>URL</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <label className='flex items-center gap-2 rounded-md border border-gray-800 bg-gray-950/30 px-3 text-sm text-gray-300'>
+                      <input
+                        type='checkbox'
+                        checked={!!q.required}
+                        onChange={e =>
+                          setForm(f => ({
+                            ...f,
+                            customQuestions: f.customQuestions.map((qq, i) =>
+                              i === idx
+                                ? { ...qq, required: e.target.checked }
+                                : qq
+                            ),
+                          }))
+                        }
+                      />
+                      Required
+                    </label>
+                    <Button
+                      type='button'
+                      variant='ghost'
+                      size='sm'
+                      onClick={() =>
+                        setForm(f => ({
+                          ...f,
+                          customQuestions: f.customQuestions.filter(
+                            (_, i) => i !== idx
+                          ),
+                        }))
+                      }
+                      className='text-red-400 hover:bg-red-500/20'
+                    >
+                      <Trash2 className='h-4 w-4' />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className='space-y-2'>
+              <div className='flex items-center justify-between'>
+                <Label>Required artifacts</Label>
+                <Button
+                  type='button'
+                  variant='outline'
+                  size='sm'
+                  onClick={() =>
+                    setForm(f => ({
+                      ...f,
+                      requiredArtifacts: [
+                        ...f.requiredArtifacts,
+                        {
+                          id: tinyId(),
+                          label: '',
+                          type: 'url',
+                          required: true,
+                        },
+                      ],
+                    }))
+                  }
+                >
+                  <Plus className='h-3.5 w-3.5' />
+                  Add artifact
+                </Button>
+              </div>
+              {form.requiredArtifacts.length === 0 && (
+                <p className='text-xs text-gray-500'>
+                  No artifact requirements. Add one if the track expects a
+                  specific link (Figma file, demo deployment, contract address,
+                  etc.).
+                </p>
+              )}
+              {form.requiredArtifacts.map((a, idx) => (
+                <div
+                  key={a.id}
+                  className='space-y-2 rounded-md border border-gray-800 bg-gray-900/40 p-3'
+                >
+                  <Input
+                    placeholder='Artifact label (e.g. "Figma file URL")'
+                    value={a.label}
+                    maxLength={120}
+                    onChange={e =>
+                      setForm(f => ({
+                        ...f,
+                        requiredArtifacts: f.requiredArtifacts.map((aa, i) =>
+                          i === idx ? { ...aa, label: e.target.value } : aa
+                        ),
+                      }))
+                    }
+                  />
+                  <div className='grid grid-cols-3 gap-2'>
+                    <Select
+                      value={a.type}
+                      onValueChange={v =>
+                        setForm(f => ({
+                          ...f,
+                          requiredArtifacts: f.requiredArtifacts.map((aa, i) =>
+                            i === idx
+                              ? {
+                                  ...aa,
+                                  type: v as TrackRequiredArtifact['type'],
+                                }
+                              : aa
+                          ),
+                        }))
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value='url'>Generic URL</SelectItem>
+                        <SelectItem value='figma'>Figma</SelectItem>
+                        <SelectItem value='github'>GitHub repo</SelectItem>
+                        <SelectItem value='video'>Video</SelectItem>
+                        <SelectItem value='pdf'>PDF</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <label className='flex items-center gap-2 rounded-md border border-gray-800 bg-gray-950/30 px-3 text-sm text-gray-300'>
+                      <input
+                        type='checkbox'
+                        checked={!!a.required}
+                        onChange={e =>
+                          setForm(f => ({
+                            ...f,
+                            requiredArtifacts: f.requiredArtifacts.map(
+                              (aa, i) =>
+                                i === idx
+                                  ? { ...aa, required: e.target.checked }
+                                  : aa
+                            ),
+                          }))
+                        }
+                      />
+                      Required
+                    </label>
+                    <Button
+                      type='button'
+                      variant='ghost'
+                      size='sm'
+                      onClick={() =>
+                        setForm(f => ({
+                          ...f,
+                          requiredArtifacts: f.requiredArtifacts.filter(
+                            (_, i) => i !== idx
+                          ),
+                        }))
+                      }
+                      className='text-red-400 hover:bg-red-500/20'
+                    >
+                      <Trash2 className='h-4 w-4' />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant='ghost' onClick={closeDialog} disabled={saving}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={saving}>
+              {saving && <Loader2 className='h-4 w-4 animate-spin' />}
+              {form.id ? 'Save changes' : 'Create track'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog
+        open={!!confirmDelete}
+        onOpenChange={o => !o && setConfirmDelete(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete track?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {confirmDelete && confirmDelete.entryCount > 0 ? (
+                <>
+                  This track has{' '}
+                  <span className='font-medium text-white'>
+                    {confirmDelete.entryCount}
+                  </span>{' '}
+                  submission
+                  {confirmDelete.entryCount === 1 ? '' : 's'} attached. It will
+                  be archived instead of deleted so the existing entries stay
+                  intact. You can restore it later.
+                </>
+              ) : (
+                'This track has no submissions yet, so it will be permanently deleted.'
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={saving}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => confirmDelete && handleDelete(confirmDelete)}
+              disabled={saving}
+            >
+              {saving && <Loader2 className='h-4 w-4 animate-spin' />}
+              {confirmDelete && confirmDelete.entryCount > 0
+                ? 'Archive'
+                : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={!!confirmBulkOptIn}
+        onOpenChange={o => !o && !bulkOptInBusy && setConfirmBulkOptIn(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Opt in all submissions?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Every existing submission in this hackathon will be added to{' '}
+              <span className='font-medium text-white'>
+                {confirmBulkOptIn?.name}
+              </span>
+              . Submitters can still opt themselves out by editing their
+              submission. Disqualified submissions are skipped.
+              <br />
+              <br />
+              Use this when tracks were created after submissions already exist
+              — it lets the winner allocator pick from the full pool instead of
+              only the (small) set of submitters who opted in manually.
+              <br />
+              <br />
+              If a submission would end up in more tracks than the current
+              per-submission cap allows, the cap is auto-raised.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={bulkOptInBusy}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() =>
+                confirmBulkOptIn && handleBulkOptIn(confirmBulkOptIn)
+              }
+              disabled={bulkOptInBusy}
+            >
+              {bulkOptInBusy && <Loader2 className='h-4 w-4 animate-spin' />}
+              Opt in all submissions
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/hooks/hackathon/use-hackathon-queries.ts
+++ b/hooks/hackathon/use-hackathon-queries.ts
@@ -19,6 +19,7 @@ import {
 } from '@/lib/api/hackathons/participants';
 import { getExploreSubmissions } from '@/lib/api/hackathons';
 import { listAnnouncements } from '@/lib/api/hackathons/index';
+import { listTracks, type HackathonTrack } from '@/lib/api/hackathons/tracks';
 import {
   getTeams,
   createTeam,
@@ -82,6 +83,7 @@ export const hackathonKeys = {
     }
   ) => ['hackathon', 'exploreSubmissions', id, params] as const,
   winners: (idOrSlug: string) => ['hackathon', 'winners', idOrSlug] as const,
+  tracks: (idOrSlug: string) => ['hackathon', 'tracks', idOrSlug] as const,
   announcements: (idOrSlug: string) =>
     ['hackathon', 'announcements', idOrSlug] as const,
   teams: (idOrSlug: string, params?: GetTeamOptions) =>
@@ -253,6 +255,10 @@ export function useExploreSubmissions(
 
 /**
  * Fetch winners for a hackathon.
+ *
+ * Returns the legacy `HackathonWinner[]` shape for backward compatibility
+ * via the array-typed callers. Use `useHackathonWinnersWithTracks` when
+ * you also need the track-based prize winners.
  */
 export function useHackathonWinners(idOrSlug: string, enabled = true) {
   return useQuery<HackathonWinner[]>({
@@ -261,6 +267,58 @@ export function useHackathonWinners(idOrSlug: string, enabled = true) {
       const response = await getHackathonWinners(idOrSlug);
       if (!response.success || !response.data) return [];
       return response.data.winners;
+    },
+    enabled: !!idOrSlug && enabled,
+  });
+}
+
+/**
+ * Fetch winners + track winners for a hackathon. Used by the public
+ * winners view to render both the overall podium and per-track prizes.
+ */
+export function useHackathonWinnersWithTracks(
+  idOrSlug: string,
+  enabled = true
+) {
+  return useQuery<{
+    winners: HackathonWinner[];
+    trackWinners: import('@/lib/api/hackathons').HackathonTrackWinner[];
+  }>({
+    queryKey: [...hackathonKeys.winners(idOrSlug), 'with-tracks'],
+    queryFn: async () => {
+      const response = await getHackathonWinners(idOrSlug);
+      if (!response.success || !response.data) {
+        return { winners: [], trackWinners: [] };
+      }
+      return {
+        winners: response.data.winners ?? [],
+        trackWinners:
+          (
+            response.data as {
+              trackWinners?: import('@/lib/api/hackathons').HackathonTrackWinner[];
+            }
+          ).trackWinners ?? [],
+      };
+    },
+    enabled: !!idOrSlug && enabled,
+  });
+}
+
+/**
+ * Public list of tracks for a hackathon. Returns only active (non-archived)
+ * tracks. Used by the public detail page to render Track Prizes and the
+ * submission form to populate the track picker.
+ */
+export function useHackathonTracks(idOrSlug: string, enabled = true) {
+  return useQuery<HackathonTrack[]>({
+    queryKey: hackathonKeys.tracks(idOrSlug),
+    queryFn: async () => {
+      try {
+        return await listTracks(idOrSlug);
+      } catch {
+        // Best-effort: a 404 / network error shouldn't kill the page.
+        return [];
+      }
     },
     enabled: !!idOrSlug && enabled,
   });

--- a/lib/api/hackathons.ts
+++ b/lib/api/hackathons.ts
@@ -404,7 +404,14 @@ export type Hackathon = {
     currency?: string;
     description?: string;
     passMark?: number;
+    kind?: 'OVERALL' | 'TRACK';
+    trackId?: string;
   }>;
+
+  /** Track-based prize structure. Defaults to OVERALL_ONLY. */
+  prizeStructure?: 'OVERALL_ONLY' | 'OVERALL_AND_TRACKS' | 'TRACKS_ONLY';
+  /** Cap on tracks a submission may opt into. Defaults to 3. */
+  tracksMaxPerSubmission?: number;
 
   phases: Array<{
     id?: string;
@@ -736,6 +743,22 @@ export interface ParticipantSubmission {
     email: string;
   } | null;
   reviewedAt?: string | null;
+  /** Track entries opted into by the submitter. */
+  trackEntries?: Array<{
+    trackId: string;
+    trackSlug: string;
+    trackName: string;
+    wonRank: number | null;
+  }>;
+  /** Overall placement (1, 2, 3, ...). Null until results published. */
+  rank?: number | null;
+
+  // ── Phase A submission polish ──
+  tagline?: string;
+  builtWith?: string[];
+  screenshots?: string[];
+  license?: string;
+  codeAttestedAt?: string | null;
 }
 
 export interface ExploreSubmissionsResponse {
@@ -879,6 +902,25 @@ export interface CreateSubmissionRequest {
     twitter?: string;
     email?: string;
   };
+  /** Optional track opt-in. Capped by hackathon.tracksMaxPerSubmission. */
+  trackIds?: string[];
+
+  /** Per-track answers (Phase B). */
+  trackAnswers?: Record<
+    string,
+    {
+      promptAnswer?: string;
+      customAnswers?: Record<string, string>;
+      artifacts?: Record<string, string>;
+    }
+  >;
+
+  // ── Phase A submission polish ──
+  tagline?: string;
+  builtWith?: string[];
+  screenshots?: string[];
+  license?: string;
+  codeAttested?: boolean;
 }
 
 export interface UpdateSubmissionRequest extends CreateSubmissionRequest {
@@ -2963,9 +3005,32 @@ export interface HackathonWinner {
   slug?: string;
 }
 
+export interface HackathonTrackWinner {
+  track: {
+    id: string;
+    slug: string;
+    name: string;
+    description?: string;
+  };
+  /** Placement within the track. P1 currently emits 1 only. */
+  wonRank: number;
+  projectName: string;
+  logo: string | null;
+  teamName: string | null;
+  participants: Array<{
+    userId?: string;
+    username: string;
+    avatar?: string;
+  }>;
+  prize: string;
+  submissionId: string;
+}
+
 export interface GetHackathonWinnersResponse extends ApiResponse<{
   hackathonId: string;
   winners: HackathonWinner[];
+  /** Track winners; empty when the hackathon uses OVERALL_ONLY structure. */
+  trackWinners?: HackathonTrackWinner[];
 }> {
   success: true;
 }

--- a/lib/api/hackathons.ts
+++ b/lib/api/hackathons.ts
@@ -32,6 +32,7 @@ export enum SubmissionVisibility {
 export enum SubmissionStatusVisibility {
   ALL = 'ALL',
   ACCEPTED_SHORTLISTED = 'ACCEPTED_SHORTLISTED',
+  HIDDEN_UNTIL_RESULTS = 'HIDDEN_UNTIL_RESULTS',
 }
 
 export enum VenueType {

--- a/lib/api/hackathons/index.ts
+++ b/lib/api/hackathons/index.ts
@@ -78,3 +78,4 @@ export * from './teams';
 export * from './resources';
 export * from './announcements';
 export * from './partners';
+export * from './tracks';

--- a/lib/api/hackathons/tracks.ts
+++ b/lib/api/hackathons/tracks.ts
@@ -1,0 +1,204 @@
+import api from '../api';
+import { ApiResponse } from '../types';
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+export type TrackEligibility = 'OPT_IN' | 'OPEN';
+
+export type HackathonPrizeStructure =
+  | 'OVERALL_ONLY'
+  | 'OVERALL_AND_TRACKS'
+  | 'TRACKS_ONLY';
+
+export interface TrackCustomQuestion {
+  id: string;
+  label: string;
+  type: 'short' | 'long' | 'url';
+  maxLength?: number;
+  required?: boolean;
+}
+
+export interface TrackRequiredArtifact {
+  id: string;
+  label: string;
+  type: 'figma' | 'github' | 'video' | 'pdf' | 'url';
+  required?: boolean;
+}
+
+export interface HackathonTrack {
+  id: string;
+  hackathonId: string;
+  slug: string;
+  name: string;
+  description?: string;
+  /** Free-form classifier: 'skill' | 'technology' | 'theme' | 'special'. */
+  type?: string;
+  eligibility: TrackEligibility;
+  displayOrder: number;
+  isArchived: boolean;
+  /** Number of submissions opted into this track. */
+  entryCount: number;
+  /** Single open-ended prompt rendered on the submission form. */
+  prompt?: string;
+  /** Organizer-defined custom questions. Phase B. */
+  customQuestions?: TrackCustomQuestion[];
+  /** Required artifact slots (e.g. Figma file URL). Phase B. */
+  requiredArtifacts?: TrackRequiredArtifact[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateTrackRequest {
+  name: string;
+  /** Optional. Auto-generated from name if omitted. */
+  slug?: string;
+  description?: string;
+  type?: string;
+  eligibility?: TrackEligibility;
+  displayOrder?: number;
+  prompt?: string;
+  customQuestions?: TrackCustomQuestion[];
+  requiredArtifacts?: TrackRequiredArtifact[];
+}
+
+export interface UpdateTrackRequest {
+  name?: string;
+  slug?: string;
+  description?: string;
+  type?: string;
+  eligibility?: TrackEligibility;
+  displayOrder?: number;
+  isArchived?: boolean;
+  prompt?: string;
+  customQuestions?: TrackCustomQuestion[];
+  requiredArtifacts?: TrackRequiredArtifact[];
+}
+
+/** Submitter responses to a single track's customization. */
+export interface TrackAnswer {
+  promptAnswer?: string;
+  customAnswers?: Record<string, string>;
+  artifacts?: Record<string, string>;
+}
+
+/**
+ * Shape returned alongside each submission once tracks are wired in.
+ * `wonRank` is stamped when results are published; null otherwise.
+ * `trackAnswers` carries the submitter's responses to the track's
+ * customization (Phase B).
+ */
+export interface SubmissionTrackEntry {
+  trackId: string;
+  trackSlug: string;
+  trackName: string;
+  wonRank: number | null;
+  trackAnswers?: TrackAnswer;
+}
+
+// ── API ─────────────────────────────────────────────────────────────────
+
+/**
+ * Public list of tracks for a hackathon. Pass includeArchived for the
+ * organizer view (the management table needs the full set so renames /
+ * un-archiving stay visible).
+ */
+export const listTracks = async (
+  idOrSlug: string,
+  options?: { includeArchived?: boolean }
+): Promise<HackathonTrack[]> => {
+  const params = new URLSearchParams();
+  if (options?.includeArchived) {
+    params.append('includeArchived', 'true');
+  }
+  const qs = params.toString();
+  const url = `/hackathons/${idOrSlug}/tracks${qs ? `?${qs}` : ''}`;
+  const res = await api.get<ApiResponse<HackathonTrack[]>>(url);
+  return res.data?.data ?? [];
+};
+
+/**
+ * Organizer view. Includes archived tracks by default; pass
+ * `{ includeArchived: false }` to hide them.
+ */
+export const listOrganizerTracks = async (
+  organizationId: string,
+  hackathonId: string,
+  options?: { includeArchived?: boolean }
+): Promise<HackathonTrack[]> => {
+  const params = new URLSearchParams();
+  if (options?.includeArchived === false) {
+    params.append('includeArchived', 'false');
+  }
+  const qs = params.toString();
+  const url = `/organizations/${organizationId}/hackathons/${hackathonId}/tracks${qs ? `?${qs}` : ''}`;
+  const res = await api.get<ApiResponse<HackathonTrack[]>>(url);
+  return res.data?.data ?? [];
+};
+
+export const createTrack = async (
+  organizationId: string,
+  hackathonId: string,
+  data: CreateTrackRequest
+): Promise<HackathonTrack> => {
+  const res = await api.post<ApiResponse<HackathonTrack>>(
+    `/organizations/${organizationId}/hackathons/${hackathonId}/tracks`,
+    data
+  );
+  if (!res.data?.data) throw new Error('Invalid create-track response');
+  return res.data.data;
+};
+
+export const updateTrack = async (
+  organizationId: string,
+  hackathonId: string,
+  trackId: string,
+  data: UpdateTrackRequest
+): Promise<HackathonTrack> => {
+  const res = await api.patch<ApiResponse<HackathonTrack>>(
+    `/organizations/${organizationId}/hackathons/${hackathonId}/tracks/${trackId}`,
+    data
+  );
+  if (!res.data?.data) throw new Error('Invalid update-track response');
+  return res.data.data;
+};
+
+/**
+ * Hard-deletes a track with no entries; soft-archives it otherwise.
+ * 204 No Content on success.
+ */
+export const deleteTrack = async (
+  organizationId: string,
+  hackathonId: string,
+  trackId: string
+): Promise<void> => {
+  await api.delete(
+    `/organizations/${organizationId}/hackathons/${hackathonId}/tracks/${trackId}`
+  );
+};
+
+export interface BulkOptInResult {
+  trackName: string;
+  added: number;
+  alreadyOptedIn: number;
+  skippedDisqualified: number;
+  totalSubmissions: number;
+  /** Set when the hackathon's tracksMaxPerSubmission was auto-raised. */
+  newCap?: number;
+}
+
+/**
+ * Organizer-only retrofit: opt every existing submission into this track.
+ * Use when tracks were added after submissions already exist.
+ * Idempotent. Auto-bumps tracksMaxPerSubmission if needed.
+ */
+export const bulkOptInAllSubmissions = async (
+  organizationId: string,
+  hackathonId: string,
+  trackId: string
+): Promise<BulkOptInResult> => {
+  const res = await api.post<ApiResponse<BulkOptInResult>>(
+    `/organizations/${organizationId}/hackathons/${hackathonId}/tracks/${trackId}/bulk-opt-in`
+  );
+  if (!res.data?.data) throw new Error('Invalid bulk-opt-in response');
+  return res.data.data;
+};

--- a/lib/providers/hackathonProvider.tsx
+++ b/lib/providers/hackathonProvider.tsx
@@ -13,13 +13,17 @@
  */
 
 import React, { createContext, useContext, ReactNode } from 'react';
-import type { Hackathon, HackathonWinner } from '@/lib/api/hackathons';
+import type {
+  Hackathon,
+  HackathonWinner,
+  HackathonTrackWinner,
+} from '@/lib/api/hackathons';
 import type { SubmissionCardProps } from '@/types/hackathon';
 import {
   useHackathon,
   useHackathonSubmissions,
   useExploreSubmissions,
-  useHackathonWinners,
+  useHackathonWinnersWithTracks,
   useRefreshHackathon,
   hackathonKeys,
 } from '@/hooks/hackathon/use-hackathon-queries';
@@ -42,6 +46,7 @@ interface HackathonDataContextType {
   exploreSubmissions: SubmissionCardProps[];
   exploreSubmissionsTotal: number;
   winners: HackathonWinner[];
+  trackWinners: HackathonTrackWinner[];
 
   // Loading / error
   loading: boolean;
@@ -137,10 +142,12 @@ export function HackathonDataProvider({
     (currentHackathon?.resultsPublished === true || isOrganizerView);
 
   const {
-    data: winners = [],
+    data: winnersBundle = { winners: [], trackWinners: [] },
     isLoading: winnersLoading,
     error: winnersError,
-  } = useHackathonWinners(hackathonSlug, canViewWinners);
+  } = useHackathonWinnersWithTracks(hackathonSlug, canViewWinners);
+  const winners = winnersBundle.winners;
+  const trackWinners = winnersBundle.trackWinners;
 
   const refreshCurrentHackathon = useRefreshHackathon(hackathonSlug);
 
@@ -158,6 +165,7 @@ export function HackathonDataProvider({
     exploreSubmissions,
     exploreSubmissionsTotal,
     winners,
+    trackWinners,
     loading,
     error,
     refreshCurrentHackathon,

--- a/types/hackathon/core.ts
+++ b/types/hackathon/core.ts
@@ -110,10 +110,23 @@ export interface PrizeTier {
   prizeAmount?: string;
   /** @deprecated Use prizeAmount. Kept for API compatibility. */
   amount?: string;
+  /** Tier classification — OVERALL (default) or TRACK. Added with the
+   *  track-based prize structure feature. Tiers without `kind` are
+   *  treated as OVERALL by the backend. */
+  kind?: 'OVERALL' | 'TRACK';
+  /** Required when kind=TRACK. References a HackathonTrack on the same hackathon. */
+  trackId?: string;
 }
+
+export type HackathonPrizeStructure =
+  | 'OVERALL_ONLY'
+  | 'OVERALL_AND_TRACKS'
+  | 'TRACKS_ONLY';
 
 export interface HackathonRewards {
   prizeTiers: PrizeTier[];
+  prizeStructure?: HackathonPrizeStructure;
+  tracksMaxPerSubmission?: number;
 }
 
 export interface JudgingCriterion {
@@ -260,7 +273,14 @@ export type Hackathon = {
     currency?: string;
     description?: string;
     passMark?: number;
+    kind?: 'OVERALL' | 'TRACK';
+    trackId?: string;
   }>;
+
+  /** P1 of track-based prize structure. Defaults to OVERALL_ONLY when omitted. */
+  prizeStructure?: HackathonPrizeStructure;
+  /** Cap on tracks a submission may opt into. Defaults to 3. */
+  tracksMaxPerSubmission?: number;
 
   phases: Array<{
     id?: string;

--- a/types/hackathon/participant.ts
+++ b/types/hackathon/participant.ts
@@ -94,6 +94,19 @@ export interface ParticipantSubmission {
     email: string;
   } | null;
   reviewedAt?: string | null;
+  /** Track entries on this submission. Populated by the backend when the
+   *  submitter opts into tracks; wonRank is stamped at publish time. */
+  trackEntries?: SubmissionTrackEntry[];
+  /** Overall placement (1, 2, 3...). Null until results are published. */
+  rank?: number | null;
+
+  // ── Phase A submission polish ──
+  tagline?: string;
+  builtWith?: string[];
+  screenshots?: string[];
+  license?: string;
+  /** ISO timestamp set when the submitter ticked the originality attestation. */
+  codeAttestedAt?: string | null;
 }
 
 export interface Participant {
@@ -166,6 +179,37 @@ export interface CreateSubmissionRequest {
     twitter?: string;
     email?: string;
   };
+  /** Optional track opt-in. Capped by the hackathon's tracksMaxPerSubmission. */
+  trackIds?: string[];
+
+  /** Per-track answers (Phase B). Keyed by trackId. */
+  trackAnswers?: Record<
+    string,
+    {
+      promptAnswer?: string;
+      customAnswers?: Record<string, string>;
+      artifacts?: Record<string, string>;
+    }
+  >;
+
+  // ── Phase A submission polish ──
+  /** Short elevator pitch (~160 chars). */
+  tagline?: string;
+  /** Free-form tech-stack chips. */
+  builtWith?: string[];
+  /** Up to 5 screenshot URLs. */
+  screenshots?: string[];
+  /** License code (MIT / Apache-2.0 / GPL-3.0 / BSD-3 / PROPRIETARY / OTHER). */
+  license?: string;
+  /** True when the submitter has ticked the originality attestation. */
+  codeAttested?: boolean;
+}
+
+export interface SubmissionTrackEntry {
+  trackId: string;
+  trackSlug: string;
+  trackName: string;
+  wonRank: number | null;
 }
 
 export interface UpdateSubmissionRequest extends CreateSubmissionRequest {


### PR DESCRIPTION
## Summary

Frontend half of the track-based judging flow. Pairs with [boundless-nestjs#109](https://github.com/boundlessfi/boundless-nestjs/pull/109). Two commits on this branch:

1. `80a8270` — earlier "hidden until results" submission-visibility mode (rolling into this PR, no separate one).
2. `bf06ced` — track UI below.

### Organizer side

- **Settings → Tracks** (`TracksSettingsTab.tsx`): full CRUD with name/slug/description/eligibility/displayOrder. Phase B builders for prompt textarea, custom questions, and required artifacts. Per-row **bulk-opt-in** action with confirmation dialog for retrofitting existing submissions.
- **Rewards step**: 3-card prize structure picker (`OVERALL_ONLY` / `OVERALL_AND_TRACKS` / `TRACKS_ONLY`), per-tier kind toggle + track dropdown, amber "tracks unbound" banner when tracks exist but no tier is `kind=TRACK`, inline **Manage Tracks** dialog embedding the settings table.

### Submission form

- Track picker + per-track answers (prompt, custom questions, required artifacts).
- Phase A polish: tagline, builtWith chips, screenshots, license, code-attestation.
- Soft compliance gate: new submissions hard-gate license + attestation; existing ones stay optional.
- `trackIds` hydrate from `trackEntries` on edit so bulk-opted-in submitters don't accidentally strip themselves out when they save.

### Public hackathon page

- **Overview**: prizes partitioned into Overall + Track sections.
- **Sidebar tier list**: shows `TRACK · ` prefix and resolves track names.
- **Winners tab**: new Track Winners section with per-track cards.

### Submission detail modal

Renders tagline, screenshots gallery, built-with chips, license badge, and per-track answers.

### API client

`lib/api/hackathons/tracks.ts` — typed `listTracks`, `listOrganizerTracks`, `createTrack`, `updateTrack`, `deleteTrack`, `bulkOptInAllSubmissions`. Types: `HackathonTrack`, `TrackCustomQuestion`, `TrackRequiredArtifact`, `TrackAnswer`, `SubmissionTrackEntry`, `BulkOptInResult`.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `next lint` clean on touched files.
- [ ] Manual smoke on staging hackathon: create tracks, bind tiers, opt-in a submission, view as participant + organizer, publishResults flow shows overall + track winners.
- [ ] Production retrofit dry-run: settings → tracks → bulk-opt-in each of the 5 tracks → confirm the submitter view of an existing submission shows all 5 pre-selected after refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added track-based prize structures, allowing hackathons to offer separate prizes for different competition tracks
  * Enhanced submission forms with track opt-in capability and per-track question answering
  * Added submission metadata: tagline, screenshots, "built with" tags, license, and code attestation options
  * Improved submission details view with expanded galleries, track answers, and project metadata
  * Track winner display alongside overall hackathon winners
  * Organizers can now create and manage competition tracks

* **Bug Fixes**
  * Updated default submission visibility to "Shortlisted only" for improved content filtering

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/boundless/pull/564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->