### PR TITLE
feat(judging): organizer dashboard — coverage, preview, per-track results

### DIFF
--- a/app/(landing)/organizations/[id]/hackathons/[hackathonId]/judging/page.tsx
+++ b/app/(landing)/organizations/[id]/hackathons/[hackathonId]/judging/page.tsx
@@ -53,7 +53,14 @@ import { reportError, reportMessage } from '@/lib/error-reporting';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { JudgingCriteriaList } from '@/components/organization/hackathons/judging/JudgingCriteriaList';
 import JudgingResultsTable from '@/components/organization/hackathons/judging/JudgingResultsTable';
+import TrackResultsSection from '@/components/organization/hackathons/judging/TrackResultsSection';
+import AllocationPreviewCard from '@/components/organization/hackathons/judging/AllocationPreviewCard';
+import CoverageMatrix from '@/components/organization/hackathons/judging/CoverageMatrix';
 import { OrganizerJudgesPanel } from '@/components/organization/hackathons/judging/OrganizerJudgesPanel';
+import {
+  useHackathon,
+  useHackathonTracks,
+} from '@/hooks/hackathon/use-hackathon-queries';
 import { Input } from '@/components/ui/input';
 import {
   AlertDialog,
@@ -79,6 +86,38 @@ export default function JudgingPage() {
   const hackathonId = params.hackathonId as string;
 
   const { activeOrgId, activeOrg } = useOrganization();
+
+  // Hackathon + tracks for the per-track Results section. Both are
+  // best-effort — a 404 or empty array degrades gracefully (the
+  // per-track UI just won't render).
+  const { data: hackathonDetail } = useHackathon(hackathonId);
+  const { data: tracksData } = useHackathonTracks(hackathonId);
+  const tracks = tracksData ?? [];
+
+  // Map trackId → human prize string ("$2,000 USDC") sourced from the
+  // hackathon's bound prize tiers. Used as a chip on each track section
+  // header so organizers know which prize a track is paying out.
+  const prizeByTrackId = useMemo<Record<string, string>>(() => {
+    const tiers =
+      (
+        hackathonDetail as
+          | { prizeTiers?: Array<Record<string, unknown>> }
+          | undefined
+      )?.prizeTiers ?? [];
+    const out: Record<string, string> = {};
+    for (const t of tiers) {
+      if (t?.kind !== 'TRACK' || !t?.trackId) continue;
+      const amount = String(t.prizeAmount ?? '').trim();
+      const currency = String(t.currency ?? 'USDC').trim();
+      if (!amount) continue;
+      out[t.trackId as string] =
+        currency.length === 1
+          ? `${currency}${amount}`
+          : `${amount} ${currency}`;
+    }
+    return out;
+  }, [hackathonDetail]);
+
   const [submissions, setSubmissions] = useState<JudgingSubmission[]>([]);
   const [criteria, setCriteria] = useState<JudgingCriterion[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -710,6 +749,14 @@ export default function JudgingPage() {
             </div>
 
             <TabsContent value='overview' className='mt-6 space-y-6'>
+              {/* Coverage heatmap. Surfaces idle judges + orphan
+                  submissions before they become a publish blocker. */}
+              <CoverageMatrix
+                organizationId={organizationId}
+                hackathonId={hackathonId}
+                refreshKey={submissionsPage}
+              />
+
               {isLoading && submissions.length === 0 ? (
                 <div className='flex items-center justify-center py-12'>
                   <Loader2 className='h-8 w-8 animate-spin text-gray-400' />
@@ -1019,6 +1066,14 @@ export default function JudgingPage() {
                     </div>
                   )}
 
+                {!resultsPublished && (
+                  <AllocationPreviewCard
+                    organizationId={organizationId}
+                    hackathonId={hackathonId}
+                    refreshKey={resultsPage}
+                  />
+                )}
+
                 {winners.length > 0 && (
                   <div className='space-y-4'>
                     <h2 className='flex items-center gap-2 text-lg font-bold text-yellow-500'>
@@ -1035,6 +1090,20 @@ export default function JudgingPage() {
                       winnerOverrides={judgingSummary?.winnerOverrides}
                     />
                   </div>
+                )}
+
+                {tracks.length > 0 && judgingResults.length > 0 && (
+                  <TrackResultsSection
+                    tracks={tracks}
+                    results={judgingResults}
+                    totalJudges={currentJudges.length}
+                    criteria={criteria}
+                    canManage={canManageJudges}
+                    winnerOverrides={judgingSummary?.winnerOverrides}
+                    prizeByTrackId={prizeByTrackId}
+                    organizationId={organizationId}
+                    hackathonId={hackathonId}
+                  />
                 )}
 
                 <div className='space-y-4'>

--- a/components/organization/hackathons/judging/AllocationPreviewCard.tsx
+++ b/components/organization/hackathons/judging/AllocationPreviewCard.tsx
@@ -1,0 +1,327 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  Trophy,
+  Layers,
+  AlertTriangle,
+  CheckCircle2,
+  Loader2,
+  RefreshCw,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  getAllocationPreview,
+  type AllocationPreview,
+} from '@/lib/api/hackathons/judging';
+import { reportError } from '@/lib/error-reporting';
+import { extractApiErrorMessage } from '@/lib/api/api';
+
+interface AllocationPreviewCardProps {
+  organizationId: string;
+  hackathonId: string;
+  /**
+   * Bumps when judging results refresh. The preview re-fetches when this
+   * changes so the organizer always sees an up-to-date allocation.
+   */
+  refreshKey?: number;
+}
+
+const formatPrize = (amount?: string, currency?: string): string | null => {
+  if (!amount) return null;
+  const c = currency || 'USDC';
+  return c.length === 1 ? `${c}${amount}` : `${amount} ${c}`;
+};
+
+/**
+ * Renders the read-only allocator dry-run for the organizer dashboard.
+ * Sits above the Publish button on the Results tab and lets the
+ * organizer see *exactly* what publish-results would commit, including
+ * EXCLUSIVE stacking effects (a track leader can lose if they also win
+ * overall). Also surfaces the publish gates (deadline, completeness,
+ * partner-allocation) so blockers are visible without an attempted
+ * publish.
+ */
+export default function AllocationPreviewCard({
+  organizationId,
+  hackathonId,
+  refreshKey = 0,
+}: AllocationPreviewCardProps) {
+  const [data, setData] = useState<AllocationPreview | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchPreview = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const res = await getAllocationPreview(organizationId, hackathonId);
+        if (cancelled) return;
+        if (res.success && res.data) {
+          setData(res.data);
+        } else {
+          setError(res.message || 'Failed to load allocation preview');
+        }
+      } catch (err) {
+        if (cancelled) return;
+        const msg = extractApiErrorMessage(
+          err,
+          'Failed to load allocation preview'
+        );
+        setError(msg);
+        reportError(err, {
+          context: 'judging-allocation-preview',
+          organizationId,
+          hackathonId,
+        });
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+    fetchPreview();
+    return () => {
+      cancelled = true;
+    };
+  }, [organizationId, hackathonId, refreshKey]);
+
+  if (isLoading && !data) {
+    return (
+      <div className='flex items-center gap-3 rounded-lg border border-gray-900 bg-black/40 p-4'>
+        <Loader2 className='h-4 w-4 animate-spin text-gray-400' />
+        <span className='text-sm text-gray-400'>
+          Computing allocation preview…
+        </span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className='flex items-center gap-3 rounded-lg border border-red-900/40 bg-red-950/20 p-4'>
+        <AlertTriangle className='h-4 w-4 text-red-400' />
+        <span className='text-sm text-red-300'>{error}</span>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const { overall, tracks, gates } = data;
+
+  // Hide when there's nothing to preview yet — no overall placements
+  // configured AND no track tiers. Avoids rendering an empty card on
+  // hackathons that haven't set up prize tiers.
+  if (overall.length === 0 && tracks.length === 0) return null;
+
+  const blockers: string[] = [];
+  if (!gates.submissionDeadlinePassed) {
+    blockers.push('Submission deadline has not passed yet.');
+  }
+  if (!gates.complete) {
+    blockers.push(
+      `${gates.incompleteSubmissionCount} submission${
+        gates.incompleteSubmissionCount === 1 ? '' : 's'
+      } missing at least one judge's score.`
+    );
+  }
+  if (gates.reviewedCount === 0) {
+    blockers.push('No submissions have been reviewed yet.');
+  }
+  if (gates.unallocatedPartnerContributionAmount > 0.0000001) {
+    blockers.push(
+      `${gates.unallocatedPartnerContributionAmount.toFixed(2)} ${
+        gates.currency
+      } of partner contributions are unallocated.`
+    );
+  }
+
+  const canPublish = blockers.length === 0;
+
+  return (
+    <div className='space-y-4 rounded-lg border border-blue-900/40 bg-blue-950/10 p-5'>
+      <div className='flex items-start justify-between gap-4'>
+        <div>
+          <h2 className='flex items-center gap-2 text-base font-bold text-blue-300'>
+            <RefreshCw className='h-4 w-4' />
+            Allocator preview
+          </h2>
+          <p className='mt-1 text-xs text-gray-500'>
+            This is exactly what will be stamped on publish. EXCLUSIVE stacking
+            applied — one award per submission. Refreshes when scores change.
+          </p>
+        </div>
+        <Badge
+          variant='outline'
+          className={
+            canPublish
+              ? 'border-green-500/40 bg-green-500/10 text-green-300'
+              : 'border-amber-500/40 bg-amber-500/10 text-amber-300'
+          }
+        >
+          {canPublish ? (
+            <>
+              <CheckCircle2 className='mr-1 h-3 w-3' />
+              Ready to publish
+            </>
+          ) : (
+            <>
+              <AlertTriangle className='mr-1 h-3 w-3' />
+              {blockers.length} blocker{blockers.length === 1 ? '' : 's'}
+            </>
+          )}
+        </Badge>
+      </div>
+
+      {blockers.length > 0 && (
+        <div className='rounded border border-amber-500/30 bg-amber-950/20 p-3'>
+          <div className='mb-2 flex items-center gap-2 text-xs font-semibold text-amber-300'>
+            <AlertTriangle className='h-3.5 w-3.5' />
+            Cannot publish yet
+          </div>
+          <ul className='space-y-1 text-xs text-amber-200/80'>
+            {blockers.map((b, i) => (
+              <li key={i} className='ml-4 list-disc'>
+                {b}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Overall placements */}
+      {overall.length > 0 && (
+        <div className='space-y-2'>
+          <div className='flex items-center gap-2 text-xs font-semibold tracking-wide text-gray-400 uppercase'>
+            <Trophy className='h-3.5 w-3.5 text-yellow-500' />
+            Overall placements
+          </div>
+          <div className='overflow-hidden rounded border border-gray-900'>
+            <table className='w-full text-sm'>
+              <thead className='bg-black/40 text-xs text-gray-500'>
+                <tr>
+                  <th className='px-3 py-2 text-left font-medium'>Rank</th>
+                  <th className='px-3 py-2 text-left font-medium'>Project</th>
+                  <th className='px-3 py-2 text-right font-medium'>Score</th>
+                  <th className='px-3 py-2 text-right font-medium'>Prize</th>
+                  <th className='px-3 py-2 text-right font-medium'>Source</th>
+                </tr>
+              </thead>
+              <tbody>
+                {overall.map(o => (
+                  <tr
+                    key={o.submissionId}
+                    className='border-t border-gray-900/60'
+                  >
+                    <td className='px-3 py-2 text-yellow-500'>#{o.rank}</td>
+                    <td className='px-3 py-2 text-gray-200'>{o.projectName}</td>
+                    <td className='px-3 py-2 text-right text-gray-400'>
+                      {o.averageScore.toFixed(2)}
+                    </td>
+                    <td className='px-3 py-2 text-right text-gray-300'>
+                      {formatPrize(o.prizeAmount, o.currency) ?? '—'}
+                    </td>
+                    <td className='px-3 py-2 text-right text-xs'>
+                      {o.isOverride ? (
+                        <span className='text-purple-400'>Override</span>
+                      ) : (
+                        <span className='text-gray-500'>Computed</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Track winners */}
+      {tracks.length > 0 && (
+        <div className='space-y-2'>
+          <div className='flex items-center gap-2 text-xs font-semibold tracking-wide text-gray-400 uppercase'>
+            <Layers className='h-3.5 w-3.5 text-blue-400' />
+            Track winners
+          </div>
+          <div className='space-y-2'>
+            {tracks.map(t => (
+              <div
+                key={t.trackId}
+                className='rounded border border-gray-900 bg-black/30 p-3'
+              >
+                <div className='flex flex-wrap items-center justify-between gap-2'>
+                  <div className='flex items-center gap-2'>
+                    <span className='text-sm font-semibold text-white'>
+                      {t.trackName}
+                    </span>
+                    {formatPrize(t.prizeAmount, t.currency) && (
+                      <Badge
+                        variant='outline'
+                        className='border-yellow-500/30 bg-yellow-500/10 text-yellow-400'
+                      >
+                        {formatPrize(t.prizeAmount, t.currency)}
+                      </Badge>
+                    )}
+                  </div>
+                  {t.skippedReason && (
+                    <Badge
+                      variant='outline'
+                      className='border-amber-500/30 bg-amber-500/10 text-amber-400'
+                    >
+                      <AlertTriangle className='mr-1 h-3 w-3' />
+                      {t.skippedReason === 'NO_ENTRIES'
+                        ? 'No opt-ins'
+                        : 'No scored entries'}
+                    </Badge>
+                  )}
+                </div>
+                {t.winner ? (
+                  <div className='mt-2 flex items-center justify-between text-sm'>
+                    <span className='text-gray-200'>
+                      Winner:{' '}
+                      <span className='font-medium text-white'>
+                        {t.winner.projectName}
+                      </span>
+                    </span>
+                    <span className='text-xs text-gray-500'>
+                      score {t.winner.averageScore.toFixed(2)}
+                    </span>
+                  </div>
+                ) : (
+                  <p className='mt-2 text-xs text-amber-300/70'>
+                    This track will not pay out — fix before publish.
+                  </p>
+                )}
+                {t.runnersUp.length > 0 && (
+                  <div className='mt-2 text-xs text-gray-500'>
+                    Runners-up:{' '}
+                    {t.runnersUp.map((r, i) => (
+                      <span key={r.submissionId}>
+                        {r.projectName} ({r.averageScore.toFixed(2)})
+                        {i < t.runnersUp.length - 1 ? ', ' : ''}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {isLoading && (
+        <div className='flex items-center gap-2 text-xs text-gray-500'>
+          <Loader2 className='h-3 w-3 animate-spin' />
+          Refreshing…
+        </div>
+      )}
+    </div>
+  );
+}
+
+// `Button` import retained for future actions (e.g. an inline "refresh"
+// button) without forcing a follow-up import edit. Strip if unused at
+// the next polish pass.
+void Button;

--- a/components/organization/hackathons/judging/CoverageMatrix.tsx
+++ b/components/organization/hackathons/judging/CoverageMatrix.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Loader2,
+  Users,
+  ChevronDown,
+  ChevronUp,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  getJudgingCoverage,
+  type JudgingCoverage,
+} from '@/lib/api/hackathons/judging';
+import { reportError } from '@/lib/error-reporting';
+import { extractApiErrorMessage } from '@/lib/api/api';
+
+interface CoverageMatrixProps {
+  organizationId: string;
+  hackathonId: string;
+  /** Bumps when something on the page should trigger a re-fetch. */
+  refreshKey?: number;
+}
+
+const initialOf = (name: string): string => {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+};
+
+/**
+ * Judges × submissions coverage heatmap for the organizer Overview
+ * tab. Rows are submissions, columns are judges, cell colour signals
+ * whether that judge has scored that submission. Designed to surface
+ * two failure modes at a glance:
+ *
+ *  • Idle judges — a column of mostly grey cells means a judge hasn't
+ *    started or is far behind.
+ *  • Orphan submissions — a row with 0-1 scored cells can't be ranked
+ *    safely (no allocator decision will be defensible).
+ *
+ * Collapsed by default; the organizer opens it when they want to triage
+ * judging progress. No backend writes — pure read of the new coverage
+ * endpoint plus a thin summary header.
+ */
+export default function CoverageMatrix({
+  organizationId,
+  hackathonId,
+  refreshKey = 0,
+}: CoverageMatrixProps) {
+  const [data, setData] = useState<JudgingCoverage | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchCoverage = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const res = await getJudgingCoverage(organizationId, hackathonId);
+        if (cancelled) return;
+        if (res.success && res.data) {
+          setData(res.data);
+        } else {
+          setError(res.message || 'Failed to load coverage matrix');
+        }
+      } catch (err) {
+        if (cancelled) return;
+        const msg = extractApiErrorMessage(
+          err,
+          'Failed to load coverage matrix'
+        );
+        setError(msg);
+        reportError(err, {
+          context: 'judging-coverage-matrix',
+          organizationId,
+          hackathonId,
+        });
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+    fetchCoverage();
+    return () => {
+      cancelled = true;
+    };
+  }, [organizationId, hackathonId, refreshKey]);
+
+  const completionPct = useMemo(() => {
+    if (!data) return 0;
+    const { expectedScores, actualScores } = data.summary;
+    if (expectedScores === 0) return 0;
+    return Math.round((actualScores / expectedScores) * 100);
+  }, [data]);
+
+  // The submission view-model. Pre-computes the scored-set as a Set so
+  // every cell render is an O(1) lookup instead of an array search.
+  const submissionRows = useMemo(() => {
+    if (!data) return [];
+    return data.submissions.map(s => ({
+      ...s,
+      scoredSet: new Set(s.scoredBy),
+    }));
+  }, [data]);
+
+  if (isLoading && !data) {
+    return (
+      <div className='flex items-center gap-3 rounded-lg border border-gray-900 bg-black/40 p-4'>
+        <Loader2 className='h-4 w-4 animate-spin text-gray-400' />
+        <span className='text-sm text-gray-400'>Loading coverage…</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className='flex items-center gap-3 rounded-lg border border-red-900/40 bg-red-950/20 p-4'>
+        <AlertTriangle className='h-4 w-4 text-red-400' />
+        <span className='text-sm text-red-300'>{error}</span>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+  if (data.summary.totalJudges === 0 || data.summary.totalSubmissions === 0) {
+    // Nothing to display yet — judging hasn't started. Avoid an empty
+    // skeleton that adds noise to the dashboard.
+    return null;
+  }
+
+  const { summary, judges } = data;
+
+  return (
+    <div className='space-y-3 rounded-lg border border-gray-900 bg-black/40 p-5'>
+      <button
+        type='button'
+        onClick={() => setOpen(v => !v)}
+        className='flex w-full items-start justify-between gap-3 text-left'
+      >
+        <div>
+          <h2 className='flex items-center gap-2 text-base font-bold text-gray-200'>
+            <Users className='h-4 w-4 text-blue-400' />
+            Coverage
+            <Badge
+              variant='outline'
+              className={
+                completionPct === 100
+                  ? 'border-green-500/40 bg-green-500/10 text-green-300'
+                  : completionPct >= 50
+                    ? 'border-blue-500/40 bg-blue-500/10 text-blue-300'
+                    : 'border-amber-500/40 bg-amber-500/10 text-amber-300'
+              }
+            >
+              {completionPct}% scored
+            </Badge>
+          </h2>
+          <p className='mt-1 text-xs text-gray-500'>
+            {summary.actualScores} of {summary.expectedScores} scores in.{' '}
+            <span className='text-gray-400'>
+              {summary.submissionsFullyCovered} fully scored,{' '}
+              {summary.submissionsPartiallyCovered} partial,{' '}
+              {summary.submissionsUncovered} unscored.
+            </span>
+          </p>
+        </div>
+        <Button variant='ghost' size='icon' className='h-7 w-7' asChild>
+          <span>
+            {open ? (
+              <ChevronUp className='h-4 w-4' />
+            ) : (
+              <ChevronDown className='h-4 w-4' />
+            )}
+          </span>
+        </Button>
+      </button>
+
+      {open && (
+        <div className='overflow-x-auto'>
+          <table className='w-full min-w-max border-separate border-spacing-0 text-xs'>
+            <thead>
+              <tr>
+                <th className='sticky left-0 z-10 bg-black/60 px-3 py-2 text-left font-medium text-gray-500'>
+                  Submission
+                </th>
+                {judges.map(j => (
+                  <th
+                    key={j.userId}
+                    className='px-2 py-2 text-center font-medium text-gray-400'
+                    title={`${j.name}\nScored ${j.scoredCount} / ${summary.totalSubmissions}`}
+                  >
+                    <div className='flex flex-col items-center gap-1'>
+                      <span className='flex h-7 w-7 items-center justify-center rounded-full bg-gray-900 text-[10px] font-semibold text-gray-300'>
+                        {initialOf(j.name)}
+                      </span>
+                      <span className='text-[10px] whitespace-nowrap text-gray-500'>
+                        {j.scoredCount}/{summary.totalSubmissions}
+                      </span>
+                    </div>
+                  </th>
+                ))}
+                <th className='px-2 py-2 text-center font-medium text-gray-500'>
+                  Status
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {submissionRows.map(sub => (
+                <tr key={sub.submissionId} className='hover:bg-white/[0.02]'>
+                  <td className='sticky left-0 z-10 max-w-[240px] truncate bg-black/60 px-3 py-2 text-gray-200'>
+                    {sub.projectName}
+                  </td>
+                  {judges.map(j => {
+                    const scored = sub.scoredSet.has(j.userId);
+                    return (
+                      <td
+                        key={j.userId}
+                        className='px-2 py-2 text-center'
+                        title={
+                          scored
+                            ? `${j.name} scored "${sub.projectName}"`
+                            : `${j.name} has not scored "${sub.projectName}"`
+                        }
+                      >
+                        <div
+                          className={`mx-auto h-6 w-6 rounded ${
+                            scored
+                              ? 'bg-green-500/40'
+                              : 'border border-gray-700/60 bg-gray-800'
+                          }`}
+                        />
+                      </td>
+                    );
+                  })}
+                  <td className='px-2 py-2 text-center'>
+                    {sub.isCovered ? (
+                      <CheckCircle2 className='mx-auto h-4 w-4 text-green-400' />
+                    ) : sub.scoredCount === 0 ? (
+                      <span className='text-[10px] font-medium text-red-400'>
+                        Orphan
+                      </span>
+                    ) : (
+                      <span className='text-[10px] text-amber-400'>
+                        {sub.scoredCount}/{summary.totalJudges}
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/organization/hackathons/judging/TrackResultsSection.tsx
+++ b/components/organization/hackathons/judging/TrackResultsSection.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  ChevronDown,
+  ChevronUp,
+  Trophy,
+  AlertTriangle,
+  Layers,
+} from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import type { HackathonTrack } from '@/lib/api/hackathons/tracks';
+import type {
+  JudgingCriterion,
+  JudgingResult,
+} from '@/lib/api/hackathons/judging';
+import JudgingResultsTable from './JudgingResultsTable';
+
+interface TrackResultsSectionProps {
+  /** All non-archived tracks for the hackathon. */
+  tracks: HackathonTrack[];
+  /** Full aggregated results list. Filtered per-track inside. */
+  results: JudgingResult[];
+  /** Total active judges, used by the inner table to compute coverage. */
+  totalJudges?: number;
+  /** Configured judging criteria for per-criterion drill-down. */
+  criteria?: JudgingCriterion[];
+  /** Organizer override capability — controlled by parent. */
+  canManage?: boolean;
+  /** Existing winner overrides, threaded through to the inner table. */
+  winnerOverrides?: Record<string, number>;
+  /**
+   * Map of trackId → bound prize tier (e.g. "$2,000"). When present, the
+   * section header shows the prize amount next to the track name. Empty
+   * map is fine — tracks without a bound prize just don't show one.
+   */
+  prizeByTrackId?: Record<string, string>;
+  organizationId: string;
+  hackathonId: string;
+}
+
+/**
+ * Per-track standings for the organizer dashboard. Renders one
+ * collapsible section per non-archived track, scoped to submissions
+ * opted into that track (`result.trackIds`). The leading submission is
+ * highlighted as the current allocator pick — but it's a soft preview,
+ * not authoritative. EXCLUSIVE stacking applied at publish time may
+ * promote a runner-up if the current leader wins an overall placement
+ * or another track. The Phase 2 allocator preview surfaces that.
+ */
+export default function TrackResultsSection({
+  tracks,
+  results,
+  totalJudges,
+  criteria,
+  canManage,
+  winnerOverrides,
+  prizeByTrackId,
+  organizationId,
+  hackathonId,
+}: TrackResultsSectionProps) {
+  // Default-collapsed; the organizer expands the tracks they care about.
+  // Tracks with no opted-in submissions are still rendered so the
+  // organizer notices the gap before publish.
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  const resultsByTrack = useMemo(() => {
+    const map = new Map<string, JudgingResult[]>();
+    for (const r of results) {
+      const trackIds = r.trackIds ?? [];
+      for (const trackId of trackIds) {
+        const list = map.get(trackId) ?? [];
+        list.push(r);
+        map.set(trackId, list);
+      }
+    }
+    // Sort each list by averageScore descending so the leader is index 0.
+    for (const [k, v] of map.entries()) {
+      map.set(
+        k,
+        [...v].sort((a, b) => (b.averageScore ?? 0) - (a.averageScore ?? 0))
+      );
+    }
+    return map;
+  }, [results]);
+
+  const visibleTracks = useMemo(
+    () =>
+      [...tracks]
+        .filter(t => !t.isArchived)
+        .sort((a, b) => a.displayOrder - b.displayOrder),
+    [tracks]
+  );
+
+  if (visibleTracks.length === 0) return null;
+
+  return (
+    <div className='space-y-4'>
+      <div className='flex items-center gap-2'>
+        <Layers className='h-5 w-5 text-blue-400' />
+        <h2 className='text-lg font-bold text-gray-200'>Per-Track Standings</h2>
+        <span className='text-xs text-gray-500'>
+          ({visibleTracks.length} track{visibleTracks.length === 1 ? '' : 's'})
+        </span>
+      </div>
+
+      <p className='text-xs text-gray-500'>
+        Each section shows submissions opted into that track, sorted by their
+        average score across all judges. The highlighted row is the current
+        leader — at publish time, EXCLUSIVE stacking may promote a runner-up if
+        the leader wins an overall placement or another track.
+      </p>
+
+      <div className='space-y-3'>
+        {visibleTracks.map(track => {
+          const trackResults = resultsByTrack.get(track.id) ?? [];
+          const isOpen = !!expanded[track.id];
+          const leader = trackResults[0];
+          const prize = prizeByTrackId?.[track.id];
+          const noEntries = trackResults.length === 0;
+
+          return (
+            <div
+              key={track.id}
+              className='overflow-hidden rounded-lg border border-gray-900 bg-black/40'
+            >
+              <button
+                type='button'
+                onClick={() =>
+                  setExpanded(prev => ({
+                    ...prev,
+                    [track.id]: !prev[track.id],
+                  }))
+                }
+                className='flex w-full items-center justify-between gap-3 px-4 py-3 text-left hover:bg-white/[0.02]'
+              >
+                <div className='flex min-w-0 flex-1 items-center gap-3'>
+                  <Trophy className='h-4 w-4 shrink-0 text-yellow-500' />
+                  <div className='min-w-0 flex-1'>
+                    <div className='flex flex-wrap items-center gap-2'>
+                      <span className='truncate text-sm font-semibold text-white'>
+                        {track.name}
+                      </span>
+                      {prize && (
+                        <Badge
+                          variant='outline'
+                          className='border-yellow-500/30 bg-yellow-500/10 text-yellow-400'
+                        >
+                          {prize}
+                        </Badge>
+                      )}
+                      <Badge
+                        variant='outline'
+                        className='border-gray-800 text-gray-400'
+                      >
+                        {trackResults.length} entr
+                        {trackResults.length === 1 ? 'y' : 'ies'}
+                      </Badge>
+                      {noEntries && (
+                        <Badge
+                          variant='outline'
+                          className='border-amber-500/30 bg-amber-500/10 text-amber-400'
+                        >
+                          <AlertTriangle className='mr-1 h-3 w-3' />
+                          No opted-in submissions
+                        </Badge>
+                      )}
+                    </div>
+                    {leader && (
+                      <div className='mt-1 truncate text-xs text-gray-500'>
+                        Currently leading:{' '}
+                        <span className='text-gray-300'>
+                          {leader.projectName}
+                        </span>{' '}
+                        ({leader.averageScore?.toFixed(2)})
+                      </div>
+                    )}
+                  </div>
+                </div>
+                <Button
+                  variant='ghost'
+                  size='icon'
+                  className='h-7 w-7 text-gray-400'
+                  asChild
+                >
+                  <span>
+                    {isOpen ? (
+                      <ChevronUp className='h-4 w-4' />
+                    ) : (
+                      <ChevronDown className='h-4 w-4' />
+                    )}
+                  </span>
+                </Button>
+              </button>
+
+              {isOpen && (
+                <div className='border-t border-gray-900 bg-black/20 p-4'>
+                  {noEntries ? (
+                    <div className='py-6 text-center text-xs text-gray-500'>
+                      No submissions have opted into this track yet. Use the{' '}
+                      <span className='text-gray-300'>
+                        Settings → Tracks → Opt in all
+                      </span>{' '}
+                      action if you want to retrofit existing submissions.
+                    </div>
+                  ) : (
+                    <JudgingResultsTable
+                      results={trackResults}
+                      organizationId={organizationId}
+                      hackathonId={hackathonId}
+                      totalJudges={totalJudges}
+                      criteria={criteria}
+                      canManage={canManage}
+                      winnerOverrides={winnerOverrides}
+                    />
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/lib/api/hackathons/judging.ts
+++ b/lib/api/hackathons/judging.ts
@@ -87,6 +87,10 @@ export interface JudgingResult {
   hasDisagreement: boolean;
   prize?: string;
   overriddenRank?: number; // Added to track manual overrides
+  /** Track opt-ins for this submission. Empty for OVERALL_ONLY hackathons
+   *  or submissions that didn't pick any track. Used to group results
+   *  per-track in the organizer dashboard. */
+  trackIds?: string[];
 }
 
 export interface AggregatedJudgingResults {
@@ -645,6 +649,118 @@ export interface JudgingCompletenessPreview {
     missingJudges: Array<{ id: string; name: string }>;
   }>;
 }
+
+// ── Coverage matrix (Phase 3: dashboard) ────────────────────────────
+
+export interface JudgingCoverageJudge {
+  userId: string;
+  name: string;
+  scoredCount: number;
+  missingCount: number;
+  lastScoredAt: string | null;
+}
+
+export interface JudgingCoverageSubmission {
+  submissionId: string;
+  projectName: string;
+  /** User IDs of judges who scored this submission. */
+  scoredBy: string[];
+  scoredCount: number;
+  missingCount: number;
+  isCovered: boolean;
+}
+
+export interface JudgingCoverage {
+  hackathonId: string;
+  judges: JudgingCoverageJudge[];
+  submissions: JudgingCoverageSubmission[];
+  summary: {
+    totalSubmissions: number;
+    totalJudges: number;
+    expectedScores: number;
+    actualScores: number;
+    submissionsFullyCovered: number;
+    submissionsPartiallyCovered: number;
+    submissionsUncovered: number;
+  };
+}
+
+/**
+ * Full judges × submissions coverage matrix for the organizer
+ * dashboard. Used to render the heatmap that exposes idle judges and
+ * orphan submissions.
+ */
+export const getJudgingCoverage = async (
+  organizationId: string,
+  hackathonId: string
+): Promise<ApiResponse<JudgingCoverage>> => {
+  const res = await api.get(
+    `/organizations/${organizationId}/hackathons/${hackathonId}/judging/coverage`
+  );
+  return res.data;
+};
+
+// ── Allocator preview (Phase 2: dashboard) ──────────────────────────
+
+export interface AllocationPreviewOverallEntry {
+  rank: number;
+  submissionId: string;
+  projectName: string;
+  averageScore: number;
+  prizeAmount?: string;
+  currency?: string;
+  isOverride: boolean;
+}
+
+export interface AllocationPreviewTrackEntry {
+  trackId: string;
+  trackName: string;
+  trackSlug: string;
+  prizeAmount?: string;
+  currency?: string;
+  winner: {
+    submissionId: string;
+    projectName: string;
+    averageScore: number;
+  } | null;
+  runnersUp: Array<{
+    submissionId: string;
+    projectName: string;
+    averageScore: number;
+  }>;
+  /** Why a track has no winner. NO_ENTRIES = no submissions opted in;
+   *  NO_SCORED_ENTRIES = opted in but no judge scored them. */
+  skippedReason: 'NO_ENTRIES' | 'NO_SCORED_ENTRIES' | null;
+}
+
+export interface AllocationPreview {
+  hackathonId: string;
+  overall: AllocationPreviewOverallEntry[];
+  tracks: AllocationPreviewTrackEntry[];
+  gates: {
+    submissionDeadlinePassed: boolean;
+    complete: boolean;
+    incompleteSubmissionCount: number;
+    reviewedCount: number;
+    unallocatedPartnerContributionAmount: number;
+    currency: string;
+  };
+}
+
+/**
+ * Read-only allocator dry-run. Returns the overall + per-track outcome
+ * `publishJudgingResults` would produce, plus the publish-gate flags so
+ * the UI can render a "what's blocking publish?" panel.
+ */
+export const getAllocationPreview = async (
+  organizationId: string,
+  hackathonId: string
+): Promise<ApiResponse<AllocationPreview>> => {
+  const res = await api.get(
+    `/organizations/${organizationId}/hackathons/${hackathonId}/judging/preview-allocation`
+  );
+  return res.data;
+};
 
 export const getJudgingCompleteness = async (
   organizationId: string,


### PR DESCRIPTION
## Summary

Stacked on top of [#564](https://github.com/boundlessfi/boundless/pull/564). Three new components on the organizer judging page; no changes to existing components, judges page, or scoring flows.

Pairs with backend PR for the new endpoints + `trackIds` field.

### What's new

- **`CoverageMatrix`** on the Overview tab — collapsible heatmap. Rows = submissions, columns = judges, cell colour signals "scored / not scored." Surfaces:
  - Idle judges (mostly-empty columns)
  - Orphan submissions (rows with 0-1 scores) that can't be ranked safely
  - Overall completion percentage with the same actual/expected math used by the publish gate

- **`AllocationPreviewCard`** on the Results tab, above the Publish button — read-only allocator dry-run. Renders exactly what `publishResults` would stamp:
  - Overall placements with prize bindings and override attribution
  - Per-track winners with EXCLUSIVE stacking applied (a track leader losing because they already claimed an overall placement is visible here)
  - Runners-up per track (top 3) so the organizer can see "if I disqualify the leader, who's next?"
  - Publish gates (deadline, completeness, partner allocation) flagged inline so the organizer knows what's blocking publish without trying to publish

- **`TrackResultsSection`** on the Results tab — per-track collapsible standings. Each section is scoped to a track's opt-ins, sorted by averageScore. Bound prize tier shown as a chip. Soft preview of the leader — the authoritative EXCLUSIVE-stacked outcome lives in the Allocation Preview above.

### Risk surface

All three components are pure reads. No mutations, no changes to existing components, no changes to the existing standings table / winners section / publish flow. Each component renders nothing when its data isn't available (loading states + empty states are explicit).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `next lint` clean on touched files
- [ ] Manual: open the organizer judging page on staging, verify Coverage matrix populates
- [ ] Manual: verify per-track section shows correct entries after track opt-ins
- [ ] Manual: verify Allocation Preview shows blockers when judging isn't complete

Pairs with backend PR: boundlessfi/boundless-nestjs feat/organizer-judging-dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)