### PR TITLE
feat(bounty): Scope + Reward + Review tabs and Zod schemas (#600)

### DIFF
--- a/components/organization/bounties/new/NewBountyTab.tsx
+++ b/components/organization/bounties/new/NewBountyTab.tsx
@@ -5,11 +5,13 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 
 import { Tabs, TabsContent } from '@/components/ui/tabs';
-import { BoundlessButton } from '@/components/buttons';
 import { useBountySteps } from '@/hooks/use-bounty-steps';
 import { useBountyDraft } from '@/hooks/use-bounty-draft';
+import ScopeTab from './tabs/ScopeTab';
 import ModeTab from './tabs/ModeTab';
 import SubmissionModelTab from './tabs/SubmissionModelTab';
+import RewardTab from './tabs/RewardTab';
+import ReviewTab from './tabs/ReviewTab';
 import type { ModeSelection } from './tabs/schemas/modeSchema';
 import {
   BountyFormData,
@@ -22,33 +24,6 @@ import {
 interface NewBountyTabProps {
   organizationId?: string;
   draftId?: string;
-}
-
-/** Placeholder for a wizard section whose tab lands in #600 (Scope / Reward). */
-function SectionPlaceholder({
-  title,
-  description,
-  onContinue,
-}: {
-  title: string;
-  description: string;
-  onContinue?: () => void;
-}) {
-  return (
-    <div className='space-y-6'>
-      <div className='rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6'>
-        <h3 className='text-sm font-medium text-white'>{title}</h3>
-        <p className='mt-1 text-sm text-zinc-500'>{description}</p>
-      </div>
-      {onContinue && (
-        <div className='flex justify-end'>
-          <BoundlessButton type='button' size='lg' onClick={onContinue}>
-            Continue
-          </BoundlessButton>
-        </div>
-      )}
-    </div>
-  );
 }
 
 /**
@@ -206,11 +181,11 @@ export default function NewBountyTab({
       <Tabs value={activeTab} className='w-full'>
         <div className='px-6 py-6 md:px-20'>
           <TabsContent value='scope' className='mt-0'>
-            {/* TODO(#600): replace with ScopeTab (title/description/github/...). */}
-            <SectionPlaceholder
-              title='Scope'
-              description='The Scope tab (title, description, GitHub issue) lands in #600.'
+            <ScopeTab
+              onSave={createSaveHandler('scope', 'mode')}
               onContinue={() => navigateToStep('mode')}
+              initialData={stepData.scope}
+              isLoading={loadingStates.scope}
             />
           </TabsContent>
 
@@ -234,41 +209,35 @@ export default function NewBountyTab({
           </TabsContent>
 
           <TabsContent value='reward' className='mt-0'>
-            {/* TODO(#600): replace with RewardTab (currency + prize tiers). */}
-            <SectionPlaceholder
-              title='Reward'
-              description='The Reward tab (currency + prize tiers) lands in #600.'
+            <RewardTab
+              mode={
+                stepData.mode
+                  ? {
+                      claimType: stepData.mode.claimType,
+                      winnerCount: stepData.mode.winnerCount,
+                    }
+                  : undefined
+              }
+              onSave={createSaveHandler('reward', 'review')}
               onContinue={() => navigateToStep('review')}
+              initialData={stepData.reward}
+              isLoading={loadingStates.reward}
             />
           </TabsContent>
 
           <TabsContent value='review' className='mt-0'>
-            {/* TODO(#600/#601): replace with ReviewTab + publish/funding flow. */}
-            <div className='space-y-6'>
-              <div className='rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6'>
-                <h3 className='text-sm font-medium text-white'>
-                  Review &amp; publish
-                </h3>
-                <p className='mt-1 text-sm text-zinc-500'>
-                  The review summary and the publish + funding flow land in #600
-                  / #601.
-                </p>
-              </div>
-              <div className='flex justify-end gap-3'>
-                <BoundlessButton
-                  type='button'
-                  variant='outline'
-                  size='lg'
-                  onClick={saveDraft}
-                  disabled={isSavingDraft}
-                >
-                  {isSavingDraft ? 'Saving...' : 'Save draft'}
-                </BoundlessButton>
-                <BoundlessButton type='button' size='lg' disabled>
-                  Publish (coming in #601)
-                </BoundlessButton>
-              </div>
-            </div>
+            <ReviewTab
+              allData={stepData}
+              onEdit={navigateToStep}
+              onSaveDraft={saveDraft}
+              isSavingDraft={isSavingDraft}
+              // TODO(#601): wire the real publish + funding flow. For now the
+              // CTA enables once every section is valid, then reports that
+              // publishing lands in #601.
+              onPublish={() => {
+                toast.info('Publishing lands in #601 (escrow publish flow).');
+              }}
+            />
           </TabsContent>
         </div>
       </Tabs>

--- a/components/organization/bounties/new/constants.ts
+++ b/components/organization/bounties/new/constants.ts
@@ -1,9 +1,7 @@
 import type { ModeFormData } from './tabs/schemas/modeSchema';
 import type { SubmissionModelFormData } from './tabs/schemas/submissionModelSchema';
-import type {
-  BountyRewardSection,
-  BountyScopeSection,
-} from '@/features/bounties';
+import type { ScopeFormData } from './tabs/schemas/scopeSchema';
+import type { RewardFormData } from './tabs/schemas/rewardSchema';
 
 export type StepStatus = 'pending' | 'active' | 'completed';
 
@@ -25,15 +23,14 @@ export const STEP_ORDER: StepKey[] = [
 ];
 
 /**
- * In-progress wizard form snapshot. The four editable sections use the #599
- * form schemas where they exist (mode, submission) and the generated section
- * types otherwise (scope, reward — refined by the dedicated tabs in #600).
+ * In-progress wizard form snapshot, one entry per editable section, each typed
+ * by its tab's form schema.
  */
 export interface BountyFormData {
-  scope?: BountyScopeSection;
+  scope?: ScopeFormData;
   mode?: ModeFormData;
   submission?: SubmissionModelFormData;
-  reward?: BountyRewardSection;
+  reward?: RewardFormData;
 }
 
 /**

--- a/components/organization/bounties/new/tabs/ReviewTab.tsx
+++ b/components/organization/bounties/new/tabs/ReviewTab.tsx
@@ -1,0 +1,295 @@
+import React from 'react';
+import { toast } from 'sonner';
+import { AlertTriangle, CheckCircle2, Loader2, Pencil } from 'lucide-react';
+
+import { BoundlessButton } from '@/components/buttons';
+import {
+  PLATFORM_FEE,
+  getBountyPlatformFee,
+  getBountyPrizePool,
+  getBountyTotalFunding,
+} from '@/lib/utils/bounty-escrow';
+import type { BountyFormData, StepKey } from '../constants';
+import { computeBountyModeLabel } from './schemas/modeSchema';
+import { scopeSchema } from './schemas/scopeSchema';
+import { modeSchema } from './schemas/modeSchema';
+import { makeSubmissionModelSchema } from './schemas/submissionModelSchema';
+import { makeRewardSchema } from './schemas/rewardSchema';
+
+interface ReviewTabProps {
+  allData: BountyFormData;
+  onEdit?: (step: StepKey) => void;
+  onPublish?: () => Promise<void> | void;
+  onSaveDraft?: () => Promise<void>;
+  isLoading?: boolean;
+  isSavingDraft?: boolean;
+}
+
+interface SectionIssues {
+  step: StepKey;
+  label: string;
+  valid: boolean;
+}
+
+/**
+ * Validate every section against its schema (the same per-mode rules the
+ * publish gate enforces). Returns per-section validity so the review step can
+ * summarize what's left and block publish until all four pass.
+ */
+function validateAll(data: BountyFormData): {
+  isValid: boolean;
+  sections: SectionIssues[];
+} {
+  const sections: SectionIssues[] = [];
+
+  sections.push({
+    step: 'scope',
+    label: 'Scope',
+    valid: scopeSchema.safeParse(data.scope).success,
+  });
+
+  const modeOk = modeSchema.safeParse(data.mode).success;
+  sections.push({ step: 'mode', label: 'Mode', valid: modeOk });
+
+  sections.push({
+    step: 'submission',
+    label: 'Submission model',
+    valid:
+      modeOk && data.mode
+        ? makeSubmissionModelSchema(
+            data.mode.entryType,
+            data.mode.claimType
+          ).safeParse(data.submission).success
+        : false,
+  });
+
+  sections.push({
+    step: 'reward',
+    label: 'Reward',
+    valid:
+      modeOk && data.mode
+        ? makeRewardSchema(data.mode.claimType).safeParse(data.reward).success
+        : false,
+  });
+
+  return { isValid: sections.every(s => s.valid), sections };
+}
+
+function Row({
+  label,
+  value,
+}: {
+  label: string;
+  value?: string | number | null;
+}) {
+  if (value === undefined || value === null || value === '') return null;
+  return (
+    <div className='flex items-center justify-between gap-4 text-sm'>
+      <span className='text-zinc-400'>{label}</span>
+      <span className='text-right text-white'>{value}</span>
+    </div>
+  );
+}
+
+function SummaryCard({
+  title,
+  step,
+  onEdit,
+  children,
+}: {
+  title: string;
+  step: StepKey;
+  onEdit?: (step: StepKey) => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className='rounded-xl border border-zinc-800 bg-zinc-900/30 p-5'>
+      <div className='mb-3 flex items-center justify-between'>
+        <h3 className='text-sm font-semibold text-white'>{title}</h3>
+        {onEdit && (
+          <button
+            type='button'
+            onClick={() => onEdit(step)}
+            className='flex items-center gap-1 text-xs text-zinc-400 transition-colors hover:text-white'
+          >
+            <Pencil className='h-3.5 w-3.5' />
+            Edit
+          </button>
+        )}
+      </div>
+      <div className='space-y-2'>{children}</div>
+    </div>
+  );
+}
+
+export default function ReviewTab({
+  allData,
+  onEdit,
+  onPublish,
+  onSaveDraft,
+  isLoading = false,
+  isSavingDraft = false,
+}: ReviewTabProps) {
+  const { isValid, sections } = validateAll(allData);
+  const currency = allData.reward?.rewardCurrency || 'USDC';
+  const prizePool = getBountyPrizePool(allData.reward);
+  const platformFee = getBountyPlatformFee(allData.reward);
+  const totalFunding = getBountyTotalFunding(allData.reward);
+
+  const modeLabel = allData.mode
+    ? computeBountyModeLabel(
+        allData.mode.entryType,
+        allData.mode.claimType,
+        allData.mode.winnerCount ?? 1
+      )
+    : undefined;
+
+  const handlePublish = async () => {
+    if (!onPublish) return;
+    try {
+      await onPublish();
+    } catch {
+      // The publish flow surfaces its own errors.
+    }
+  };
+
+  const handleSaveDraft = async () => {
+    if (!onSaveDraft) return;
+    try {
+      await onSaveDraft();
+    } catch {
+      toast.error('Failed to save draft. Please try again.');
+    }
+  };
+
+  return (
+    <div className='space-y-6'>
+      {/* Validation summary */}
+      <div className='rounded-xl border border-zinc-800 bg-zinc-900/30 p-5'>
+        <div className='mb-3 flex items-center gap-2'>
+          {isValid ? (
+            <CheckCircle2 className='h-5 w-5 text-emerald-500' />
+          ) : (
+            <AlertTriangle className='h-5 w-5 text-amber-500' />
+          )}
+          <h3 className='text-sm font-semibold text-white'>
+            {isValid
+              ? 'Everything looks good — ready to publish'
+              : 'Some sections still need attention'}
+          </h3>
+        </div>
+        <div className='grid gap-2 sm:grid-cols-2'>
+          {sections.map(s => (
+            <button
+              key={s.step}
+              type='button'
+              onClick={() => onEdit?.(s.step)}
+              className='flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-900/40 px-3 py-2 text-left text-sm transition-colors hover:border-zinc-700'
+            >
+              <span className='text-zinc-300'>{s.label}</span>
+              {s.valid ? (
+                <CheckCircle2 className='h-4 w-4 text-emerald-500' />
+              ) : (
+                <span className='text-xs text-amber-500'>Incomplete</span>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <SummaryCard title='Scope' step='scope' onEdit={onEdit}>
+        <Row label='Title' value={allData.scope?.title} />
+        <Row label='Description' value={allData.scope?.description} />
+        <Row label='GitHub issue' value={allData.scope?.githubIssueUrl} />
+      </SummaryCard>
+
+      <SummaryCard title='Mode' step='mode' onEdit={onEdit}>
+        <Row label='Mode' value={modeLabel} />
+        <Row label='Winners' value={allData.mode?.winnerCount} />
+      </SummaryCard>
+
+      <SummaryCard title='Submission model' step='submission' onEdit={onEdit}>
+        <Row
+          label='Submission deadline'
+          value={allData.submission?.submissionDeadline}
+        />
+        <Row
+          label='Application window closes'
+          value={allData.submission?.applicationWindowCloseAt}
+        />
+        <Row label='Max applicants' value={allData.submission?.maxApplicants} />
+        <Row label='Shortlist size' value={allData.submission?.shortlistSize} />
+        <Row
+          label='Reputation minimum'
+          value={allData.submission?.reputationMinimum}
+        />
+        <Row
+          label='Submission visibility'
+          value={
+            allData.submission?.submissionVisibility === 'HIDDEN_UNTIL_DEADLINE'
+              ? 'Hidden until deadline'
+              : allData.submission?.submissionVisibility === 'ORGANIZER_ONLY'
+                ? 'Organizer only'
+                : undefined
+          }
+        />
+      </SummaryCard>
+
+      <SummaryCard title='Reward' step='reward' onEdit={onEdit}>
+        <Row label='Currency' value={currency} />
+        {(allData.reward?.prizeTiers ?? []).map((tier, i) => (
+          <Row
+            key={tier.position ?? i}
+            label={`Position ${tier.position ?? i + 1}`}
+            value={`${tier.amount || '0'} ${currency}`}
+          />
+        ))}
+        <div className='mt-2 space-y-2 border-t border-zinc-800 pt-3'>
+          <Row
+            label='Prize pool'
+            value={`${prizePool.toLocaleString()} ${currency}`}
+          />
+          <Row
+            label={`Platform fee (${PLATFORM_FEE}%)`}
+            value={`${platformFee.toLocaleString()} ${currency}`}
+          />
+          <Row
+            label='Total to fund'
+            value={`${totalFunding.toLocaleString()} ${currency}`}
+          />
+        </div>
+      </SummaryCard>
+
+      {/* Publish CTA — disabled until every section is valid. */}
+      <div className='flex justify-end gap-3 pt-2'>
+        {onSaveDraft && (
+          <BoundlessButton
+            type='button'
+            variant='outline'
+            size='lg'
+            onClick={handleSaveDraft}
+            disabled={isSavingDraft}
+          >
+            {isSavingDraft ? 'Saving...' : 'Save draft'}
+          </BoundlessButton>
+        )}
+        <BoundlessButton
+          type='button'
+          size='lg'
+          className='min-w-32'
+          onClick={handlePublish}
+          disabled={!isValid || isLoading || !onPublish}
+        >
+          {isLoading ? (
+            <>
+              <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+              Publishing...
+            </>
+          ) : (
+            'Publish'
+          )}
+        </BoundlessButton>
+      </div>
+    </div>
+  );
+}

--- a/components/organization/bounties/new/tabs/RewardTab.tsx
+++ b/components/organization/bounties/new/tabs/RewardTab.tsx
@@ -1,0 +1,227 @@
+import React from 'react';
+import { useForm, useFieldArray } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import { Loader2 } from 'lucide-react';
+
+import { BoundlessButton } from '@/components/buttons';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  PLATFORM_FEE,
+  getBountyPlatformFee,
+  getBountyPrizePool,
+  getBountyTotalFunding,
+} from '@/lib/utils/bounty-escrow';
+import { MAX_PRIZE_TIERS, type BountyClaimType } from './schemas/modeSchema';
+import { makeRewardSchema, type RewardFormData } from './schemas/rewardSchema';
+
+interface RewardTabProps {
+  /** The claim type + winner count chosen in ModeTab; drives the tier count. */
+  mode?: { claimType: BountyClaimType; winnerCount?: number };
+  onContinue?: () => void;
+  onSave?: (data: RewardFormData) => Promise<void>;
+  initialData?: Partial<RewardFormData>;
+  isLoading?: boolean;
+}
+
+const ordinal = (n: number): string => {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  return `${n}${s[(v - 20) % 10] ?? s[v] ?? s[0]}`;
+};
+
+export default function RewardTab({
+  mode,
+  onContinue,
+  onSave,
+  initialData,
+  isLoading = false,
+}: RewardTabProps) {
+  const claimType: BountyClaimType = mode?.claimType ?? 'SINGLE_CLAIM';
+  const targetCount =
+    claimType === 'SINGLE_CLAIM'
+      ? 1
+      : Math.min(Math.max(mode?.winnerCount ?? 1, 1), MAX_PRIZE_TIERS);
+
+  const form = useForm<RewardFormData>({
+    resolver: zodResolver(makeRewardSchema(claimType)),
+    defaultValues: {
+      rewardCurrency: initialData?.rewardCurrency ?? 'USDC',
+      prizeTiers:
+        initialData?.prizeTiers && initialData.prizeTiers.length > 0
+          ? initialData.prizeTiers
+          : [{ position: 1, amount: '', passMark: null }],
+    },
+  });
+
+  const { fields, replace } = useFieldArray({
+    control: form.control,
+    name: 'prizeTiers',
+  });
+
+  // Keep the tier rows in sync with the mode's winner count, preserving any
+  // amounts already entered.
+  React.useEffect(() => {
+    const current = form.getValues('prizeTiers') ?? [];
+    if (current.length === targetCount) return;
+    const next = Array.from({ length: targetCount }, (_, i) => ({
+      position: i + 1,
+      amount: current[i]?.amount ?? '',
+      passMark: current[i]?.passMark ?? null,
+    }));
+    replace(next);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [targetCount]);
+
+  const watched = form.watch();
+  const prizePool = getBountyPrizePool(watched);
+  const platformFee = getBountyPlatformFee(watched);
+  const totalFunding = getBountyTotalFunding(watched);
+  const currency = watched.rewardCurrency || 'USDC';
+
+  const onSubmit = async (data: RewardFormData) => {
+    try {
+      if (onSave) await onSave(data);
+      if (onContinue) onContinue();
+    } catch (error: unknown) {
+      const err = error as {
+        response?: { data?: { message?: string | string[] } };
+        message?: string;
+      };
+      const message = err.response?.data?.message || err.message;
+      const errorMessage = Array.isArray(message) ? message[0] : message;
+      toast.error(errorMessage || 'Failed to save reward. Please try again.');
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>
+        <FormField
+          control={form.control}
+          name='rewardCurrency'
+          render={({ field }) => (
+            <FormItem className='max-w-xs'>
+              <FormLabel className='text-sm font-medium text-white'>
+                Reward currency<span className='text-red-500'>*</span>
+              </FormLabel>
+              <FormControl>
+                <Input
+                  placeholder='USDC'
+                  className='h-10 rounded-lg border-zinc-800 bg-zinc-900/50 text-white'
+                  {...field}
+                  value={field.value ?? ''}
+                />
+              </FormControl>
+              <FormMessage className='text-xs text-red-500' />
+            </FormItem>
+          )}
+        />
+
+        <div className='space-y-4'>
+          <div>
+            <h3 className='text-sm font-medium text-white'>
+              Prize tiers<span className='text-red-500'>*</span>
+            </h3>
+            <p className='mt-1 text-sm text-zinc-500'>
+              {claimType === 'SINGLE_CLAIM'
+                ? 'A single-claim bounty pays one winner.'
+                : `This competition pays ${targetCount} winner${targetCount > 1 ? 's' : ''}. Adjust the winner count in the Mode step.`}
+            </p>
+          </div>
+
+          <div className='space-y-3'>
+            {fields.map((fieldRow, index) => (
+              <FormField
+                key={fieldRow.id}
+                control={form.control}
+                name={`prizeTiers.${index}.amount`}
+                render={({ field }) => (
+                  <FormItem>
+                    <div className='flex items-center gap-4 rounded-lg border border-zinc-800 bg-zinc-900/30 p-4'>
+                      <div className='w-24 text-sm font-medium text-zinc-400'>
+                        {ordinal(index + 1)} place
+                      </div>
+                      <FormControl>
+                        <div className='relative flex-1'>
+                          <Input
+                            type='number'
+                            min={0}
+                            step='any'
+                            placeholder='0.00'
+                            className='h-10 rounded-lg border-zinc-800 bg-zinc-900/50 pr-16 text-white'
+                            value={field.value ?? ''}
+                            onChange={e => field.onChange(e.target.value)}
+                          />
+                          <span className='absolute top-1/2 right-3 -translate-y-1/2 text-xs text-zinc-500'>
+                            {currency}
+                          </span>
+                        </div>
+                      </FormControl>
+                    </div>
+                    <FormMessage className='text-xs text-red-500' />
+                  </FormItem>
+                )}
+              />
+            ))}
+          </div>
+          {form.formState.errors.prizeTiers?.message && (
+            <p className='text-xs text-red-500'>
+              {form.formState.errors.prizeTiers.message}
+            </p>
+          )}
+        </div>
+
+        {/* Funding preview */}
+        <div className='space-y-2 rounded-lg border border-zinc-800 bg-zinc-900/30 p-4'>
+          <div className='flex items-center justify-between text-sm'>
+            <span className='text-zinc-400'>Prize pool</span>
+            <span className='text-white'>
+              {prizePool.toLocaleString()} {currency}
+            </span>
+          </div>
+          <div className='flex items-center justify-between text-sm'>
+            <span className='text-zinc-400'>
+              Platform fee ({PLATFORM_FEE}%)
+            </span>
+            <span className='text-white'>
+              {platformFee.toLocaleString()} {currency}
+            </span>
+          </div>
+          <div className='flex items-center justify-between border-t border-zinc-800 pt-2 text-sm font-medium'>
+            <span className='text-white'>Total to fund</span>
+            <span className='text-primary'>
+              {totalFunding.toLocaleString()} {currency}
+            </span>
+          </div>
+        </div>
+
+        <div className='flex justify-end pt-4'>
+          <BoundlessButton
+            type='submit'
+            size='lg'
+            disabled={isLoading}
+            className='min-w-32'
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                Saving...
+              </>
+            ) : (
+              'Continue'
+            )}
+          </BoundlessButton>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/components/organization/bounties/new/tabs/ScopeTab.tsx
+++ b/components/organization/bounties/new/tabs/ScopeTab.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import { Loader2 } from 'lucide-react';
+
+import { BoundlessButton } from '@/components/buttons';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { scopeSchema, type ScopeFormData } from './schemas/scopeSchema';
+
+interface ScopeTabProps {
+  onContinue?: () => void;
+  onSave?: (data: ScopeFormData) => Promise<void>;
+  initialData?: Partial<ScopeFormData>;
+  isLoading?: boolean;
+}
+
+const defaultValues: ScopeFormData = {
+  title: '',
+  description: '',
+  githubIssueUrl: null,
+  githubIssueNumber: null,
+};
+
+export default function ScopeTab({
+  onContinue,
+  onSave,
+  initialData,
+  isLoading = false,
+}: ScopeTabProps) {
+  const form = useForm<ScopeFormData>({
+    resolver: zodResolver(scopeSchema),
+    defaultValues: { ...defaultValues, ...initialData },
+  });
+
+  React.useEffect(() => {
+    if (initialData) form.reset({ ...defaultValues, ...initialData });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialData]);
+
+  const onSubmit = async (data: ScopeFormData) => {
+    try {
+      if (onSave) await onSave(data);
+      if (onContinue) onContinue();
+    } catch (error: unknown) {
+      const err = error as {
+        response?: { data?: { message?: string | string[] } };
+        message?: string;
+      };
+      const message = err.response?.data?.message || err.message;
+      const errorMessage = Array.isArray(message) ? message[0] : message;
+      toast.error(errorMessage || 'Failed to save scope. Please try again.');
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>
+        <FormField
+          control={form.control}
+          name='title'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className='text-sm font-medium text-white'>
+                Title<span className='text-red-500'>*</span>
+              </FormLabel>
+              <FormControl>
+                <Input
+                  placeholder='e.g. Build a Soroban faucet bot'
+                  className='h-10 rounded-lg border-zinc-800 bg-zinc-900/50 text-white'
+                  {...field}
+                  value={field.value ?? ''}
+                />
+              </FormControl>
+              <FormMessage className='text-xs text-red-500' />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name='description'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className='text-sm font-medium text-white'>
+                Description<span className='text-red-500'>*</span>
+              </FormLabel>
+              <FormControl>
+                <Textarea
+                  rows={6}
+                  placeholder='What needs to be built, and what does done look like?'
+                  className='rounded-lg border-zinc-800 bg-zinc-900/50 text-white'
+                  {...field}
+                  value={field.value ?? ''}
+                />
+              </FormControl>
+              <FormMessage className='text-xs text-red-500' />
+            </FormItem>
+          )}
+        />
+
+        <div className='grid gap-6 sm:grid-cols-2'>
+          <FormField
+            control={form.control}
+            name='githubIssueUrl'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className='text-sm font-medium text-white'>
+                  GitHub issue URL{' '}
+                  <span className='text-zinc-500'>(optional)</span>
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder='https://github.com/org/repo/issues/123'
+                    className='h-10 rounded-lg border-zinc-800 bg-zinc-900/50 text-white'
+                    value={field.value ?? ''}
+                    onChange={e => field.onChange(e.target.value || null)}
+                  />
+                </FormControl>
+                <FormMessage className='text-xs text-red-500' />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name='githubIssueNumber'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className='text-sm font-medium text-white'>
+                  GitHub issue number{' '}
+                  <span className='text-zinc-500'>(optional)</span>
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    type='number'
+                    min={1}
+                    placeholder='123'
+                    className='h-10 rounded-lg border-zinc-800 bg-zinc-900/50 text-white'
+                    value={field.value ?? ''}
+                    onChange={e => {
+                      const n = parseInt(e.target.value, 10);
+                      field.onChange(Number.isNaN(n) ? null : n);
+                    }}
+                  />
+                </FormControl>
+                <FormMessage className='text-xs text-red-500' />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <div className='flex justify-end pt-4'>
+          <BoundlessButton
+            type='submit'
+            size='lg'
+            disabled={isLoading}
+            className='min-w-32'
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                Saving...
+              </>
+            ) : (
+              'Continue'
+            )}
+          </BoundlessButton>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/components/organization/bounties/new/tabs/schemas/rewardSchema.ts
+++ b/components/organization/bounties/new/tabs/schemas/rewardSchema.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod';
+
+import { MAX_PRIZE_TIERS, type BountyClaimType } from './modeSchema';
+
+/** A single prize position. `amount` is a positive decimal string (token units). */
+export const prizeTierSchema = z.object({
+  position: z.number().int().min(1, 'Position must be >= 1'),
+  amount: z
+    .string()
+    .regex(/^\d+(?:\.\d+)?$/, 'Amount must be a positive decimal')
+    .refine(s => Number(s) > 0, 'Amount must be greater than 0'),
+  passMark: z.union([z.number().int().min(0).max(100), z.null()]).optional(),
+});
+
+const rewardBase = z.object({
+  rewardCurrency: z.string().trim().min(1, 'Reward currency is required'),
+  prizeTiers: z.array(prizeTierSchema).min(1, 'Add at least one prize tier'),
+});
+
+export type RewardFormData = z.input<typeof rewardBase>;
+
+/** Shared default-export schema for the type only; use makeRewardSchema to validate. */
+export const rewardSchema = rewardBase;
+
+/**
+ * Mode-aware reward schema. A single-claim bounty pays exactly one winner; a
+ * competition pays 1 to {MAX_PRIZE_TIERS}. Positions must be unique and include
+ * position 1, and every amount must be > 0 — matching the publish gate
+ * (`deriveWinnerDistribution` in the backend).
+ */
+export function makeRewardSchema(claimType: BountyClaimType) {
+  return rewardBase.superRefine((data, ctx) => {
+    const tiers = data.prizeTiers ?? [];
+    const count = tiers.length;
+
+    if (claimType === 'SINGLE_CLAIM' && count !== 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['prizeTiers'],
+        message: 'A single-claim bounty has exactly one prize tier',
+      });
+    }
+    if (claimType === 'COMPETITION' && (count < 1 || count > MAX_PRIZE_TIERS)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['prizeTiers'],
+        message: `A competition has 1 to ${MAX_PRIZE_TIERS} prize tiers`,
+      });
+    }
+
+    const positions = new Set<number>();
+    tiers.forEach((tier, index) => {
+      if (positions.has(tier.position)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['prizeTiers', index, 'position'],
+          message: `Duplicate position ${tier.position}`,
+        });
+      }
+      positions.add(tier.position);
+    });
+    if (count > 0 && !positions.has(1)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['prizeTiers'],
+        message: 'A prize tier at position 1 is required',
+      });
+    }
+  });
+}

--- a/components/organization/bounties/new/tabs/schemas/scopeSchema.ts
+++ b/components/organization/bounties/new/tabs/schemas/scopeSchema.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+/**
+ * Scope step: the bounty's identity. Mirrors the backend BountyScopeSection
+ * (title / description / optional GitHub issue / optional project + window).
+ * The reward currency lives in the Reward step alongside the prize tiers it
+ * denominates (that is the section the backend persists it under).
+ */
+export const scopeSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(1, 'Title is required')
+    .max(200, 'Title must be 200 characters or fewer'),
+  description: z
+    .string()
+    .trim()
+    .min(1, 'Description is required')
+    .max(5000, 'Description must be 5000 characters or fewer'),
+  githubIssueUrl: z
+    .union([z.string().url('Enter a valid URL'), z.literal(''), z.null()])
+    .optional()
+    .transform(v => (v === '' ? null : v)),
+  githubIssueNumber: z
+    .union([z.number().int().positive(), z.null()])
+    .optional(),
+  projectId: z.union([z.string(), z.null()]).optional(),
+  bountyWindowId: z.union([z.string(), z.null()]).optional(),
+});
+
+export type ScopeFormData = z.input<typeof scopeSchema>;

