### PR TITLE
feat(didit): drive verification UI from /didit/status, fix In Review button

### DIFF
--- a/app/api/didit/callback/route.ts
+++ b/app/api/didit/callback/route.ts
@@ -1,17 +1,31 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-/**
- * Didit redirect callback: user is sent here after completing verification on Didit.
- * We redirect them to Settings → Identity so they see their updated status.
- * The backend receives the final result via webhook; this route only handles the browser redirect.
- */
-export async function GET(request: NextRequest) {
-  const searchParams = request.nextUrl.searchParams;
-  const verification = searchParams.get('verification') ?? 'complete';
+const KNOWN_STATES = new Set([
+  'not_started',
+  'in_progress',
+  'in_review',
+  'approved',
+  'declined',
+  'abandoned',
+  'expired',
+]);
 
-  const baseUrl = request.nextUrl.origin;
-  const redirectUrl = new URL('/me/settings', baseUrl);
-  redirectUrl.searchParams.set('verification', verification);
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams;
+
+  // Backend (`GET /api/didit/callback` on NestJS) forwards an authoritative
+  // `state` from the DB. Didit's hosted flow may instead arrive here directly
+  // with `?status=Approved` (legacy) or `?verification=complete` (legacy).
+  // We normalize all of those, but only the new `state` is trusted as a
+  // status — the rest just route the user back to settings.
+  const stateRaw = params.get('state');
+  const state = stateRaw && KNOWN_STATES.has(stateRaw) ? stateRaw : 'in_review';
+
+  const redirectUrl = new URL('/me/settings', request.nextUrl.origin);
+  redirectUrl.searchParams.set('verification', state);
+  redirectUrl.searchParams.set('tab', 'identity');
+  const sessionId = params.get('session_id');
+  if (sessionId) redirectUrl.searchParams.set('session_id', sessionId);
 
   return NextResponse.redirect(redirectUrl, 302);
 }

--- a/app/me/settings/SettingsContent.tsx
+++ b/app/me/settings/SettingsContent.tsx
@@ -6,6 +6,11 @@ import { useSearchParams } from 'next/navigation';
 import { VerificationSubmittedModal } from '@/components/didit/VerificationSubmittedModal';
 import { User } from '@/types/user';
 import { getMe } from '@/lib/api/auth';
+import {
+  getDiditStatus,
+  type VerificationState,
+  type VerificationStatus,
+} from '@/lib/api/didit';
 import { GetMeResponse } from '@/lib/api/types';
 import { Skeleton } from '@/components/ui/skeleton';
 import Settings from '@/components/profile/update/Settings';
@@ -15,9 +20,32 @@ import { IdentityVerificationSection } from '@/components/didit/IdentityVerifica
 import { useRef } from 'react';
 import { Loader2 } from 'lucide-react';
 
+const KNOWN_VERIFICATION_STATES = new Set<VerificationState>([
+  'not_started',
+  'in_progress',
+  'in_review',
+  'approved',
+  'declined',
+  'abandoned',
+  'expired',
+]);
+
 const SettingsContent = () => {
   const searchParams = useSearchParams();
-  const fromVerification = searchParams.get('verification') === 'complete';
+  const verificationParam = searchParams.get('verification');
+  // Modal is shown when the user just returned from the Didit hosted flow:
+  // the legacy callback used `verification=complete`, the new callback
+  // forwards the resolved `state` (e.g. `verification=in_review`).
+  const fromVerification = Boolean(verificationParam);
+  const initialModalState: VerificationState | null =
+    verificationParam &&
+    KNOWN_VERIFICATION_STATES.has(verificationParam as VerificationState)
+      ? (verificationParam as VerificationState)
+      : verificationParam === 'complete'
+        ? 'in_review'
+        : null;
+  const [verificationModalStatus, setVerificationModalStatus] =
+    useState<VerificationStatus | null>(null);
   const [userData, setUserData] = useState<GetMeResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [showVerificationModal, setShowVerificationModal] =
@@ -38,12 +66,34 @@ const SettingsContent = () => {
   }, []);
 
   useEffect(() => {
-    // Only set isLoading true on the very first fetch
     if (!hasLoadedOnce.current) {
       setIsLoading(true);
     }
     fetchUserData();
   }, [fetchUserData]);
