### PR TITLE
fix(judging): unallocated partner funds become a warning, not a blocker

### DIFF
--- a/components/organization/hackathons/judging/AllocationPreviewCard.tsx
+++ b/components/organization/hackathons/judging/AllocationPreviewCard.tsx
@@ -130,11 +130,17 @@ export default function AllocationPreviewCard({
   if (gates.reviewedCount === 0) {
     blockers.push('No submissions have been reviewed yet.');
   }
+
+  // Unallocated partner contributions are surfaced as a non-blocking
+  // warning. The escrow still holds the funds; organizers can release
+  // or refund them after publish. The backend gate that prevented this
+  // is intentionally relaxed (see judging.service.publishResults).
+  const warnings: string[] = [];
   if (gates.unallocatedPartnerContributionAmount > 0.0000001) {
-    blockers.push(
+    warnings.push(
       `${gates.unallocatedPartnerContributionAmount.toFixed(2)} ${
         gates.currency
-      } of partner contributions are unallocated.`
+      } of partner contributions are unallocated. Publish will succeed; funds remain in escrow until you release or refund them.`
     );
   }
 
@@ -185,6 +191,22 @@ export default function AllocationPreviewCard({
             {blockers.map((b, i) => (
               <li key={i} className='ml-4 list-disc'>
                 {b}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {warnings.length > 0 && (
+        <div className='rounded border border-blue-500/30 bg-blue-950/20 p-3'>
+          <div className='mb-2 flex items-center gap-2 text-xs font-semibold text-blue-300'>
+            <AlertTriangle className='h-3.5 w-3.5' />
+            Heads up
+          </div>
+          <ul className='space-y-1 text-xs text-blue-200/80'>
+            {warnings.map((w, i) => (
+              <li key={i} className='ml-4 list-disc'>
+                {w}
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Why

Pairs with boundless-nestjs#130 which relaxes the backend gate. The previous PR #572 already merged the dashboard, but this small follow-up was orphaned on the merged branch and needs a fresh PR off main.

## Change

In `AllocationPreviewCard`, split publish-readiness signals into:

- **Blockers** (red, hard gates) — deadline not passed, incomplete judging, no reviewed submissions.
- **Warnings** (blue, informational) — unallocated partner contributions. Does not change the Ready-to-publish badge.

## What organizers see

For an escrow that exceeds the prize pool (e.g. 2074.98 USDC escrow against 1500 USDC pool), the publish flow now shows:

```
Allocator preview                          Ready to publish ✓

Heads up
  • 575.00 USDC of partner contributions are unallocated.
    Publish will succeed; funds remain in escrow until you
    release or refund them.
```

The Publish button works. Funds stay in escrow safely.

## Risk

Pure UI change, one file, one logical condition moved between two lists.

## Pairs with

boundlessfi/boundless-nestjs#130 (the backend allow-publish change).

## Deploy order

1. Merge + deploy boundless-nestjs#130 first.
2. Merge + deploy this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an informational warning to the hackathon judging allocation preview that appears when unallocated contributions exist. The warning informs users that publishing will proceed successfully while funds remain in escrow until released or refunded.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/boundless/pull/574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->