### PR TITLE
fix(blog): drop duplicate h1 from hackathon winners post

### DIFF
--- a/content/blog/boundless-trustless-work-hackathon-winners.mdx
+++ b/content/blog/boundless-trustless-work-hackathon-winners.mdx
@@ -23,8 +23,6 @@ seoTitle: 'Boundless x Trustless Work Hackathon Winners Announced'
 seoDescription: 'The winners of the Boundless x Trustless Work Hackathon: Conductor takes first place, with Crypt and GoPadi rounding out the podium and five honorable mentions on escrow-powered builds.'
 ---
 
-# Boundless x Trustless Work Hackathon: Winners and Recognitions
-
 Last week, we wrapped up four exciting days of building, collaboration, and innovation during the Boundless x Trustless Work Hackathon and now, the results are in.
 
 What started as a small hackathon aimed at improving our hackathon flow quickly turned into something much bigger. Builders from different tech backgrounds and countries came together to explore practical ways to implement [Trustless Work](https://www.trustlesswork.com/)'s escrow infrastructure, and the response exceeded our expectations with far more submissions than we anticipated.


### PR DESCRIPTION
## Summary
`BlogPostDetails` already renders `post.title` from frontmatter as the page heading above the cover banner, so the matching `# Boundless x Trustless Work Hackathon: Winners and Recognitions` at the top of the MDX body was rendering a second time directly under the banner. Removed the body-level h1 so the page only shows the title once.

Only the new hackathon-winners post is touched. The other existing posts in `content/blog/` carry the same duplicate-h1 pattern and presumably render the same way today — leaving them alone here since I haven't been asked to touch them.

## Test plan
- [ ] Open `/blog/boundless-trustless-work-hackathon-winners`. The title should appear once (above the banner), not twice.
- [ ] Other blog posts are visually unchanged.