--- a/lib/utils/bounty-escrow.ts
+++ b/lib/utils/bounty-escrow.ts
@@ -1,0 +1,58 @@
+import type { RewardsFormData } from '@/components/organization/hackathons/new/tabs/schemas/rewardsSchema';
+import type { RewardFormData } from '@/components/organization/bounties/new/tabs/schemas/rewardSchema';
+import type { BountyWinnerDistributionEntry } from '@/features/bounties';
+import {
+  PLATFORM_FEE,
+  buildWinnerDistribution,
+  calculatePlatformFeeAmount,
+  calculateTotalPrizeAmount,
+  getTotalPrizePoolForFunding,
+} from './hackathon-escrow';
+
+export { PLATFORM_FEE };
+
+/**
+ * Adapt the bounty reward shape (`{ position, amount }`) to the hackathon
+ * RewardsFormData the prize-pool helpers expect (`{ place, prizeAmount, rank,
+ * kind: 'OVERALL' }`), so the configure + publish flows reuse one source of
+ * prize-pool / fee / winner-distribution math (lib/utils/hackathon-escrow.ts)
+ * instead of duplicating it.
+ */
+function toRewards(reward: RewardFormData | undefined): RewardsFormData {
+  const tiers = reward?.prizeTiers ?? [];
+  return {
+    prizeTiers: tiers.map(tier => ({
+      id: String(tier.position),
+      place: String(tier.position),
+      prizeAmount: tier.amount,
+      rank: tier.position,
+      passMark: tier.passMark ?? 0,
+      kind: 'OVERALL' as const,
+    })),
+  };
+}
+
+/** Sum of the prize tiers (token-native units), excluding the platform fee. */
+export const getBountyPrizePool = (
+  reward: RewardFormData | undefined
+): number => calculateTotalPrizeAmount(toRewards(reward));
+
+/** The 2.5% platform fee charged on top of the prize pool at publish. */
+export const getBountyPlatformFee = (
+  reward: RewardFormData | undefined
+): number => calculatePlatformFeeAmount(getBountyPrizePool(reward));
+
+/** Total the funder is debited: prize pool + platform fee. */
+export const getBountyTotalFunding = (
+  reward: RewardFormData | undefined
+): number => getTotalPrizePoolForFunding(toRewards(reward));
+
+/**
+ * On-chain winner distribution ([{position, percent}] summing to 100) derived
+ * from the prize tiers. Used by the publish flow (#601); returns undefined when
+ * there are no fundable tiers (the backend then defaults to 100% @ position 1).
+ */
+export const buildBountyWinnerDistribution = (
+  reward: RewardFormData | undefined
+): BountyWinnerDistributionEntry[] | undefined =>
+  buildWinnerDistribution(toRewards(reward));


