### PR TITLE
feat(bounty): ModeTab + SubmissionModelTab for the Configure wizard (#599)

### DIFF
--- a/components/organization/bounties/new/tabs/ModeTab.tsx
+++ b/components/organization/bounties/new/tabs/ModeTab.tsx
@@ -1,0 +1,337 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import {
+  Globe,
+  ClipboardList,
+  FileText,
+  Trophy,
+  UserCheck,
+  Loader2,
+  Minus,
+  Plus,
+} from 'lucide-react';
+
+import { BoundlessButton } from '@/components/buttons';
+import { Form, FormField, FormItem, FormMessage } from '@/components/ui/form';
+import { cn } from '@/lib/utils';
+import {
+  BountyClaimType,
+  BountyEntryType,
+  computeBountyModeLabel,
+  isCompetition,
+  MAX_PRIZE_TIERS,
+  modeSchema,
+  ModeFormData,
+} from './schemas/modeSchema';
+
+interface ModeTabProps {
+  onContinue?: () => void;
+  onSave?: (data: ModeFormData) => Promise<void>;
+  initialData?: Partial<ModeFormData>;
+  isLoading?: boolean;
+}
+
+const entryOptions: Array<{
+  value: BountyEntryType;
+  label: string;
+  description: string;
+  icon: typeof Globe;
+}> = [
+  {
+    value: 'OPEN',
+    label: 'Open',
+    description: 'Anyone can start working right away.',
+    icon: Globe,
+  },
+  {
+    value: 'APPLICATION_LIGHT',
+    label: 'Application (light)',
+    description: 'A short application before work begins.',
+    icon: ClipboardList,
+  },
+  {
+    value: 'APPLICATION_FULL',
+    label: 'Application (full)',
+    description: 'A full application and review before work begins.',
+    icon: FileText,
+  },
+];
+
+const claimOptions: Array<{
+  value: BountyClaimType;
+  label: string;
+  description: string;
+  icon: typeof Trophy;
+}> = [
+  {
+    value: 'SINGLE_CLAIM',
+    label: 'Single claim',
+    description: 'One contributor works exclusively and is paid.',
+    icon: UserCheck,
+  },
+  {
+    value: 'COMPETITION',
+    label: 'Competition',
+    description: 'Several work in parallel; the best win.',
+    icon: Trophy,
+  },
+];
+
+const defaultValues: ModeFormData = {
+  entryType: 'OPEN',
+  claimType: 'SINGLE_CLAIM',
+  winnerCount: 1,
+};
+
+export default function ModeTab({
+  onContinue,
+  onSave,
+  initialData,
+  isLoading = false,
+}: ModeTabProps) {
+  const form = useForm<ModeFormData>({
+    resolver: zodResolver(modeSchema),
+    defaultValues: { ...defaultValues, ...initialData },
+  });
+
+  const entryType = form.watch('entryType');
+  const claimType = form.watch('claimType');
+  const winnerCount = form.watch('winnerCount') ?? 1;
+
+  const onSubmit = async (data: ModeFormData) => {
+    try {
+      // Single claim always pays exactly one winner.
+      const normalized: ModeFormData =
+        data.claimType === 'SINGLE_CLAIM' ? { ...data, winnerCount: 1 } : data;
+      if (onSave) await onSave(normalized);
+      if (onContinue) onContinue();
+    } catch (error: unknown) {
+      const err = error as {
+        response?: { data?: { message?: string | string[] } };
+        message?: string;
+      };
+      const message = err.response?.data?.message || err.message;
+      const errorMessage = Array.isArray(message) ? message[0] : message;
+      toast.error(errorMessage || 'Failed to save mode. Please try again.');
+    }
+  };
+
+  const setWinnerCount = (next: number) => {
+    form.setValue('winnerCount', Math.min(Math.max(next, 1), MAX_PRIZE_TIERS), {
+      shouldValidate: true,
+    });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>
+        {/* Entry type axis */}
+        <div className='space-y-4'>
+          <div>
+            <h3 className='text-sm font-medium text-white'>
+              How do contributors enter? <span className='text-red-500'>*</span>
+            </h3>
+            <p className='mt-1 text-sm text-zinc-500'>
+              Controls whether contributors apply before working.
+            </p>
+          </div>
+
+          <FormField
+            control={form.control}
+            name='entryType'
+            render={({ field }) => (
+              <FormItem>
+                <div className='grid gap-3 sm:grid-cols-3'>
+                  {entryOptions.map(
+                    ({ value, label, description, icon: Icon }) => {
+                      const isSelected = field.value === value;
+                      return (
+                        <button
+                          key={value}
+                          type='button'
+                          onClick={() => field.onChange(value)}
+                          className={cn(
+                            'flex flex-col gap-2 rounded-lg border p-4 text-left transition-all',
+                            isSelected
+                              ? 'border-primary/50 bg-primary/10 shadow-primary/10 shadow-sm'
+                              : 'border-zinc-800 bg-zinc-900/30 hover:border-zinc-700 hover:bg-zinc-900/50'
+                          )}
+                        >
+                          <div
+                            className={cn(
+                              'flex h-10 w-10 items-center justify-center rounded-lg transition-all',
+                              isSelected
+                                ? 'bg-primary/20 text-primary'
+                                : 'bg-zinc-800 text-zinc-500'
+                            )}
+                          >
+                            <Icon className='h-5 w-5' />
+                          </div>
+                          <span
+                            className={cn(
+                              'text-sm font-medium',
+                              isSelected ? 'text-primary' : 'text-white'
+                            )}
+                          >
+                            {label}
+                          </span>
+                          <span className='text-xs text-zinc-500'>
+                            {description}
+                          </span>
+                        </button>
+                      );
+                    }
+                  )}
+                </div>
+                <FormMessage className='text-xs text-red-500' />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        {/* Claim type axis */}
+        <div className='space-y-4'>
+          <div>
+            <h3 className='text-sm font-medium text-white'>
+              How is the work claimed? <span className='text-red-500'>*</span>
+            </h3>
+            <p className='mt-1 text-sm text-zinc-500'>
+              One exclusive contributor, or a competition of many.
+            </p>
+          </div>
+
+          <FormField
+            control={form.control}
+            name='claimType'
+            render={({ field }) => (
+              <FormItem>
+                <div className='grid gap-3 sm:grid-cols-2'>
+                  {claimOptions.map(
+                    ({ value, label, description, icon: Icon }) => {
+                      const isSelected = field.value === value;
+                      return (
+                        <button
+                          key={value}
+                          type='button'
+                          onClick={() => {
+                            field.onChange(value);
+                            if (value === 'SINGLE_CLAIM') setWinnerCount(1);
+                          }}
+                          className={cn(
+                            'flex flex-col gap-2 rounded-lg border p-4 text-left transition-all',
+                            isSelected
+                              ? 'border-primary/50 bg-primary/10 shadow-primary/10 shadow-sm'
+                              : 'border-zinc-800 bg-zinc-900/30 hover:border-zinc-700 hover:bg-zinc-900/50'
+                          )}
+                        >
+                          <div
+                            className={cn(
+                              'flex h-10 w-10 items-center justify-center rounded-lg transition-all',
+                              isSelected
+                                ? 'bg-primary/20 text-primary'
+                                : 'bg-zinc-800 text-zinc-500'
+                            )}
+                          >
+                            <Icon className='h-5 w-5' />
+                          </div>
+                          <span
+                            className={cn(
+                              'text-sm font-medium',
+                              isSelected ? 'text-primary' : 'text-white'
+                            )}
+                          >
+                            {label}
+                          </span>
+                          <span className='text-xs text-zinc-500'>
+                            {description}
+                          </span>
+                        </button>
+                      );
+                    }
+                  )}
+                </div>
+                <FormMessage className='text-xs text-red-500' />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        {/* Winners (competition only) */}
+        {isCompetition(claimType) && (
+          <FormField
+            control={form.control}
+            name='winnerCount'
+            render={() => (
+              <FormItem>
+                <div className='rounded-lg border border-zinc-800 bg-zinc-900/30 p-6'>
+                  <h4 className='mb-1 text-sm font-medium text-white'>
+                    Winners
+                  </h4>
+                  <p className='mb-4 text-sm text-zinc-500'>
+                    A competition can pay a single winner or up to{' '}
+                    {MAX_PRIZE_TIERS} prize positions.
+                  </p>
+                  <div className='flex items-center gap-4'>
+                    <div className='w-28 text-sm font-medium text-zinc-400'>
+                      Prize positions
+                    </div>
+                    <div className='flex items-center overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900/50'>
+                      <div className='flex-1 px-4 py-2.5 text-sm font-medium text-white'>
+                        {winnerCount}
+                      </div>
+                      <div className='flex border-l border-zinc-800'>
+                        <button
+                          type='button'
+                          onClick={() => setWinnerCount(winnerCount - 1)}
+                          className='flex items-center justify-center bg-zinc-900/50 px-3 py-2.5 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-white'
+                        >
+                          <Minus className='h-4 w-4' />
+                        </button>
+                        <button
+                          type='button'
+                          onClick={() => setWinnerCount(winnerCount + 1)}
+                          className='flex items-center justify-center border-l border-zinc-800 bg-zinc-900/50 px-3 py-2.5 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-white'
+                        >
+                          <Plus className='h-4 w-4' />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <FormMessage className='text-xs text-red-500' />
+              </FormItem>
+            )}
+          />
+        )}
+
+        {/* Computed mode label */}
+        <div className='border-primary/30 bg-primary/5 rounded-lg border p-4'>
+          <p className='text-xs text-zinc-500'>Selected mode</p>
+          <p className='text-primary mt-1 text-sm font-medium'>
+            {computeBountyModeLabel(entryType, claimType, winnerCount)}
+          </p>
+        </div>
+
+        <div className='flex justify-end pt-4'>
+          <BoundlessButton
+            type='submit'
+            size='lg'
+            disabled={isLoading}
+            className='min-w-32'
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                Saving...
+              </>
+            ) : (
+              'Continue'
+            )}
+          </BoundlessButton>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/components/organization/bounties/new/tabs/SubmissionModelTab.tsx
+++ b/components/organization/bounties/new/tabs/SubmissionModelTab.tsx
@@ -1,0 +1,334 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import { EyeOff, Lock, Loader2 } from 'lucide-react';
+
+import { BoundlessButton } from '@/components/buttons';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  getModeFields,
+  ModeSelection,
+  type FieldRule,
+} from './schemas/modeSchema';
+import {
+  makeSubmissionModelSchema,
+  SubmissionModelFormData,
+} from './schemas/submissionModelSchema';
+
+interface SubmissionModelTabProps {
+  /** The mode chosen in ModeTab; drives which fields show and how they validate. */
+  mode?: ModeSelection;
+  onContinue?: () => void;
+  onSave?: (data: SubmissionModelFormData) => Promise<void>;
+  initialData?: Partial<SubmissionModelFormData>;
+  isLoading?: boolean;
+}
+
+const labelFor: Record<FieldRule, string> = {
+  required: ' *',
+  optional: ' (optional)',
+  hidden: '',
+};
+
+/** Parse a numeric input, treating empty as null. */
+const toNumberOrNull = (raw: string): number | null => {
+  if (raw.trim() === '') return null;
+  const n = Number(raw);
+  return Number.isNaN(n) ? null : n;
+};
+
+export default function SubmissionModelTab({
+  mode,
+  onContinue,
+  onSave,
+  initialData,
+  isLoading = false,
+}: SubmissionModelTabProps) {
+  // Hooks must run unconditionally, so fall back to a neutral mode for the
+  // form setup and render the "pick a mode" notice below if mode is unset.
+  const effectiveMode: ModeSelection = mode ?? {
+    entryType: 'OPEN',
+    claimType: 'SINGLE_CLAIM',
+  };
+  const fields = getModeFields(
+    effectiveMode.entryType,
+    effectiveMode.claimType
+  );
+
+  const form = useForm<SubmissionModelFormData>({
+    resolver: zodResolver(
+      makeSubmissionModelSchema(
+        effectiveMode.entryType,
+        effectiveMode.claimType
+      )
+    ),
+    defaultValues: {
+      submissionDeadline: '',
+      reputationMinimum: null,
+      applicationWindowCloseAt: null,
+      maxApplicants: null,
+      shortlistSize: null,
+      applicationCreditCost: null,
+      ...initialData,
+      // The mode forces submission visibility, regardless of any saved value.
+      submissionVisibility: fields.submissionVisibility,
+    },
+  });
+
+  // Keep the forced visibility in sync if the mode changes between renders.
+  React.useEffect(() => {
+    form.setValue('submissionVisibility', fields.submissionVisibility);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fields.submissionVisibility]);
+
+  if (!mode) {
+    return (
+      <div className='rounded-lg border border-zinc-800 bg-zinc-900/30 p-6 text-sm text-zinc-400'>
+        Choose a mode in the previous step to configure the submission model.
+      </div>
+    );
+  }
+
+  const isCompetition = mode.claimType === 'COMPETITION';
+
+  const onSubmit = async (data: SubmissionModelFormData) => {
+    try {
+      if (onSave) await onSave(data);
+      if (onContinue) onContinue();
+    } catch (error: unknown) {
+      const err = error as {
+        response?: { data?: { message?: string | string[] } };
+        message?: string;
+      };
+      const message = err.response?.data?.message || err.message;
+      const errorMessage = Array.isArray(message) ? message[0] : message;
+      toast.error(
+        errorMessage || 'Failed to save submission settings. Please try again.'
+      );
+    }
+  };
+
+  const hidden = (rule: FieldRule) => rule === 'hidden';
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>
+        {/* Submission deadline (always required) */}
+        <FormField
+          control={form.control}
+          name='submissionDeadline'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className='text-sm font-medium text-white'>
+                Submission deadline<span className='text-red-500'>*</span>
+              </FormLabel>
+              <FormControl>
+                <Input
+                  type='datetime-local'
+                  className='h-10 rounded-lg border-zinc-800 bg-zinc-900/50 text-white'
+                  value={field.value ?? ''}
+                  onChange={e => field.onChange(e.target.value)}
+                />
+              </FormControl>
+              <FormMessage className='text-xs text-red-500' />
+            </FormItem>
+          )}
+        />
+
+        {/* Application window close (application entry types) */}
+        {!hidden(fields.applicationWindowCloseAt) && (
+          <FormField
+            control={form.control}
+            name='applicationWindowCloseAt'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className='text-sm font-medium text-white'>
+                  Application window closes
+                  {labelFor[fields.applicationWindowCloseAt]}
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    type='datetime-local'
+                    className='h-10 rounded-lg border-zinc-800 bg-zinc-900/50 text-white'
+                    value={field.value ?? ''}
+                    onChange={e => field.onChange(e.target.value || null)}
+                  />
+                </FormControl>
+                <FormMessage className='text-xs text-red-500' />
+              </FormItem>
+            )}
+          />
+        )}
+
+        {/* Reputation minimum (open + single claim) */}
+        {!hidden(fields.reputationMinimum) && (
+          <FormField
+            control={form.control}
+            name='reputationMinimum'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className='text-sm font-medium text-white'>
+                  Minimum reputation to claim
+                  {labelFor[fields.reputationMinimum]}
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    type='number'
+                    min={0}
+                    className='h-10 rounded-lg border-zinc-800 bg-zinc-900/50 text-white'
+                    value={field.value ?? ''}
+                    onChange={e =>
+                      field.onChange(toNumberOrNull(e.target.value))
+                    }
+                  />
+                </FormControl>
+                <FormMessage className='text-xs text-red-500' />
+              </FormItem>
+            )}
+          />
+        )}
+
+        {/* Max applicants */}
+        {!hidden(fields.maxApplicants) && (
+          <FormField
+            control={form.control}
+            name='maxApplicants'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className='text-sm font-medium text-white'>
+                  Max applicants{labelFor[fields.maxApplicants]}
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    type='number'
+                    min={fields.maxApplicants === 'required' ? 2 : 1}
+                    className='h-10 rounded-lg border-zinc-800 bg-zinc-900/50 text-white'
+                    value={field.value ?? ''}
+                    onChange={e =>
+                      field.onChange(toNumberOrNull(e.target.value))
+                    }
+                  />
+                </FormControl>
+                <FormMessage className='text-xs text-red-500' />
+              </FormItem>
+            )}
+          />
+        )}
+
+        {/* Shortlist size */}
+        {!hidden(fields.shortlistSize) && (
+          <FormField
+            control={form.control}
+            name='shortlistSize'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className='text-sm font-medium text-white'>
+                  Shortlist size{labelFor[fields.shortlistSize]}
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    type='number'
+                    min={fields.shortlistSize === 'required' ? 2 : 1}
+                    className='h-10 rounded-lg border-zinc-800 bg-zinc-900/50 text-white'
+                    value={field.value ?? ''}
+                    onChange={e =>
+                      field.onChange(toNumberOrNull(e.target.value))
+                    }
+                  />
+                </FormControl>
+                <FormMessage className='text-xs text-red-500' />
+              </FormItem>
+            )}
+          />
+        )}
+
+        {/* Application credit cost (application entry types) */}
+        {!hidden(fields.applicationCreditCost) && (
+          <FormField
+            control={form.control}
+            name='applicationCreditCost'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className='text-sm font-medium text-white'>
+                  Credits required to apply
+                  {labelFor[fields.applicationCreditCost]}
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    type='number'
+                    min={0}
+                    max={100}
+                    className='h-10 rounded-lg border-zinc-800 bg-zinc-900/50 text-white'
+                    value={field.value ?? ''}
+                    onChange={e =>
+                      field.onChange(toNumberOrNull(e.target.value))
+                    }
+                  />
+                </FormControl>
+                <FormMessage className='text-xs text-red-500' />
+              </FormItem>
+            )}
+          />
+        )}
+
+        {/* Submission visibility (forced, read-only) */}
+        <div className='rounded-lg border border-zinc-800 bg-zinc-900/30 p-4'>
+          <div className='flex items-center gap-3'>
+            <div className='flex h-9 w-9 items-center justify-center rounded-lg bg-zinc-800 text-zinc-400'>
+              {isCompetition ? (
+                <EyeOff className='h-4 w-4' />
+              ) : (
+                <Lock className='h-4 w-4' />
+              )}
+            </div>
+            <div>
+              <p className='text-sm font-medium text-white'>
+                Submission visibility
+              </p>
+              <p className='mt-0.5 text-xs text-zinc-500'>
+                {isCompetition
+                  ? 'Hidden until the deadline so the organizer cannot play favorites.'
+                  : 'Visible to the organizer as submissions arrive.'}
+              </p>
+            </div>
+          </div>
+          <p className='mt-3 text-xs font-medium text-zinc-400'>
+            {fields.submissionVisibility === 'HIDDEN_UNTIL_DEADLINE'
+              ? 'Hidden until deadline'
+              : 'Organizer only'}
+            <span className='ml-2 text-zinc-600'>
+              (set by the selected mode)
+            </span>
+          </p>
+        </div>
+
+        <div className='flex justify-end pt-4'>
+          <BoundlessButton
+            type='submit'
+            size='lg'
+            disabled={isLoading}
+            className='min-w-32'
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                Saving...
+              </>
+            ) : (
+              'Continue'
+            )}
+          </BoundlessButton>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/components/organization/bounties/new/tabs/schemas/modeSchema.ts
+++ b/components/organization/bounties/new/tabs/schemas/modeSchema.ts
@@ -1,0 +1,144 @@
+import { z } from 'zod';
+
+/**
+ * Bounty two-axis taxonomy (plain language, see boundless-nestjs #317). These
+ * literal unions mirror the backend Prisma enums; once the bounties data layer
+ * (#596) lands they can be re-exported from the generated client.
+ */
+export const ENTRY_TYPES = [
+  'OPEN',
+  'APPLICATION_LIGHT',
+  'APPLICATION_FULL',
+] as const;
+export const CLAIM_TYPES = ['SINGLE_CLAIM', 'COMPETITION'] as const;
+export const SUBMISSION_VISIBILITIES = [
+  'ORGANIZER_ONLY',
+  'HIDDEN_UNTIL_DEADLINE',
+] as const;
+
+export type BountyEntryType = (typeof ENTRY_TYPES)[number];
+export type BountyClaimType = (typeof CLAIM_TYPES)[number];
+export type BountySubmissionVisibility =
+  (typeof SUBMISSION_VISIBILITIES)[number];
+
+export const MAX_PRIZE_TIERS = 3;
+
+/** Whether a contributor applies before working. */
+export const isApplicationEntry = (entryType: BountyEntryType): boolean =>
+  entryType === 'APPLICATION_LIGHT' || entryType === 'APPLICATION_FULL';
+
+export const isCompetition = (claimType: BountyClaimType): boolean =>
+  claimType === 'COMPETITION';
+
+/**
+ * Plain-language label for the configured mode, derived from
+ * (entryType, claimType, winner count). Mirrors `computeBountyMode` in the
+ * backend; a competition paying more than one tier is flagged "multiple
+ * winners".
+ */
+export function computeBountyModeLabel(
+  entryType: BountyEntryType,
+  claimType: BountyClaimType,
+  winnerCount = 1
+): string {
+  const claim = claimType === 'SINGLE_CLAIM' ? 'single claim' : 'competition';
+  let base: string;
+  if (entryType === 'OPEN') {
+    base = claim === 'single claim' ? 'Open, single claim' : 'Open competition';
+  } else {
+    const entry =
+      entryType === 'APPLICATION_LIGHT'
+        ? 'Application (light)'
+        : 'Application (full)';
+    base =
+      claim === 'single claim'
+        ? `${entry}, single claim`
+        : `${entry} competition`;
+  }
+  if (isCompetition(claimType) && winnerCount > 1) {
+    return `${base} (multiple winners)`;
+  }
+  return base;
+}
+
+export type FieldRule = 'required' | 'optional' | 'hidden';
+
+export interface ModeFields {
+  /** Forced submission visibility for the mode (read-only in the UI). */
+  submissionVisibility: BountySubmissionVisibility;
+  submissionDeadline: FieldRule;
+  reputationMinimum: FieldRule;
+  applicationWindowCloseAt: FieldRule;
+  maxApplicants: FieldRule;
+  shortlistSize: FieldRule;
+  /** Anti-spam knob; only meaningful for application entry types. */
+  applicationCreditCost: FieldRule;
+}
+
+/**
+ * The mode -> field matrix from the authoritative publish gate
+ * (`validateTwoAxisMode` in boundless-nestjs). Derived functionally so it
+ * cannot drift from the backend rules.
+ */
+export function getModeFields(
+  entryType: BountyEntryType,
+  claimType: BountyClaimType
+): ModeFields {
+  const application = isApplicationEntry(entryType);
+  const competition = isCompetition(claimType);
+
+  return {
+    submissionVisibility: competition
+      ? 'HIDDEN_UNTIL_DEADLINE'
+      : 'ORGANIZER_ONLY',
+    submissionDeadline: 'required',
+    // Open + single claim gates on reputation (squat-guard).
+    reputationMinimum: !application && !competition ? 'required' : 'hidden',
+    applicationWindowCloseAt: application ? 'required' : 'hidden',
+    // Open competition caps direct joins; application modes cap optionally.
+    maxApplicants:
+      entryType === 'OPEN' && competition
+        ? 'required'
+        : application
+          ? 'optional'
+          : 'hidden',
+    // Application competition requires a shortlist; single-claim app is optional.
+    shortlistSize:
+      application && competition
+        ? 'required'
+        : application
+          ? 'optional'
+          : 'hidden',
+    applicationCreditCost: application ? 'optional' : 'hidden',
+  };
+}
+
+export const modeSchema = z
+  .object({
+    entryType: z.enum(ENTRY_TYPES),
+    claimType: z.enum(CLAIM_TYPES),
+    // Number of prize positions. 1 for single claim; 1-3 for a competition.
+    winnerCount: z.number().int().min(1).max(MAX_PRIZE_TIERS).default(1),
+  })
+  .superRefine((data, ctx) => {
+    if (data.claimType === 'SINGLE_CLAIM' && data.winnerCount !== 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'A single-claim bounty pays exactly one winner',
+        path: ['winnerCount'],
+      });
+    }
+    if (
+      data.claimType === 'COMPETITION' &&
+      (data.winnerCount < 1 || data.winnerCount > MAX_PRIZE_TIERS)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'A competition pays 1 to 3 winners',
+        path: ['winnerCount'],
+      });
+    }
+  });
+
+export type ModeFormData = z.input<typeof modeSchema>;
+export type ModeSelection = Pick<ModeFormData, 'entryType' | 'claimType'>;

