### PR TITLE
feat(bounty): sidebar nav entry + Post Bounty quick action (#602)

### DIFF
--- a/components/organization/OrganizationSidebar.tsx
+++ b/components/organization/OrganizationSidebar.tsx
@@ -1,5 +1,6 @@
 import {
   Trophy,
+  Target,
   HandCoins,
   Landmark,
   Settings,
@@ -211,6 +212,12 @@ export default function OrganizationSidebar({
       description: 'Manage your events',
     },
     {
+      icon: Target,
+      label: 'Bounties',
+      href: derivedOrgId ? `/organizations/${derivedOrgId}/bounties` : '#',
+      description: 'Host and fund bounties',
+    },
+    {
       icon: HandCoins,
       label: 'Grants',
       href: derivedOrgId ? `/organizations/${derivedOrgId}/grants` : '#',
@@ -238,6 +245,13 @@ export default function OrganizationSidebar({
       icon: Plus,
       label: 'Host Hackathon',
       href: `/organizations/${derivedOrgId}/hackathons/new`,
+      gradient: 'from-primary/20 to-primary/5',
+      disabled: false,
+    },
+    {
+      icon: Target,
+      label: 'Post Bounty',
+      href: `/organizations/${derivedOrgId}/bounties/new`,
       gradient: 'from-primary/20 to-primary/5',
       disabled: false,
     },


### PR DESCRIPTION
Part of the **Bounty Configure (Host a Bounty)** frontend epic (#603). Closes #602.

> Targets `feat/t-replace` (not `main`) as requested.

## What

- **`components/organization/OrganizationSidebar.tsx`** — adds a **Bounties** menu item (`/organizations/{orgId}/bounties`) and a **Post Bounty** quick action (`/organizations/{orgId}/bounties/new`), so organizers can reach the bounty list (#597) and the Configure wizard.

## Codegen reconcile

Re-ran `npm run codegen` against the v2 backend (Docker, :8000). The committed `lib/api/generated/schema.d.ts` already matches — `BountyDraftResponseDto` and `UpdateBountyDraftDto` are present and there's **no content drift** (the only difference vs raw codegen output is prettier formatting, which the committed file already has). No schema change needed in this PR.

`tsc --noEmit`: 0 errors; ESLint + Prettier clean; production build green (pre-commit hook).

## End-to-end verification (not automated here)

The testnet E2E pass — six mode combinations, save/resume round-trip, MANAGED `draft → draft_awaiting_funding → open`, single vs multi-winner split, and the negative gate checks — requires a running app + funded testnet wallets + a live browser session, which can't be driven from CI. A manual checklist is tracked in the PR discussion / handed to QA; the nav entries and codegen confirmation (the automatable parts of #602) are done here.