### PR DESCRIPTION
Closes #600. Part of the **Bounty Configure (Host a Bounty)** frontend epic (#603).

> Targets `feat/t-replace` (not `main`) as requested. Builds on the merged wizard shell (#598) and data layer (#596).

## What

Completes the editable surface of the wizard, dropping the three remaining tabs into the seams the shell left.

- **`tabs/schemas/scopeSchema.ts`** — title, description, optional GitHub issue url/number, optional project/window.
- **`tabs/schemas/rewardSchema.ts`** — `makeRewardSchema(claimType)`: exactly one tier for single claim, 1–3 for a competition; amounts > 0, unique positions including position 1 (mirrors the publish gate's `deriveWinnerDistribution`).
- **`lib/utils/bounty-escrow.ts`** — adapts the bounty reward shape to **reuse** the hackathon prize-pool math (`getTotalPrizePoolForFunding`, `buildWinnerDistribution`, 2.5% `PLATFORM_FEE`) instead of duplicating it.
- **`tabs/ScopeTab.tsx`** — scope form.
- **`tabs/RewardTab.tsx`** — currency + mode-driven prize tiers (field array sized to the winner count) with a live prize-pool / fee / total preview.
- **`tabs/ReviewTab.tsx`** — per-section summary, validation summary, funding totals, and a publish CTA **disabled until every section validates**.
- **`NewBountyTab.tsx` + `constants.ts`** — wire the three tabs in; the form snapshot now uses the per-tab schema types.

## Acceptance criteria

- **Full wizard validates end to end** — each tab validates on save; ReviewTab re-validates all four sections against the same per-mode rules.
- **Review blocks publish until valid** — the Publish button is disabled until `validateAll` passes.

`tsc --noEmit`: 0 errors; ESLint + Prettier clean; production build green (all enforced by the pre-commit hook).

## Two intentional deviations

1. **Reward currency is in RewardTab, not ScopeTab** (the issue lists it under Scope). The backend persists `rewardCurrency` in the **reward** section, so saving it via the scope section would silently drop it (backend Zod strips unknown keys). Grouping it with the prize tiers it denominates is also better UX.
2. **Publish is a placeholder** (`onPublish` toasts "lands in #601"). The real escrow publish + funding modals are #601's job; #600 owns the disabled-until-valid gate, which is wired and working.

## Next

#601 swaps the placeholder for the real `use-bounty-publish` flow; #597 adds the routes + org bounty list page that mount this wizard.