--- a/components/organization/bounties/new/tabs/schemas/submissionModelSchema.ts
+++ b/components/organization/bounties/new/tabs/schemas/submissionModelSchema.ts
@@ -1,0 +1,101 @@
+import { z } from 'zod';
+
+import {
+  BountyClaimType,
+  BountyEntryType,
+  getModeFields,
+  SUBMISSION_VISIBILITIES,
+} from './modeSchema';
+
+/**
+ * Base shape of the Submission Model section. All conditional fields are
+ * optional here; the per-mode required / optional / hidden rules are layered on
+ * by `makeSubmissionModelSchema(mode)`, which mirrors the backend publish gate
+ * (`validateTwoAxisMode`). Keeping a base object lets us derive a stable
+ * FormData type while the active schema varies by mode.
+ */
+const submissionModelBase = z.object({
+  submissionDeadline: z.string().min(1, 'Submission deadline is required'),
+  submissionVisibility: z.enum(SUBMISSION_VISIBILITIES),
+  reputationMinimum: z.union([z.number().int().min(0), z.null()]).optional(),
+  applicationWindowCloseAt: z.union([z.string().min(1), z.null()]).optional(),
+  maxApplicants: z.union([z.number().int().min(1), z.null()]).optional(),
+  shortlistSize: z.union([z.number().int().min(1), z.null()]).optional(),
+  applicationCreditCost: z
+    .union([z.number().int().min(0).max(100), z.null()])
+    .optional(),
+});
+
+export type SubmissionModelFormData = z.input<typeof submissionModelBase>;
+
+const isSet = (v: unknown): boolean => v !== null && v !== undefined;
+
+/**
+ * Build the mode-aware schema. The required fields, and the `>= 2` floors on
+ * maxApplicants (open competition) and shortlistSize (application
+ * competition), match the server gate so the client blocks the same invalid
+ * combinations before publish.
+ */
+export function makeSubmissionModelSchema(
+  entryType: BountyEntryType,
+  claimType: BountyClaimType
+) {
+  const fields = getModeFields(entryType, claimType);
+
+  return submissionModelBase.superRefine((data, ctx) => {
+    if (
+      fields.reputationMinimum === 'required' &&
+      !isSet(data.reputationMinimum)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'Reputation minimum is required for open single-claim bounties',
+        path: ['reputationMinimum'],
+      });
+    }
+
+    if (
+      fields.applicationWindowCloseAt === 'required' &&
+      !isSet(data.applicationWindowCloseAt)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'An application window close time is required',
+        path: ['applicationWindowCloseAt'],
+      });
+    }
+
+    if (fields.maxApplicants === 'required') {
+      if (!isSet(data.maxApplicants) || (data.maxApplicants as number) < 2) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'An open competition needs a max applicants of at least 2',
+          path: ['maxApplicants'],
+        });
+      }
+    }
+
+    if (fields.shortlistSize === 'required') {
+      if (!isSet(data.shortlistSize) || (data.shortlistSize as number) < 2) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'A competition needs a shortlist size of at least 2',
+          path: ['shortlistSize'],
+        });
+      }
+    }
+
+    // Competition modes must hide submissions until the deadline.
+    if (
+      claimType === 'COMPETITION' &&
+      data.submissionVisibility !== 'HIDDEN_UNTIL_DEADLINE'
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Competition submissions are hidden until the deadline',
+        path: ['submissionVisibility'],
+      });
+    }
+  });
+}