+
+  useEffect(() => {
+    if (!fromVerification) return;
+    let cancelled = false;
+    getDiditStatus()
+      .then(status => {
+        if (cancelled) return;
+        setVerificationModalStatus(status);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        if (initialModalState) {
+          setVerificationModalStatus({
+            state: initialModalState,
+            canStartNew: false,
+            message: '',
+          });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [fromVerification, initialModalState]);
 
   // Only show skeleton on first load — not on background refetches
   if (isLoading && !hasLoadedOnce.current) {
@@ -58,6 +108,7 @@ const SettingsContent = () => {
       <VerificationSubmittedModal
         open={showVerificationModal}
         onClose={() => setShowVerificationModal(false)}
+        status={verificationModalStatus}
       />
       <div className=''>
         {/* Header */}
@@ -70,7 +121,11 @@ const SettingsContent = () => {
           </p>
         </div>
         <Tabs
-          defaultValue={fromVerification ? 'identity' : 'profile'}
+          defaultValue={
+            searchParams.get('tab') === 'identity' || fromVerification
+              ? 'identity'
+              : 'profile'
+          }
           className='w-full'
         >
           <TabsList className='inline-flex h-auto gap-6 bg-transparent p-0'>
@@ -171,7 +226,7 @@ const SettingsContent = () => {
             )}
           </TabsContent>
           <TabsContent value='identity' className='space-y-6'>
-            <IdentityVerificationSection user={userData} />
+            <IdentityVerificationSection />
           </TabsContent>
         </Tabs>
       </div>

--- a/components/didit/DiditVerifyButton.tsx
+++ b/components/didit/DiditVerifyButton.tsx
@@ -9,12 +9,14 @@ export interface DiditVerifyButtonProps {
   onError?: (error: Error | { code?: string; message?: string }) => void;
   className?: string;
   disabled?: boolean;
+  label?: string;
 }
 
 export function DiditVerifyButton({
   onError,
   className,
   disabled = false,
+  label = 'Verify identity',
 }: DiditVerifyButtonProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -50,7 +52,7 @@ export function DiditVerifyButton({
         disabled={disabled || loading}
         className={clsx(className)}
       >
-        {loading ? 'Redirecting to verification…' : 'Verify identity'}
+        {loading ? 'Redirecting to verification…' : label}
       </Button>
       {error && (
         <p className='text-sm text-red-500' role='alert'>

--- a/components/didit/IdentityVerificationSection.tsx
+++ b/components/didit/IdentityVerificationSection.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useCallback, useEffect, useState } from 'react';
 import { DiditVerifyButton } from './DiditVerifyButton';
 import {
   Card,
@@ -9,39 +10,59 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { CheckCircle2, XCircle, Clock, AlertCircle } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  CheckCircle2,
+  XCircle,
+  Clock,
+  AlertCircle,
+  Hourglass,
+  RotateCcw,
+} from 'lucide-react';
 import clsx from 'clsx';
-import type { GetMeResponse } from '@/lib/api/types';
+import {
+  getDiditStatus,
+  type VerificationState,
+  type VerificationStatus,
+} from '@/lib/api/didit';
 
-export type IdentityVerificationStatus =
-  | 'Approved'
-  | 'Declined'
-  | 'In Review'
-  | null
-  | undefined;
-
-export interface IdentityVerificationSectionProps {
-  user: GetMeResponse | null;
+interface BadgeConfig {
+  label: string;
+  icon: React.ElementType;
+  className: string;
 }
 
-const statusConfig: Record<
-  string,
-  { label: string; icon: React.ElementType; className: string }
-> = {
-  Approved: {
+const STATE_BADGES: Record<VerificationState, BadgeConfig | null> = {
+  not_started: null,
+  in_progress: {
+    label: 'In progress',
+    icon: Hourglass,
+    className: 'text-sky-400 bg-sky-500/10 border-sky-500/20',
+  },
+  in_review: {
+    label: 'Under review',
+    icon: Clock,
+    className: 'text-amber-400 bg-amber-500/10 border-amber-500/20',
+  },
+  approved: {
     label: 'Verified',
     icon: CheckCircle2,
     className: 'text-emerald-500 bg-emerald-500/10 border-emerald-500/20',
   },
-  Declined: {
+  declined: {
     label: 'Declined',
     icon: XCircle,
     className: 'text-red-500 bg-red-500/10 border-red-500/20',
   },
-  'In Review': {
-    label: 'In review',
-    icon: Clock,
-    className: 'text-amber-500 bg-amber-500/10 border-amber-500/20',
+  abandoned: {
+    label: 'Not completed',
+    icon: AlertCircle,
+    className: 'text-zinc-400 bg-zinc-500/10 border-zinc-500/20',
+  },
+  expired: {
+    label: 'Expired',
+    icon: RotateCcw,
+    className: 'text-zinc-400 bg-zinc-500/10 border-zinc-500/20',
   },
 };
 
@@ -50,14 +71,39 @@ const isLocalhost = (): boolean =>
   (window.location.hostname === 'localhost' ||
     window.location.hostname === '127.0.0.1');
 
-export function IdentityVerificationSection({
-  user,
-}: IdentityVerificationSectionProps) {
-  const status = user?.user
-    ?.identityVerificationStatus as IdentityVerificationStatus;
-  const verifiedAt = user?.user?.identityVerificationAt;
-  const config = status ? statusConfig[status] : null;
-  const StatusIcon = config?.icon ?? AlertCircle;
+const formatDate = (iso?: string): string | null => {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString(undefined, { dateStyle: 'medium' });
+};
+
+export function IdentityVerificationSection() {
+  const [status, setStatus] = useState<VerificationStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setError(null);
+      const next = await getDiditStatus();
+      setStatus(next);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load status');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (status?.state !== 'in_progress') return;
+    const id = setInterval(refresh, 10_000);
+    return () => clearInterval(id);
+  }, [status?.state, refresh]);
 
   return (
     <Card className='border-zinc-800 bg-zinc-900/30'>
@@ -69,47 +115,98 @@ export function IdentityVerificationSection({
         </CardDescription>
       </CardHeader>
       <CardContent className='space-y-4'>
-        {status && config ? (
-          <div className='flex flex-wrap items-center gap-3'>
-            <Badge
-              variant='outline'
-              className={clsx(
-                'inline-flex items-center gap-1.5 font-medium',
-                config.className
-              )}
+        {loading ? (
+          <Skeleton className='h-9 w-48' />
+        ) : error ? (
+          <div className='flex items-center justify-between gap-3 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-300'>
+            <span>Could not load verification status: {error}</span>
+            <button
+              type='button'
+              onClick={refresh}
+              className='text-xs underline'
             >
-              <StatusIcon className='h-3.5 w-3.5' />
-              {config.label}
-            </Badge>
-            {verifiedAt && status === 'Approved' && (
-              <span className='text-sm text-zinc-500'>
-                Verified on{' '}
-                {new Date(verifiedAt).toLocaleDateString(undefined, {
-                  dateStyle: 'medium',
-                })}
-              </span>
-            )}
+              Retry
+            </button>
           </div>
-        ) : (
-          <p className='text-sm text-zinc-500'>
-            You have not completed identity verification yet.
-          </p>
-        )}
+        ) : status ? (
+          <StatusBlock status={status} onRetry={refresh} />
+        ) : null}
 
-        {user && status !== 'Approved' && status !== 'In Review' && (
-          <>
-            <DiditVerifyButton />
-            {isLocalhost() && (
-              <p className='rounded-md border border-zinc-700 bg-zinc-800/50 px-3 py-2 text-xs text-zinc-500'>
-                Using localhost? If verification is blocked by the browser, use
-                a tunnel (e.g. ngrok) and set your backend FRONTEND_URL or
-                DIDIT_CALLBACK_URL to the tunnel URL. See DIDIT_INTEGRATION.md →
-                Troubleshooting.
-              </p>
-            )}
-          </>
+        {!loading && status?.canStartNew && isLocalhost() && (
+          <p className='rounded-md border border-zinc-700 bg-zinc-800/50 px-3 py-2 text-xs text-zinc-500'>
+            Using localhost? If verification is blocked by the browser, use a
+            tunnel (e.g. ngrok) and set your backend FRONTEND_URL or
+            DIDIT_CALLBACK_URL to the tunnel URL. See DIDIT_INTEGRATION.md →
+            Troubleshooting.
+          </p>
         )}
       </CardContent>
     </Card>
+  );
+}
+
+interface StatusBlockProps {
+  status: VerificationStatus;
+  onRetry: () => void;
+}
+
+function StatusBlock({ status, onRetry }: StatusBlockProps) {
+  const badge = STATE_BADGES[status.state];
+  const BadgeIcon = badge?.icon ?? AlertCircle;
+  const verifiedOn = formatDate(status.verifiedAt);
+  const estimatedOn = formatDate(status.reviewWindow?.estimatedCompletionAt);
+
+  return (
+    <div className='space-y-4'>
+      <div className='flex flex-wrap items-center gap-3'>
+        {badge && (
+          <Badge
+            variant='outline'
+            className={clsx(
+              'inline-flex items-center gap-1.5 font-medium',
+              badge.className
+            )}
+          >
+            <BadgeIcon className='h-3.5 w-3.5' />
+            {badge.label}
+          </Badge>
+        )}
+        {verifiedOn && status.state === 'approved' && (
+          <span className='text-sm text-zinc-500'>
+            Verified on {verifiedOn}
+          </span>
+        )}
+      </div>
+
+      <p className='text-sm text-zinc-400'>{status.message}</p>
+
+      {status.state === 'in_review' && status.reviewWindow && (
+        <div className='rounded-md border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-xs text-amber-200/90'>
+          Expected completion: by <strong>{estimatedOn}</strong> (
+          {status.reviewWindow.minBusinessDays}-
+          {status.reviewWindow.maxBusinessDays} business days). We will email
+          you when it&rsquo;s done — no need to wait on this page.
+        </div>
+      )}
+
+      {status.state === 'declined' && status.decline?.reason && (
+        <div className='rounded-md border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-200/90'>
+          Reason: {status.decline.reason}
+        </div>
+      )}
+
+      {status.canStartNew && (
+        <DiditVerifyButton
+          label={
+            status.state === 'declined'
+              ? 'Try verification again'
+              : status.state === 'expired' || status.state === 'abandoned'
+                ? 'Start new verification'
+                : 'Verify identity'
+          }
+          onError={onRetry}
+        />
+      )}
+    </div>
   );
 }

--- a/components/didit/VerificationSubmittedModal.tsx
+++ b/components/didit/VerificationSubmittedModal.tsx
@@ -9,44 +9,163 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { Clock } from 'lucide-react';
+import { CheckCircle2, Clock, XCircle, AlertCircle } from 'lucide-react';
+import clsx from 'clsx';
+import type { VerificationState, VerificationStatus } from '@/lib/api/didit';
 
 interface VerificationSubmittedModalProps {
   open: boolean;
   onClose: () => void;
+  status?: VerificationStatus | null;
 }
+
+interface StateCopy {
+  title: string;
+  description: (status: VerificationStatus) => string;
+  icon: React.ElementType;
+  iconClass: string;
+  ringClass: string;
+  haloClass: string;
+  cta: string;
+}
+
+const COPY: Partial<Record<VerificationState, StateCopy>> = {
+  in_review: {
+    title: 'Verification submitted',
+    description: status => {
+      const { reviewWindow } = status;
+      if (!reviewWindow) {
+        return 'Your identity is under review. We will email you once it is complete.';
+      }
+      const completion = new Date(
+        reviewWindow.estimatedCompletionAt
+      ).toLocaleDateString(undefined, { dateStyle: 'medium' });
+      return `Your identity is under review. Decisions usually take ${reviewWindow.minBusinessDays}-${reviewWindow.maxBusinessDays} business days — expected by ${completion}. We will email you when it is complete.`;
+    },
+    icon: Clock,
+    iconClass: 'text-amber-400',
+    ringClass: 'bg-amber-500/10 ring-amber-500/30',
+    haloClass: 'bg-amber-500/20',
+    cta: 'Got it',
+  },
+  approved: {
+    title: 'You are verified',
+    description: () =>
+      'Your identity has been verified. You can now use all features that require KYC.',
+    icon: CheckCircle2,
+    iconClass: 'text-emerald-400',
+    ringClass: 'bg-emerald-500/10 ring-emerald-500/30',
+    haloClass: 'bg-emerald-500/20',
+    cta: 'Continue',
+  },
+  declined: {
+    title: 'Verification was declined',
+    description: status => {
+      const reason = status.decline?.reason;
+      return reason
+        ? `Reason: ${reason}. You can try again from this page.`
+        : 'Your verification did not pass review. You can try again from this page.';
+    },
+    icon: XCircle,
+    iconClass: 'text-red-400',
+    ringClass: 'bg-red-500/10 ring-red-500/30',
+    haloClass: 'bg-red-500/20',
+    cta: 'Got it',
+  },
+  in_progress: {
+    title: 'Verification in progress',
+    description: () =>
+      'We are still receiving your verification result. This page will update automatically — you can also wait for the email.',
+    icon: Clock,
+    iconClass: 'text-sky-400',
+    ringClass: 'bg-sky-500/10 ring-sky-500/30',
+    haloClass: 'bg-sky-500/20',
+    cta: 'Got it',
+  },
+  abandoned: {
+    title: 'Verification was not completed',
+    description: () =>
+      'It looks like the verification flow ended before you finished. You can start a new verification from this page.',
+    icon: AlertCircle,
+    iconClass: 'text-zinc-300',
+    ringClass: 'bg-zinc-500/10 ring-zinc-500/30',
+    haloClass: 'bg-zinc-500/20',
+    cta: 'Got it',
+  },
+  expired: {
+    title: 'Verification session expired',
+    description: () =>
+      'Your verification session expired before you finished. You can start a new one from this page.',
+    icon: AlertCircle,
+    iconClass: 'text-zinc-300',
+    ringClass: 'bg-zinc-500/10 ring-zinc-500/30',
+    haloClass: 'bg-zinc-500/20',
+    cta: 'Got it',
+  },
+};
+
+const FALLBACK: StateCopy = {
+  title: 'Verification submitted',
+  description: () =>
+    'Your identity is under review. We will email you once it is complete.',
+  icon: Clock,
+  iconClass: 'text-amber-400',
+  ringClass: 'bg-amber-500/10 ring-amber-500/30',
+  haloClass: 'bg-amber-500/20',
+  cta: 'Got it',
+};
 
 export function VerificationSubmittedModal({
   open,
   onClose,
+  status,
 }: VerificationSubmittedModalProps) {
+  const state = status?.state ?? 'in_review';
+  const copy = COPY[state] ?? FALLBACK;
+  const Icon = copy.icon;
+  const description = status
+    ? copy.description(status)
+    : copy.description({
+        state,
+        canStartNew: false,
+        message: '',
+      } as VerificationStatus);
+
   return (
     <Dialog open={open} onOpenChange={o => !o && onClose()}>
       <DialogContent
         showCloseButton={false}
         className='flex flex-col items-center gap-0 border-zinc-800 bg-zinc-900 p-8 text-center sm:max-w-sm'
       >
-        {/* Animated icon */}
         <div className='relative mb-6 flex items-center justify-center'>
-          <span className='absolute inline-flex h-20 w-20 animate-ping rounded-full bg-amber-500/20' />
-          <span className='relative flex h-16 w-16 items-center justify-center rounded-full bg-amber-500/10 ring-1 ring-amber-500/30'>
-            <Clock className='h-8 w-8 text-amber-400' />
+          <span
+            className={clsx(
+              'absolute inline-flex h-20 w-20 animate-ping rounded-full',
+              copy.haloClass
+            )}
+          />
+          <span
+            className={clsx(
+              'relative flex h-16 w-16 items-center justify-center rounded-full ring-1',
+              copy.ringClass
+            )}
+          >
+            <Icon className={clsx('h-8 w-8', copy.iconClass)} />
           </span>
         </div>
 
         <DialogHeader className='w-full'>
           <DialogTitle className='text-center text-xl text-white'>
-            Verification submitted
+            {copy.title}
           </DialogTitle>
           <DialogDescription className='mt-2 text-center text-sm text-zinc-400'>
-            Your identity is under review. This usually takes a few minutes. We
-            will notify you by email once it is complete.
+            {description}
           </DialogDescription>
         </DialogHeader>
 
         <DialogFooter className='mt-6 w-full'>
           <Button onClick={onClose} className='w-full'>
-            Got it
+            {copy.cta}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/lib/api/didit.ts
+++ b/lib/api/didit.ts
@@ -49,3 +49,41 @@ export const createDiditSession = async (
     status: session.status,
   };
 };
+
+export type VerificationState =
+  | 'not_started'
+  | 'in_progress'
+  | 'in_review'
+  | 'approved'
+  | 'declined'
+  | 'abandoned'
+  | 'expired';
+
+export interface VerificationReviewWindow {
+  minBusinessDays: number;
+  maxBusinessDays: number;
+  estimatedCompletionAt: string;
+}
+
+export interface VerificationDecline {
+  reason?: string;
+  canRetry: boolean;
+}
+
+export interface VerificationStatus {
+  state: VerificationState;
+  canStartNew: boolean;
+  message: string;
+  verifiedAt?: string;
+  reviewedAt?: string;
+  reviewWindow?: VerificationReviewWindow;
+  decline?: VerificationDecline;
+}
+
+export const getDiditStatus = async (): Promise<VerificationStatus> => {
+  const res = await api.get<ApiResponse<VerificationStatus>>('/didit/status');
+  if (!res.data?.data?.state) {
+    throw new Error('Invalid verification status response');
+  }
+  return res.data.data;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "gray-matter": "^4.0.3",
         "gsap": "^3.13.0",
         "input-otp": "^1.4.2",
-        "js-cookie": "^3.0.5",
+        "js-cookie": "^3.0.7",
         "lodash.debounce": "^4.0.8",
         "lucide-react": "^0.525.0",
         "marked": "^16.3.0",
@@ -11931,12 +11931,12 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "gray-matter": "^4.0.3",
     "gsap": "^3.13.0",
     "input-otp": "^1.4.2",
-    "js-cookie": "^3.0.5",
+    "js-cookie": "^3.0.7",
     "lodash.debounce": "^4.0.8",
     "lucide-react": "^0.525.0",
     "marked": "^16.3.0",


### PR DESCRIPTION
## Summary

Reported issues:
- When the user's identity verification is **In Review**, the verify button still shows.
- After returning from the Didit hosted flow, there is no clear "what happens next, how long" copy.

Pairs with the backend PR that adds [`GET /api/didit/status`](https://github.com/boundlessfi/boundless-nestjs/pull/192) — a single normalized state object the frontend can switch on instead of inferring from the raw `identityVerificationStatus` string.

## Changes

### `lib/api/didit.ts`
- `getDiditStatus()` returning a typed `VerificationStatus`:
  ```ts
  state: 'not_started' | 'in_progress' | 'in_review' | 'approved' | 'declined' | 'abandoned' | 'expired';
  canStartNew: boolean;
  message: string;
  verifiedAt?: string;
  reviewedAt?: string;
  reviewWindow?: { minBusinessDays, maxBusinessDays, estimatedCompletionAt };
  decline?: { reason?, canRetry };
  ```

### `IdentityVerificationSection`
- Source of truth is now the status endpoint, not `user.identityVerificationStatus`. The user prop is gone.
- **The verify button is gated on `canStartNew === true`.** That kills the reported bug for every status string the backend can return.
- Each state gets its own badge + copy + (conditional) review-window or decline-reason block:
  - `in_review` → amber "Under review" badge, message, and a card showing "Expected completion: by *date* (1-3 business days)".
  - `approved` → emerald "Verified" badge with `verifiedAt`.
  - `declined` → red badge + reason (if present) + "Try verification again" button.
  - `abandoned` / `expired` → zinc badge + "Start new verification" button.
  - `in_progress` → sky badge; component auto-polls every 10s so the UI flips once the webhook lands.

### `VerificationSubmittedModal`
- Now takes the full `VerificationStatus`. Title, icon, halo color, body copy, and CTA all switch per state. The `in_review` body reads "Decisions usually take 1-3 business days — expected by *date*. We will email you when it is complete." using the precise SLA from the backend.

### `app/api/didit/callback/route.ts`
- Accepts the new `?state=...&session_id=...` (from the backend's callback redirect) and the legacy `?verification=complete`.
- Redirects to `/me/settings?verification=<state>&tab=identity&session_id=...` so users land on the identity tab and the modal opens with the right copy.

### `SettingsContent`
- Fetches `getDiditStatus()` when `?verification=...` is present so the modal can render with the exact `reviewWindow`. Falls back to the URL state if the fetch fails.
- Tab picker honors `?tab=identity`.

### Side fix: dependency

Pre-push hook ran `npm audit --audit-level=high` and blocked on a high-severity advisory in `js-cookie` 3.0.5 (cookie-attribute injection via prototype hijack in `.assign()`). Bumped to 3.0.7 — patch only, no API change. Same audit returned 9 moderate, 1 high before; 9 moderate, 0 high after.

## Verified locally

- `tsc --noEmit` clean.
- `npm run lint` clean.
- Prettier clean.
- Husky pre-commit + pre-push all green after the dep bump.

## Walked through each state in the type system

The state union and switch tables in `STATE_BADGES` (section) and `COPY` (modal) cover all seven values exhaustively. `canStartNew` is derived on the backend, so a future state addition won't accidentally re-show the verify button until both sides know about it.

## Deploy notes

No env changes required. Once the backend PR lands, this UI starts consuming the new endpoint immediately. If `GET /api/didit/status` returns an error, the section shows a small retry button instead of crashing the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Identity verification modal now displays real-time verification status with estimated completion dates and detailed decline information.
  * Enhanced verification flow that properly manages state when users return from the verification process.

* **Improvements**
  * Verify button now supports custom labels for flexible UI customization.
  * Identity verification status automatically updates with 10-second polling during review.
  * Improved error handling and retry functionality for verification status retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boundlessfi/boundless/pull/590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->