### PR TITLE
feat(hackathons): add judging dataset to export dropdown

### DIFF
--- a/components/organization/hackathons/details/ExportButton.tsx
+++ b/components/organization/hackathons/details/ExportButton.tsx
@@ -50,6 +50,11 @@ const DATASETS = [
     label: 'Winners',
     description: 'Wallet address, activation & USDC trustline',
   },
+  {
+    id: 'judging',
+    label: 'Judging',
+    description: 'Results, judges, scores & comments',
+  },
 ] as const;
 
 export function ExportButton({

--- a/lib/api/hackathons/rewards.ts
+++ b/lib/api/hackathons/rewards.ts
@@ -214,6 +214,7 @@ export const exportHackathon = async (
     | 'submissions'
     | 'prize_tiers'
     | 'winners'
+    | 'judging'
     | 'full' = 'full'
 ): Promise<Blob> => {
   const res = await api.get(


### PR DESCRIPTION
## Summary
- Adds a **Judging** entry to the organizer's *Export Data* dropdown (CSV and PDF submenus), alongside Winners, Submissions, etc.
- Extends the typed `dataset` union on `exportHackathon()` so the new option is fully typesafe.

Pairs with the backend PR that introduces the `judging` dataset. The frontend should ship after the backend is live; if it ships first, clicking *Judging* will return a 400 from the validator (no other regression).

## Test plan
- [ ] Organizer dashboard → hackathon overview → *Export Data* → *CSV Spreadsheet* → *Judging*. Confirm a CSV downloads with sections: Judging Criteria, Judges, Judging Results, Judge Scores, Judge Comments.
- [ ] Same flow, *Branded PDF* → *Judging*. Confirm a PDF downloads with matching sections.
- [ ] *Full Report* in either format now also contains the Judging sections.
- [ ] Existing options (Overview, Participants, Submissions, Prize Tiers, Winners) still download unchanged.
- [ ] Hackathon with no scoring yet renders empty placeholders, not an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Judging" dataset export option for hackathons, allowing organizers to download judging results, judges information, scores, and comments in both CSV and PDF formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/boundless/pull/577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->