### PR DESCRIPTION
Closes #599. Part of the **Bounty Configure (Host a Bounty)** frontend epic (#603).

> Targets `feat/t-replace` (not `main`) as requested.

## What

The net-new bounty UI with no hackathon analog: the two-axis mode picker and the mode-conditional submission settings that drive all six combinations. Uses the plain taxonomy (`claimType` / `entryType`).

- **`tabs/schemas/modeSchema.ts`** — taxonomy literal unions, `computeBountyModeLabel`, and **`getModeFields(entryType, claimType)`**: the mode → field matrix derived functionally from the publish gate (`validateTwoAxisMode`) so it cannot drift from the backend.
- **`tabs/schemas/submissionModelSchema.ts`** — `makeSubmissionModelSchema(mode)`, a mode-aware Zod factory whose required fields and the `>= 2` floors (maxApplicants for open competition, shortlistSize for application competition) mirror the server gate.
- **`tabs/ModeTab.tsx`** — entry × claim picker, a winners stepper (1–3) for competitions, and a live computed mode label.
- **`tabs/SubmissionModelTab.tsx`** — renders each field per the matrix (required / optional / hidden) and shows `submissionVisibility` read-only, forced by the mode (`HIDDEN_UNTIL_DEADLINE` for competitions).

## Mode → field matrix

