### PR TITLE
feat(bounty): routes + organization bounty list page (#597)

### DIFF
--- a/app/(landing)/organizations/[id]/bounties/drafts/[draftId]/page.tsx
+++ b/app/(landing)/organizations/[id]/bounties/drafts/[draftId]/page.tsx
@@ -1,0 +1,25 @@
+import React, { Suspense } from 'react';
+
+import NewBountyTab from '@/components/organization/bounties/new/NewBountyTab';
+import { AuthGuard } from '@/components/auth';
+import Loading from '@/components/Loading';
+
+interface BountyDraftPageProps {
+  params: Promise<{ id: string; draftId: string }>;
+}
+
+const BountyDraftPage = async ({ params }: BountyDraftPageProps) => {
+  const { id, draftId } = await params;
+
+  return (
+    <AuthGuard redirectTo='/auth?mode=signin' fallback={<Loading />}>
+      <div>
+        <Suspense fallback={<Loading />}>
+          <NewBountyTab organizationId={id} draftId={draftId} />
+        </Suspense>
+      </div>
+    </AuthGuard>
+  );
+};
+
+export default BountyDraftPage;

--- a/app/(landing)/organizations/[id]/bounties/new/page.tsx
+++ b/app/(landing)/organizations/[id]/bounties/new/page.tsx
@@ -1,0 +1,25 @@
+import React, { Suspense } from 'react';
+
+import NewBountyTab from '@/components/organization/bounties/new/NewBountyTab';
+import { AuthGuard } from '@/components/auth';
+import Loading from '@/components/Loading';
+
+interface NewBountyPageProps {
+  params: Promise<{ id: string }>;
+}
+
+const NewBountyPage = async ({ params }: NewBountyPageProps) => {
+  const { id } = await params;
+
+  return (
+    <AuthGuard redirectTo='/auth?mode=signin' fallback={<Loading />}>
+      <div>
+        <Suspense fallback={<Loading />}>
+          <NewBountyTab organizationId={id} />
+        </Suspense>
+      </div>
+    </AuthGuard>
+  );
+};
+
+export default NewBountyPage;

--- a/app/(landing)/organizations/[id]/bounties/page.tsx
+++ b/app/(landing)/organizations/[id]/bounties/page.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useMemo } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { FileText, Plus, Trophy } from 'lucide-react';
+
+import { BoundlessButton } from '@/components/buttons';
+import { Badge } from '@/components/ui/badge';
+import { AuthGuard } from '@/components/auth';
+import Loading from '@/components/Loading';
+import {
+  useDraftList,
+  useOrganizationBounties,
+  type BountyDraft,
+  type OrganizationBountyListItem,
+} from '@/features/bounties';
+
+const DRAFT_STATUSES = new Set(['draft', 'draft_awaiting_funding']);
+
+const STATUS_LABEL: Record<string, string> = {
+  draft: 'Draft',
+  draft_awaiting_funding: 'Publishing',
+  open: 'Open',
+  in_progress: 'In progress',
+  submitted: 'Submitted',
+  under_review: 'Under review',
+  completed: 'Completed',
+  cancelled: 'Cancelled',
+  disputed: 'Disputed',
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const tone =
+    status === 'open' || status === 'in_progress'
+      ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400'
+      : status === 'draft_awaiting_funding'
+        ? 'border-amber-500/30 bg-amber-500/10 text-amber-400'
+        : status === 'completed'
+          ? 'border-primary/30 bg-primary/10 text-primary'
+          : 'border-zinc-700 bg-zinc-800/60 text-zinc-300';
+  return (
+    <Badge variant='outline' className={tone}>
+      {STATUS_LABEL[status] ?? status}
+    </Badge>
+  );
+}
+
+export default function OrganizationBountiesPage() {
+  const params = useParams<{ id: string }>();
+  const organizationId = params?.id ?? '';
+
+  const draftsQuery = useDraftList(organizationId);
+  const publishedQuery = useOrganizationBounties(organizationId);
+
+  const drafts: BountyDraft[] = draftsQuery.data ?? [];
+  // The root list returns every bounty; show only the published ones here
+  // (drafts have their own section above).
+  const published: OrganizationBountyListItem[] = useMemo(
+    () =>
+      (publishedQuery.data ?? []).filter(b => !DRAFT_STATUSES.has(b.status)),
+    [publishedQuery.data]
+  );
+
+  const isLoading = draftsQuery.isLoading || publishedQuery.isLoading;
+
+  return (
+    <AuthGuard redirectTo='/auth?mode=signin' fallback={<Loading />}>
+      <div className='bg-background-main-bg mx-auto max-w-6xl flex-1 px-6 py-8 text-white'>
+        <div className='mb-8 flex items-center justify-between'>
+          <div>
+            <h1 className='text-2xl font-semibold text-white'>Bounties</h1>
+            <p className='mt-1 text-sm text-zinc-400'>
+              Host and manage bounties for your organization.
+            </p>
+          </div>
+          <Link href={`/organizations/${organizationId}/bounties/new`}>
+            <BoundlessButton size='lg' className='gap-2'>
+              <Plus className='h-4 w-4' />
+              Host a bounty
+            </BoundlessButton>
+          </Link>
+        </div>
+
+        {isLoading ? (
+          <div className='py-20 text-center text-sm text-zinc-400'>
+            Loading bounties…
+          </div>
+        ) : (
+          <div className='space-y-10'>
+            {/* Drafts */}
+            <section>
+              <h2 className='mb-3 flex items-center gap-2 text-sm font-medium text-zinc-300'>
+                <FileText className='h-4 w-4 text-zinc-500' />
+                Drafts
+              </h2>
+              {drafts.length === 0 ? (
+                <p className='rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-sm text-zinc-500'>
+                  No drafts yet. Start one with “Host a bounty”.
+                </p>
+              ) : (
+                <div className='grid gap-3'>
+                  {drafts.map(draft => (
+                    <Link
+                      key={draft.id}
+                      href={`/organizations/${organizationId}/bounties/drafts/${draft.id}`}
+                      className='flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-900/30 p-4 transition-colors hover:border-zinc-700'
+                    >
+                      <div className='min-w-0'>
+                        <p className='truncate text-sm font-medium text-white'>
+                          {draft.data?.scope?.title || 'Untitled bounty'}
+                        </p>
+                        <p className='mt-0.5 text-xs text-zinc-500'>
+                          {draft.modeLabel ?? 'Mode not set'} ·{' '}
+                          {draft.completedSteps?.length ?? 0}/4 sections
+                        </p>
+                      </div>
+                      <div className='flex items-center gap-3'>
+                        <StatusBadge status={draft.status} />
+                        <span className='text-xs text-zinc-400'>Resume</span>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </section>
+
+            {/* Published */}
+            <section>
+              <h2 className='mb-3 flex items-center gap-2 text-sm font-medium text-zinc-300'>
+                <Trophy className='h-4 w-4 text-zinc-500' />
+                Published
+              </h2>
+              {published.length === 0 ? (
+                <p className='rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-sm text-zinc-500'>
+                  No published bounties yet.
+                </p>
+              ) : (
+                <div className='grid gap-3'>
+                  {published.map(bounty => (
+                    <div
+                      key={bounty.id}
+                      className='flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-900/30 p-4'
+                    >
+                      <div className='min-w-0'>
+                        <p className='truncate text-sm font-medium text-white'>
+                          {bounty.title || 'Untitled bounty'}
+                        </p>
+                        {bounty.rewardAmount != null && (
+                          <p className='mt-0.5 text-xs text-zinc-500'>
+                            {bounty.rewardAmount.toLocaleString()}{' '}
+                            {bounty.rewardCurrency ?? ''}
+                          </p>
+                        )}
+                      </div>
+                      <StatusBadge status={bounty.status} />
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+          </div>
+        )}
+      </div>
+    </AuthGuard>
+  );
+}

--- a/features/bounties/api/core.ts
+++ b/features/bounties/api/core.ts
@@ -1,0 +1,38 @@
+/**
+ * Non-hook client for an organization's published bounties (the root list).
+ * The backend root GET isn't modelled with a response body in the OpenAPI
+ * schema, so the row shape is projected here to the fields the list page reads.
+ */
+import { apiClient, unwrapData } from '@/lib/api';
+
+export interface OrganizationBountyListItem {
+  id: string;
+  title: string;
+  /** Lowercase lifecycle status (draft, open, completed, ...). */
+  status: string;
+  rewardAmount?: number;
+  rewardCurrency?: string;
+  createdAt?: string;
+}
+
+/** List an organization's bounties, newest first. */
+export const listOrganizationBounties = async (
+  organizationId: string,
+  opts: { page?: number; limit?: number } = {}
+): Promise<OrganizationBountyListItem[]> => {
+  const res = await apiClient.GET(
+    '/api/organizations/{organizationId}/bounties',
+    {
+      params: {
+        path: { organizationId },
+        query: { page: opts.page ?? 1, limit: opts.limit ?? 20 },
+      },
+    }
+  );
+  // The response body is untyped in the schema (no response DTO on the
+  // controller); project it to the list-item shape.
+  return (
+    (unwrapData(res) as unknown as OrganizationBountyListItem[] | undefined) ??
+    []
+  );
+};

--- a/features/bounties/api/use-bounties.ts
+++ b/features/bounties/api/use-bounties.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import {
+  listOrganizationBounties,
+  type OrganizationBountyListItem,
+} from './core';
+import { bountyKeys } from './keys';
+
+/** An organization's published bounties (newest first). */
+export function useOrganizationBounties(organizationId: string) {
+  return useQuery({
+    queryKey: [...bountyKeys.all, 'published', organizationId],
+    enabled: Boolean(organizationId),
+    queryFn: (): Promise<OrganizationBountyListItem[]> =>
+      listOrganizationBounties(organizationId),
+  });
+}

--- a/features/bounties/index.ts
+++ b/features/bounties/index.ts
@@ -37,6 +37,11 @@ export {
 // Query keys.
 export { bountyKeys } from './api/keys';
 
+// Published bounty list (client + hook).
+export { listOrganizationBounties } from './api/core';
+export type { OrganizationBountyListItem } from './api/core';
+export { useOrganizationBounties } from './api/use-bounties';
+
 // Draft client (imperative helpers).
 export {
   createBountyDraft,


### PR DESCRIPTION
Closes #597. Part of the **Bounty Configure (Host a Bounty)** frontend epic (#603).

> Targets `feat/t-replace` (not `main`) as requested. Independent of #600/#601 — it mounts the merged wizard shell (#598) and data layer (#596).

## What

Adds the organizer bounty routes, mirroring the hackathon route tree, plus the published-list data the list page needs.

- **`app/(landing)/organizations/[id]/bounties/page.tsx`** — list page: a **Drafts** section (resume links → `/drafts/[draftId]`, status badges, mode label + section count) and a **Published** section (status badges + reward), with a "Host a bounty" CTA → `/new`. Empty + loading states.
- **`.../bounties/new/page.tsx`** — renders `<NewBountyTab organizationId={id} />`.
- **`.../bounties/drafts/[draftId]/page.tsx`** — renders `<NewBountyTab organizationId={id} draftId={draftId} />`.
- **`features/bounties/api/core.ts` + `use-bounties.ts`** — `listOrganizationBounties` + `useOrganizationBounties` for the root list. The backend root GET has no response DTO, so the row shape is projected to a typed `OrganizationBountyListItem`.

## Acceptance criteria

- **Routes render under the org dashboard** — three `AuthGuard`-wrapped pages under `organizations/[id]/bounties`.
- **List shows org bounties + links into create / resume** — drafts link to resume, the CTA links to create; published shown separately (filtered so drafts don't double-list).

`tsc --noEmit`: 0 errors; ESLint + Prettier clean; production build green (pre-commit hook).

## Notes

- Published rows have no deep link yet (no bounty detail/overview route in this epic's scope); they show status + reward. Resume/create links are wired per the acceptance criteria.

## Next

#602 — sidebar nav entry + codegen reconcile + end-to-end testnet verification (the last issue in the epic).