### PR TITLE
fix(auth): send absolute callbackURL on Google sign-up

### DIFF
--- a/components/auth/SignupWrapper.tsx
+++ b/components/auth/SignupWrapper.tsx
@@ -27,11 +27,25 @@ const SignupWrapper = ({
     setIsLoading(true);
     setLoadingState(true);
 
+    // Better Auth treats a relative `callbackURL` as relative to the API
+    // host that handled the OAuth callback (e.g. api.boundlessfi.xyz),
+    // not the frontend host. The previous default of '/' caused
+    // successful sign-ups to land on the API host's root, so users saw
+    // a blank/404 page and thought sign-up had failed — yet the session
+    // cookie was already set, so a later cache clear silently logged
+    // them in. Always send an absolute URL pointing at the frontend.
+    const callbackURL =
+      typeof window !== 'undefined'
+        ? window.location.origin
+        : (
+            process.env.NEXT_PUBLIC_APP_URL || 'https://boundlessfi.xyz'
+          ).replace(/\/$/, '');
+
     try {
       await authClient.signIn.social(
         {
           provider: 'google',
-          callbackURL: process.env.NEXT_PUBLIC_APP_URL || '/',
+          callbackURL,
         },
         {
           onRequest: () => {


### PR DESCRIPTION
## Why

Google sign-up appeared to fail but actually succeeded. Users saw "nothing happened" after consenting on Google, then later (sometimes after clearing browser cache, sometimes just on next visit) found themselves silently logged in.

### Root cause

\`SignupWrapper\` passed \`callbackURL: process.env.NEXT_PUBLIC_APP_URL || '/'\` to \`authClient.signIn.social\`. Better Auth treats a relative path as relative to the **API host** that handled the OAuth callback (\`api.boundlessfi.xyz\`), not the frontend host. When the env var wasn't set or wasn't present at runtime, the fallback \`'/'\` sent users to the API host's root.

The session cookie WAS set during the callback (scoped to \`.boundlessfi.xyz\`, so visible across subdomains). But the user landed on a blank API page and assumed sign-up had failed.

When they later cleared "cached files and images" in their browser, the **cookie survived** (different toggle in Chrome's clear-data dialog), so the next visit to \`www.boundlessfi.xyz\` restored their session via \`authClient.useSession()\` and they appeared "automatically logged in."

### Fix

Build the \`callbackURL\` as an absolute URL pointing at the frontend host. Mirrors the pattern \`LoginWrapper\` already uses:

\`\`\`ts
const callbackURL =
  typeof window !== 'undefined'
    ? window.location.origin
    : (process.env.NEXT_PUBLIC_APP_URL || 'https://boundlessfi.xyz').replace(/\\/\$/, '');
\`\`\`

\`window.location.origin\` resolves at runtime (handles preview/staging hosts correctly). All three resolution paths (window, env, hard-coded) produce URLs already in the BE's \`trustedOrigins\` list, so Better Auth won't reject the request.

### Out of scope (flagged for follow-up)

\`auth/index.ts:144\` has \`disableCSRFCheck: true\`. That's a real risk on a public-facing auth endpoint and should be re-enabled in a separate PR.

## Risk

One file, +15/-1, frontend-only, no API surface change.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] Pre-push hooks pass
- [ ] Manual: sign up with Google in an incognito window. Expect to land on the frontend (post-callback) and see the logged-in state immediately, no cache-clear needed.
- [ ] Manual: same flow with \`NEXT_PUBLIC_APP_URL\` unset locally. Expect the same outcome (window.location.origin now drives the redirect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google sign-in reliability by fixing OAuth callback URL handling. The authentication system now correctly computes and uses absolute callback URLs, ensuring reliable sign-in with Google across all deployment environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/boundless/pull/584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->