| Field | Open + single | Open + comp | App(light) + single | App(light) + comp | App(full) + single | App(full) + comp |
|---|---|---|---|---|---|---|
| submissionVisibility | ORGANIZER_ONLY | HIDDEN (forced) | ORGANIZER_ONLY | HIDDEN (forced) | ORGANIZER_ONLY | HIDDEN (forced) |
| reputationMinimum | required | hidden | hidden | hidden | hidden | hidden |
| applicationWindowCloseAt | hidden | hidden | required | required | required | required |
| maxApplicants | hidden | required (>=2) | optional | optional | optional | optional |
| shortlistSize | hidden | hidden | optional | required (>=2) | optional | required (>=2) |
| submissionDeadline | required | required | required | required | required | required |
| Prize tiers (winners) | 1 | 1-3 | 1 | 1-3 | 1 | 1-3 |

## Acceptance criteria

- **Each combination shows / hides the correct fields** — driven by `getModeFields`.
- **Client blocks invalid combinations before publish** — `modeSchema` + `makeSubmissionModelSchema` mirror the server gate.

## Verification

- `tsc --noEmit`: 0 errors; ESLint + Prettier clean; production build passes (enforced by the pre-commit hook).

## Notes

- Standalone components (props: `mode`, `onSave`, `onContinue`, `initialData`, `isLoading`). They wire into the wizard shell + routes in **#597 / #598**, which thread the chosen `mode` from ModeTab into SubmissionModelTab.
- Taxonomy unions are local for now; once the data layer (#596) lands they can be re-exported from the generated client.