### PR TITLE
fix: align request payloads with backend DTOs ahead of forbidNonWhitelisted

### DIFF
--- a/app/(landing)/hackathons/[slug]/teams/[teamId]/page.tsx
+++ b/app/(landing)/hackathons/[slug]/teams/[teamId]/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useHackathon, useTeam } from '@/hooks/hackathon/use-hackathon-queries';
 import { Button } from '@/components/ui/button';
 import BasicAvatar from '@/components/avatars/BasicAvatar';
+import { readTeamContact } from '@/lib/api/hackathons/teams';
 import {
   ArrowLeft,
   Calendar,
@@ -227,22 +228,24 @@ export default function TeamDetailsPage({
                   </div>
                 )}
 
-                {team.contactInfo && (
-                  <div className='rounded-2xl border border-white/5 bg-[#0A0B0D] p-6'>
-                    <h2 className='mb-4 text-[10px] font-black tracking-[0.2em] text-[#555555] uppercase'>
-                      Contact
-                    </h2>
-                    <div className='flex items-start gap-3 text-sm text-gray-300'>
-                      <Mail className='mt-0.5 h-4 w-4 shrink-0 text-gray-500' />
-                      <span className='break-all'>{team.contactInfo}</span>
-                    </div>
-                    {team.contactMethod && (
+                {(() => {
+                  const contact = readTeamContact(team.contactInfo);
+                  if (!contact) return null;
+                  return (
+                    <div className='rounded-2xl border border-white/5 bg-[#0A0B0D] p-6'>
+                      <h2 className='mb-4 text-[10px] font-black tracking-[0.2em] text-[#555555] uppercase'>
+                        Contact
+                      </h2>
+                      <div className='flex items-start gap-3 text-sm text-gray-300'>
+                        <Mail className='mt-0.5 h-4 w-4 shrink-0 text-gray-500' />
+                        <span className='break-all'>{contact.value}</span>
+                      </div>
                       <p className='mt-2 text-[10px] font-bold tracking-wider text-gray-500 uppercase'>
-                        Via {team.contactMethod}
+                        Via {contact.method}
                       </p>
-                    )}
-                  </div>
-                )}
+                    </div>
+                  );
+                })()}
               </div>
             </div>
           </div>

--- a/components/hackathons/team-formation/ContactTeamModal.tsx
+++ b/components/hackathons/team-formation/ContactTeamModal.tsx
@@ -18,7 +18,10 @@ import {
   ExternalLink,
   Check,
 } from 'lucide-react';
-import { TeamRecruitmentPost } from '@/lib/api/hackathons/teams';
+import {
+  readTeamContact,
+  TeamRecruitmentPost,
+} from '@/lib/api/hackathons/teams';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
@@ -39,10 +42,16 @@ export function ContactTeamModal({
 
   if (!team) return null;
 
-  const { teamName, contactMethod, contactInfo, id } = team;
+  const { teamName, contactInfo, id } = team;
+  const contact = readTeamContact(contactInfo);
+
+  // If the team has no contact info at all, render nothing: the parent
+  // should have already gated this modal, but defend against bad data.
+  if (!contact) return null;
+  const { method: contactMethod, value: contactValue } = contact;
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(contactInfo);
+    navigator.clipboard.writeText(contactValue);
     setCopied(true);
     toast.success('Contact info copied to clipboard');
     setTimeout(() => setCopied(false), 2000);
@@ -56,8 +65,6 @@ export function ContactTeamModal({
       case 'telegram':
       case 'discord':
         return <MessageCircle className='h-5 w-5' />;
-      case 'github':
-        return <Github className='h-5 w-5' />;
       default:
         return <Globe className='h-5 w-5' />;
     }
@@ -71,15 +78,13 @@ export function ContactTeamModal({
         return 'Telegram Username/Link';
       case 'discord':
         return 'Discord Username';
-      case 'github':
-        return 'GitHub Profile';
       default:
         return 'Contact Info';
     }
   };
 
   const isLink =
-    contactInfo.startsWith('http') || contactInfo.startsWith('https');
+    contactValue.startsWith('http') || contactValue.startsWith('https');
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -104,7 +109,7 @@ export function ContactTeamModal({
                   {getLabel()}
                 </p>
                 <p className='truncate text-lg font-bold text-white'>
-                  {contactInfo}
+                  {contactValue}
                 </p>
               </div>
             </div>
@@ -132,7 +137,7 @@ export function ContactTeamModal({
                 variant='outline'
                 className='h-12 flex-1 rounded-xl border-white/10 bg-white/5 font-bold hover:bg-white/10'
                 onClick={() => {
-                  window.open(contactInfo, '_blank', 'noopener,noreferrer');
+                  window.open(contactValue, '_blank', 'noopener,noreferrer');
                   onTrackContact?.(id);
                 }}
               >

--- a/components/hackathons/team-formation/CreateTeamPostModal.tsx
+++ b/components/hackathons/team-formation/CreateTeamPostModal.tsx
@@ -28,7 +28,11 @@ import { BoundlessButton } from '@/components/buttons/BoundlessButton';
 import { useTeamPosts } from '@/hooks/hackathon/use-team-posts';
 import { Loader2, Plus, X, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { type TeamRecruitmentPost } from '@/lib/api/hackathons/teams';
+import {
+  readTeamContact,
+  type TeamContactInfo,
+  type TeamRecruitmentPost,
+} from '@/lib/api/hackathons/teams';
 
 const roleSchema = z.object({
   role: z.string().min(1, 'Role name is required'),
@@ -86,13 +90,12 @@ export function CreateTeamPostModal({
             maxRoles,
             `You can add at most ${maxRoles} open role${maxRoles === 1 ? '' : 's'} (the team is capped at ${effectiveTeamMax} member${effectiveTeamMax === 1 ? '' : 's'} including you)`
           ),
-        contactMethod: z.enum([
-          'email',
-          'telegram',
-          'discord',
-          'github',
-          'other',
-        ]),
+        // contactMethod stays on the form for UX (radio-style selector)
+        // but is NOT sent to the backend as a separate field. Backend stores
+        // contact as a sparse object keyed by channel (TeamContactInfo);
+        // onSubmit transforms { contactMethod, contactInfo } into that shape.
+        // github / other were dropped because the backend cannot store them.
+        contactMethod: z.enum(['email', 'telegram', 'discord']),
         contactInfo: z.string().min(1, 'Contact info is required'),
       }),
     [maxRoles, effectiveTeamMax]
@@ -105,6 +108,11 @@ export function CreateTeamPostModal({
 
   const isEditMode = !!initialData;
 
+  // Flatten the backend's sparse contactInfo object back into the form's
+  // single { method, value } UI representation. Used both as the initial
+  // form value and in the edit-mode reset below.
+  const initialContact = readTeamContact(initialData?.contactInfo);
+
   const form = useForm<TeamPostFormData>({
     resolver: zodResolver(teamPostSchema),
     defaultValues: {
@@ -115,8 +123,8 @@ export function CreateTeamPostModal({
           role: typeof roleObj === 'string' ? roleObj : roleObj.role,
           skills: typeof roleObj === 'string' ? [] : roleObj.skills || [],
         })) || [],
-      contactMethod: initialData?.contactMethod || 'email',
-      contactInfo: initialData?.contactInfo || '',
+      contactMethod: initialContact?.method ?? 'email',
+      contactInfo: initialContact?.value ?? '',
     },
   });
 
@@ -125,6 +133,7 @@ export function CreateTeamPostModal({
 
   useEffect(() => {
     if (open && initialData) {
+      const contact = readTeamContact(initialData.contactInfo);
       form.reset({
         teamName: initialData.teamName,
         description: initialData.description,
@@ -132,8 +141,8 @@ export function CreateTeamPostModal({
           role: typeof roleObj === 'string' ? roleObj : roleObj.role,
           skills: typeof roleObj === 'string' ? [] : roleObj.skills || [],
         })),
-        contactMethod: initialData.contactMethod || 'email',
-        contactInfo: initialData.contactInfo,
+        contactMethod: contact?.method ?? 'email',
+        contactInfo: contact?.value ?? '',
       });
     } else if (!open) {
       form.reset();
@@ -207,6 +216,11 @@ export function CreateTeamPostModal({
   };
 
   const onSubmit = async (data: TeamPostFormData) => {
+    // Project the form's single { method, value } shape into the backend's
+    // sparse TeamContactInfo object. The channel is implicit in the key.
+    const contactInfo: TeamContactInfo = {
+      [data.contactMethod]: data.contactInfo,
+    };
     try {
       if (isEditMode && initialData) {
         await updatePost(initialData.id, {
@@ -214,11 +228,15 @@ export function CreateTeamPostModal({
           description: data.description,
           lookingFor: data.lookingFor,
           isOpen: data.lookingFor.length > 0,
-          contactMethod: data.contactMethod,
-          contactInfo: data.contactInfo,
+          contactInfo,
         });
       } else {
-        await createPost(data);
+        await createPost({
+          teamName: data.teamName,
+          description: data.description,
+          lookingFor: data.lookingFor,
+          contactInfo,
+        });
       }
 
       onOpenChange(false);
@@ -483,8 +501,6 @@ export function CreateTeamPostModal({
                             <SelectItem value='email'>Email</SelectItem>
                             <SelectItem value='telegram'>Telegram</SelectItem>
                             <SelectItem value='discord'>Discord</SelectItem>
-                            <SelectItem value='github'>GitHub</SelectItem>
-                            <SelectItem value='other'>Other</SelectItem>
                           </SelectContent>
                         </Select>
                         <FormMessage />

--- a/components/organization/cards/GradeSubmissionModal/useScoreForm.ts
+++ b/components/organization/cards/GradeSubmissionModal/useScoreForm.ts
@@ -175,7 +175,7 @@ export const useScoreForm = ({
           : await submitJudgingScore({
               submissionId,
               criteriaScores: scoreData,
-              comment: overallComment,
+              notes: overallComment,
             });
 
       const isSuccess = response.success !== false;

--- a/hooks/hackathon/use-submission.ts
+++ b/hooks/hackathon/use-submission.ts
@@ -51,6 +51,55 @@ export type SubmissionFormData = Omit<
   }>;
 };
 
+/**
+ * Fields the backend `UpdateSubmissionDto` accepts. Backend rejects any
+ * other field after PR #187 (forbidNonWhitelisted: true). Keep this list
+ * in sync with src/modules/hackathons/dto/submission.dto.ts.
+ *
+ * Notably NOT on update: participationType, teamId, teamName,
+ * organizationId, hackathonId, participantId. Those are set on create
+ * only and cannot be changed via PATCH.
+ */
+const UPDATE_SUBMISSION_FIELDS: readonly (keyof SubmissionFormData)[] = [
+  'projectName',
+  'category',
+  'description',
+  'logo',
+  'banner',
+  'videoUrl',
+  'introduction',
+  'links',
+  'socialLinks',
+  'teamMembers',
+  'trackIds',
+  'trackAnswers',
+  'tagline',
+  'builtWith',
+  'screenshots',
+  'license',
+  'codeAttested',
+] as const;
+
+function pickUpdateSubmissionFields(
+  data: Partial<SubmissionFormData>
+): Partial<SubmissionFormData> {
+  const out: Partial<SubmissionFormData> = {};
+  for (const key of UPDATE_SUBMISSION_FIELDS) {
+    if (key in data && data[key] !== undefined) {
+      // The index type below is awkward because SubmissionFormData has
+      // many optional fields with different shapes. The cast is safe
+      // because each `key` is a real key of SubmissionFormData.
+      (out as Record<string, unknown>)[key] = data[key];
+    }
+  }
+  // teamMembers entries must not carry `email` (UpdateSubmissionDto's
+  // TeamMemberDto has no such field). Strip per-entry.
+  if (Array.isArray(out.teamMembers)) {
+    out.teamMembers = out.teamMembers.map(({ email: _email, ...rest }) => rest);
+  }
+  return out;
+}
+
 interface UseSubmissionOptions {
   hackathonSlugOrId: string;
   organizationId?: string;
@@ -170,7 +219,11 @@ export function useSubmission({
       setError(null);
 
       try {
-        const response = await updateSubmission(submissionId, data);
+        // Strip create-only fields (participationType, teamId, teamName,
+        // organizationId, ...) and per-team-member email so the request
+        // matches UpdateSubmissionDto under forbidNonWhitelisted: true.
+        const payload = pickUpdateSubmissionFields(data);
+        const response = await updateSubmission(submissionId, payload);
 
         if (response?.success && response?.data) {
           setSubmission(response.data);

--- a/hooks/hackathon/use-submission.ts
+++ b/hooks/hackathon/use-submission.ts
@@ -92,10 +92,16 @@ function pickUpdateSubmissionFields(
       (out as Record<string, unknown>)[key] = data[key];
     }
   }
-  // teamMembers entries must not carry `email` (UpdateSubmissionDto's
-  // TeamMemberDto has no such field). Strip per-entry.
+  // teamMembers entries must match the backend TeamMemberDto exactly:
+  // { userId, name, username?, role } — no `email`, no `avatar`. Project
+  // each entry down to that shape so unknown fields never reach the wire.
   if (Array.isArray(out.teamMembers)) {
-    out.teamMembers = out.teamMembers.map(({ email: _email, ...rest }) => rest);
+    out.teamMembers = out.teamMembers.map(member => ({
+      userId: member.userId,
+      name: member.name,
+      role: member.role,
+      ...(member.username ? { username: member.username } : {}),
+    }));
   }
   return out;
 }

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -55,7 +55,15 @@ export const getAuthHeaders = (): Record<string, string> => {
 };
 
 /**
- * Update user profile request interface - matches API payload specification
+ * Update user profile request interface. Mirrors the backend
+ * `UpdateProfileDto` (src/modules/users/dto/update-profile.dto.ts).
+ *
+ * Notably absent: a `preferences` block. The backend has dedicated
+ * endpoints for theme / language / timezone / notification toggles
+ * (see updateAppearanceSettings, updateNotificationsSettings,
+ * updateUserSettings in lib/api/user/settings.ts). Sending a
+ * `preferences` field here would be rejected as an unknown property
+ * once the backend enables forbidNonWhitelisted (PR #187).
  */
 export interface UpdateUserProfileRequest {
   bio?: string;
@@ -68,13 +76,6 @@ export interface UpdateUserProfileRequest {
     twitter?: string;
     linkedin?: string;
     discord?: string;
-  };
-  preferences?: {
-    theme?: 'light' | 'dark' | 'auto';
-    language?: string;
-    timezone?: string;
-    emailNotifications?: boolean;
-    pushNotifications?: boolean;
   };
 }
 

--- a/lib/api/hackathons.ts
+++ b/lib/api/hackathons.ts
@@ -502,9 +502,24 @@ export interface PublishHackathonRequest extends Hackathon {
   escrowDetails?: object;
 }
 
-export type UpdateHackathonRequest = Partial<Hackathon> & {
+/**
+ * Narrow shape for the PUT /hackathons/:id endpoint. The previous wider
+ * `Partial<Hackathon>` typing let callers leak Hackathon-shape fields
+ * (id, organizationId, creatorId, status, ...) into the request body,
+ * any of which would 400 once the backend enables
+ * forbidNonWhitelisted (PR #187). The only caller today is the rank
+ * override save in JudgingResultsTable, which sends only `rewards`.
+ *
+ * Note: the backend route this calls (PUT /hackathons/:id) does not
+ * currently exist as a separate endpoint; the section-specific PATCH
+ * routes (/content, /schedule, /financial) are where edits should go.
+ * That mismatch is a separate pre-existing bug, but the narrow type
+ * here at least prevents the request from carrying unknown fields if
+ * the route is wired up later.
+ */
+export interface UpdateHackathonRequest {
   rewards?: HackathonRewards;
-};
+}
 
 // Response Types
 export interface CreateDraftResponse extends ApiResponse<HackathonDraft> {

--- a/lib/api/hackathons/judging.ts
+++ b/lib/api/hackathons/judging.ts
@@ -237,7 +237,7 @@ export interface CriterionScoreRequest {
 export interface SubmitJudgingScoreRequest {
   submissionId: string;
   criteriaScores: CriterionScoreRequest[];
-  comment?: string; // Optional global feedback
+  notes?: string; // Optional global feedback (per-judge notes on this submission)
 }
 
 export interface OverrideSubmissionScoreRequest {

--- a/lib/api/hackathons/teams.ts
+++ b/lib/api/hackathons/teams.ts
@@ -24,6 +24,31 @@ export interface LookingForRole {
   skills?: string[];
 }
 
+/**
+ * Contact information for a team. Backend stores this as a sparse object
+ * keyed by channel rather than a string + separate method enum. The
+ * channel is implicit in whichever key is populated.
+ */
+export interface TeamContactInfo {
+  telegram?: string;
+  discord?: string;
+  email?: string;
+}
+
+/**
+ * Surface the active channel + raw string from a TeamContactInfo for UI
+ * display. Returns null when no channel is populated.
+ */
+export function readTeamContact(
+  info: TeamContactInfo | undefined | null
+): { method: 'email' | 'telegram' | 'discord'; value: string } | null {
+  if (!info) return null;
+  if (info.email) return { method: 'email', value: info.email };
+  if (info.telegram) return { method: 'telegram', value: info.telegram };
+  if (info.discord) return { method: 'discord', value: info.discord };
+  return null;
+}
+
 // Team Interface (Updated from TeamRecruitmentPost)
 export interface Team {
   id: string;
@@ -44,8 +69,7 @@ export interface Team {
   maxSize: number;
   lookingFor: LookingForRole[];
   rolesStatus?: TeamRole[]; // Track hired status for each role
-  contactMethod?: 'email' | 'telegram' | 'discord' | 'github' | 'other';
-  contactInfo: string;
+  contactInfo?: TeamContactInfo;
   isOpen: boolean;
   organizationId?: string;
   views?: number;
@@ -64,8 +88,7 @@ export interface CreateTeamRequest {
   description: string;
   lookingFor: LookingForRole[];
   maxSize?: number;
-  contactMethod?: 'email' | 'telegram' | 'discord' | 'github' | 'other';
-  contactInfo: string;
+  contactInfo?: TeamContactInfo;
 }
 
 export interface UpdateTeamRequest extends Partial<CreateTeamRequest> {


### PR DESCRIPTION
Companion to backend PR [boundlessfi/boundless-nestjs#187](https://github.com/boundlessfi/boundless-nestjs/pull/187), which flips the global `ValidationPipe` from `forbidNonWhitelisted: false` to `true`. Today any unknown body field is silently stripped; after the flip, sending such a field returns a **400** with class-validator's `property X should not exist`.

This PR fixes every front-end -> back-end payload an audit flagged.

## Changes

### 1. Team posts — `contactInfo` shape + `contactMethod` dropped

Backend `CreateTeamDto` / `UpdateTeamDto` expect `contactInfo` as a sparse object `{ telegram?, discord?, email? }`; the channel is implicit in the populated key. There is no separate `contactMethod` field.

- `lib/api/hackathons/teams.ts`: introduces `TeamContactInfo` type and `readTeamContact(info)` helper that flattens the sparse object back to `{ method, value }` for UI display. `Team.contactInfo` and `CreateTeamRequest.contactInfo` switch to the new shape; `contactMethod` is removed from both.
- `CreateTeamPostModal.tsx`: keeps the form UX (single channel selector + string input), but the submit handler projects to `{ contactInfo: { [method]: value } }` before calling the API. Edit-mode initial data hydrates via `readTeamContact()`. `github` and `other` were removed from the method enum because the backend cannot store them.
- `ContactTeamModal.tsx`: replaced `contactInfo` / `contactMethod` direct access with `readTeamContact()` + `contact.method` / `contact.value`. The github icon branch was dropped.
- `app/(landing)/hackathons/[slug]/teams/[teamId]/page.tsx`: same `readTeamContact()` flattening on the team detail page.

### 2. Judging score — `comment` -> `notes`

`SubmitJudgingScoreRequest.comment` was renamed to `notes` to match the backend `ScoreSubmissionDto.notes`. Per-criterion `comment` stays because `CriterionScoreDto` does accept it.

- `lib/api/hackathons/judging.ts`: field rename.
- `components/organization/cards/GradeSubmissionModal/useScoreForm.ts`: call site updated.

### 3. Submission update — whitelist filter at the hook layer

`hooks/hackathon/use-submission.ts` now exposes a `pickUpdateSubmissionFields()` mapping to the backend `UpdateSubmissionDto`. The update path strips:

- `participationType`, `teamId`, `teamName` (Create-only)
- `organizationId`, `hackathonId`, `participantId` (server-derived)
- per-entry `email` on `teamMembers` (`TeamMemberDto` has no `email` field)

before `PATCH /hackathons/submissions/:id`. The form continues to send the full shape; the hook filters at the API boundary so future callers are also protected.

### 4. User profile — removed `preferences` block

`UpdateUserProfileRequest.preferences` had no counterpart on backend `UpdateProfileDto`. The frontend already uses the dedicated `/users/settings/*` endpoints for appearance / language / timezone / notifications, so this was an unused typed door. Closed it.

### 5. Hackathon update — narrowed `UpdateHackathonRequest`

Was `Partial<Hackathon> & { rewards? }`, which let any Hackathon-shape field (`id`, `organizationId`, `status`, `creatorId`, ...) leak into `PUT /hackathons/:id`. Narrowed to just `{ rewards?: HackathonRewards }` since that's the only field actually sent today (the rank-override save in `JudgingResultsTable`).

`PublishHackathonRequest extends Hackathon` was left alone because the publish flow legitimately sends a full hackathon shape.

## Out of scope (separate pre-existing bugs)

The audit also surfaced URL mismatches between frontend and backend that are not whitelist issues:

- `PUT /hackathons/:id` has no matching backend route. The rank-override save in `JudgingResultsTable` is broken regardless of #187.
- `POST /users/earnings/claim` doesn't match backend `/users/earnings/withdraw`.
- `POST /organizations/:id/invite` doesn't match backend `/invitations`.

Worth filing as separate frontend tickets.

## Backend PR #188 (global ThrottlerGuard + per-route 429 limits)

**No frontend changes needed.** `lib/api/api.ts` already honours `Retry-After` and exponential backoff (1s / 2s / 4s) for three retries before surfacing a `RATE_LIMIT_EXCEEDED` error code. Verified during the audit.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `prettier --check .` — clean
- [x] `npm run build` — pre-commit build passes
- [ ] Manual on staging once backend #187 is on a staging deploy:
  - [ ] Create + edit a team post (each contact method: email / telegram / discord)
  - [ ] Submit + edit a judging score with overall notes
  - [ ] Edit a hackathon submission (verify no 400 from stripped fields)
  - [ ] Save user profile (verify no `preferences` regression)

## Coordination

Merge **after** backend PR #187 lands on staging so dev / staging do not 400 in the interim window. The changes here are backward-compatible with the current `forbidNonWhitelisted: false` backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)