### PR TITLE
fix(rewards): match track winners by submissionId, not participantId

### DIFF
--- a/components/organization/hackathons/rewards/types.ts
+++ b/components/organization/hackathons/rewards/types.ts
@@ -1,5 +1,12 @@
 export interface Submission {
   id: string;
+  /**
+   * The actual HackathonSubmission row ID, distinct from `id` which the
+   * rewards data mapper sets to the participant ID. Required for
+   * matching submissions against backend payloads (judging results,
+   * track winners) that key by submissionId.
+   */
+  submissionId?: string;
   name: string;
   projectName: string;
   avatar?: string;

--- a/hooks/use-hackathon-rewards.ts
+++ b/hooks/use-hackathon-rewards.ts
@@ -472,7 +472,14 @@ export const useHackathonRewards = (
         const byId = new Map(fetched.map(tw => [tw.submissionId, tw]));
         setSubmissions(prev =>
           prev.map(sub => {
-            const tw = byId.get(sub.id);
+            // Match against the real submission row ID (now threaded
+            // through by the mapper). Fall back to `sub.id` for any
+            // mapper output that predates the `submissionId` field —
+            // older rows would have `id === submissionId` when
+            // participant data was missing.
+            const tw =
+              (sub.submissionId && byId.get(sub.submissionId)) ||
+              byId.get(sub.id);
             if (!tw) return sub;
             return {
               ...sub,

--- a/lib/utils/rewards-data-mapper.ts
+++ b/lib/utils/rewards-data-mapper.ts
@@ -63,6 +63,12 @@ export const mapJudgingSubmissionToRewardSubmission = (
 
   return {
     id: participant.id || sub.id || '',
+    // The real submission row ID, used by backend payloads (judging
+    // results, track winners) that key by submissionId. The mapper's
+    // `id` field stays on the participant ID for compatibility with
+    // existing rank-assignment and display code that already keys off
+    // it.
+    submissionId: submissionData.id || sub.id || sub.submissionId || '',
     participantId: participant.id || sub.id || '',
     name,
     projectName: submissionData.projectName || '',


### PR DESCRIPTION
## Why

Even after #576 landed the track-winner enrichment, the publish wizard preview was still rendering "3 of 8 winners assigned" on the Boundless × Trustless Work hackathon. The 5 track winners (Sunvasi, Stipend, Verix, Trustless OSS, Kinetic) were still being filtered out.

Root cause: the rewards data mapper at \`lib/utils/rewards-data-mapper.ts\` sets \`Submission.id\` to the **participant ID**, not the submission row ID. My #576 enrichment effect did:

\`\`\`ts
const byId = new Map(fetched.map(tw => [tw.submissionId, tw]));
setSubmissions(prev =>
  prev.map(sub => {
    const tw = byId.get(sub.id);  // sub.id is participantId, not submissionId
    if (!tw) return sub;
    // never reached
  })
);
\`\`\`

The Map keyed by submissionId never matched, so no submission got \`isTrackWinner = true\` stamped, and the wizard's filter (rank-OR-isTrackWinner) only caught the 3 overall winners.

## Fix

Three small files, one logical change:

- \`Submission\` type gains optional \`submissionId?: string\`.
- Mapper populates \`submissionId: submissionData.id || sub.id || sub.submissionId\`. The mapper's \`id\` field stays on the participant ID for compatibility with the existing rank-assignment / display code that already keys off it.
- Track-winner enrichment looks up \`byId.get(sub.submissionId)\` first, falls back to \`byId.get(sub.id)\` for any older mapper output that predates the new field.

After this, the wizard preview will show "All 8 winners assigned • 1,500 USDC pool" with the three overall placements and five track winners rendered as cards.

## Test plan

- [x] \`tsc --noEmit\` clean
- [ ] Manual: open the rewards page on the Boundless × Trustless Work hackathon. Expect "All 8 winners assigned" in the wizard, plus all 5 track winners visible on the rewards page TrackWinnersSection.
- [ ] Sanity: hackathon with no tracks renders unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced submission matching in the hackathon rewards system to correctly identify submissions for judging results and track winner assignments across different data formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/boundless/pull/582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->