### PR TITLE
feat(bounty): wizard enhancements + hackathon-style org bounty list

### DIFF
--- a/app/(landing)/organizations/[id]/bounties/page.tsx
+++ b/app/(landing)/organizations/[id]/bounties/page.tsx
@@ -1,15 +1,25 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
-import { FileText, Plus, Trophy } from 'lucide-react';
+import { useParams, useRouter } from 'next/navigation';
+import { Calendar, FileText, Plus, Search, Target, Trash2 } from 'lucide-react';
 
 import { BoundlessButton } from '@/components/buttons';
 import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { AuthGuard } from '@/components/auth';
 import Loading from '@/components/Loading';
+import DeleteBountyDraftDialog from '@/components/organization/bounties/DeleteBountyDraftDialog';
 import {
+  useDeleteDraft,
   useDraftList,
   useOrganizationBounties,
   type BountyDraft,
@@ -18,150 +28,378 @@ import {
 
 const DRAFT_STATUSES = new Set(['draft', 'draft_awaiting_funding']);
 
-const STATUS_LABEL: Record<string, string> = {
-  draft: 'Draft',
-  draft_awaiting_funding: 'Publishing',
-  open: 'Open',
-  in_progress: 'In progress',
-  submitted: 'Submitted',
-  under_review: 'Under review',
-  completed: 'Completed',
-  cancelled: 'Cancelled',
-  disputed: 'Disputed',
+const STATUS_DISPLAY: Record<string, { label: string; className: string }> = {
+  open: {
+    label: 'Open',
+    className: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400',
+  },
+  in_progress: {
+    label: 'In progress',
+    className: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400',
+  },
+  submitted: {
+    label: 'Submitted',
+    className: 'border-blue-500/30 bg-blue-500/10 text-blue-400',
+  },
+  under_review: {
+    label: 'Under review',
+    className: 'border-blue-500/30 bg-blue-500/10 text-blue-400',
+  },
+  completed: {
+    label: 'Completed',
+    className: 'border-primary/30 bg-primary/10 text-primary',
+  },
+  cancelled: {
+    label: 'Cancelled',
+    className: 'border-zinc-700 bg-zinc-800/60 text-zinc-300',
+  },
+  disputed: {
+    label: 'Disputed',
+    className: 'border-red-500/30 bg-red-500/10 text-red-400',
+  },
 };
 
-function StatusBadge({ status }: { status: string }) {
-  const tone =
-    status === 'open' || status === 'in_progress'
-      ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400'
-      : status === 'draft_awaiting_funding'
-        ? 'border-amber-500/30 bg-amber-500/10 text-amber-400'
-        : status === 'completed'
-          ? 'border-primary/30 bg-primary/10 text-primary'
-          : 'border-zinc-700 bg-zinc-800/60 text-zinc-300';
+function statusDisplay(status: string) {
   return (
-    <Badge variant='outline' className={tone}>
-      {STATUS_LABEL[status] ?? status}
-    </Badge>
+    STATUS_DISPLAY[status] ?? {
+      label: status,
+      className: 'border-zinc-700 bg-zinc-800/60 text-zinc-300',
+    }
   );
 }
 
+const draftPrizePool = (draft: BountyDraft): number =>
+  (draft.data?.reward?.prizeTiers ?? []).reduce(
+    (sum, tier) => sum + (Number(tier.amount) || 0),
+    0
+  );
+
 export default function OrganizationBountiesPage() {
   const params = useParams<{ id: string }>();
+  const router = useRouter();
   const organizationId = params?.id ?? '';
+
+  const [tab, setTab] = useState<'published' | 'drafts'>('published');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortBy, setSortBy] = useState<'newest' | 'oldest'>('newest');
 
   const draftsQuery = useDraftList(organizationId);
   const publishedQuery = useOrganizationBounties(organizationId);
+  const deleteDraft = useDeleteDraft(organizationId);
+  const [draftToDelete, setDraftToDelete] = useState<{
+    id: string;
+    title: string;
+  } | null>(null);
 
-  const drafts: BountyDraft[] = draftsQuery.data ?? [];
-  // The root list returns every bounty; show only the published ones here
-  // (drafts have their own section above).
-  const published: OrganizationBountyListItem[] = useMemo(
-    () =>
-      (publishedQuery.data ?? []).filter(b => !DRAFT_STATUSES.has(b.status)),
-    [publishedQuery.data]
-  );
+  const allDrafts: BountyDraft[] = draftsQuery.data ?? [];
+
+  const published: OrganizationBountyListItem[] = useMemo(() => {
+    let items = (publishedQuery.data ?? []).filter(
+      b => !DRAFT_STATUSES.has(b.status)
+    );
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      items = items.filter(b => b.title?.toLowerCase().includes(q));
+    }
+    return [...items].sort((a, b) => {
+      const ta = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const tb = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return sortBy === 'newest' ? tb - ta : ta - tb;
+    });
+  }, [publishedQuery.data, searchQuery, sortBy]);
+
+  const drafts: BountyDraft[] = useMemo(() => {
+    let items = allDrafts;
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      items = items.filter(d =>
+        (d.data?.scope?.title ?? '').toLowerCase().includes(q)
+      );
+    }
+    return [...items].sort((a, b) => {
+      const ta = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const tb = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return sortBy === 'newest' ? tb - ta : ta - tb;
+    });
+  }, [allDrafts, searchQuery, sortBy]);
 
   const isLoading = draftsQuery.isLoading || publishedQuery.isLoading;
+  const publishedCount = (publishedQuery.data ?? []).filter(
+    b => !DRAFT_STATUSES.has(b.status)
+  ).length;
+  const stats = {
+    total: publishedCount + allDrafts.length,
+    published: publishedCount,
+    drafts: allDrafts.length,
+  };
 
   return (
     <AuthGuard redirectTo='/auth?mode=signin' fallback={<Loading />}>
-      <div className='bg-background-main-bg mx-auto max-w-6xl flex-1 px-6 py-8 text-white'>
-        <div className='mb-8 flex items-center justify-between'>
-          <div>
-            <h1 className='text-2xl font-semibold text-white'>Bounties</h1>
-            <p className='mt-1 text-sm text-zinc-400'>
-              Host and manage bounties for your organization.
-            </p>
+      <div className='min-h-screen bg-black'>
+        {/* Header */}
+        <div className='sticky top-0 z-20 border-b border-zinc-900 bg-black/80 backdrop-blur-xl'>
+          <div className='mx-auto max-w-6xl px-6 py-8'>
+            <div className='mb-8 flex items-center justify-between'>
+              <div>
+                <h1 className='mb-2 text-3xl font-bold tracking-tight text-white'>
+                  Bounties
+                </h1>
+                <div className='flex items-center gap-6 text-sm text-zinc-500'>
+                  <span>{stats.total} total</span>
+                  <span>•</span>
+                  <span>{stats.published} published</span>
+                  <span>•</span>
+                  <span>{stats.drafts} drafts</span>
+                </div>
+              </div>
+              <Link href={`/organizations/${organizationId}/bounties/new`}>
+                <BoundlessButton className='shadow-primary/20 gap-2 shadow-lg'>
+                  <Plus className='h-4 w-4' />
+                  Host a bounty
+                </BoundlessButton>
+              </Link>
+            </div>
+
+            {/* Tabs */}
+            <div className='mb-6 flex gap-2'>
+              <button
+                className={`rounded-full px-4 py-2 text-sm font-medium transition-all ${tab === 'published' ? 'bg-primary text-black shadow' : 'bg-zinc-900 text-white hover:bg-zinc-800'}`}
+                onClick={() => setTab('published')}
+              >
+                Published
+              </button>
+              <button
+                className={`rounded-full px-4 py-2 text-sm font-medium transition-all ${tab === 'drafts' ? 'bg-primary text-black shadow' : 'bg-zinc-900 text-white hover:bg-zinc-800'}`}
+                onClick={() => setTab('drafts')}
+              >
+                Drafts
+              </button>
+            </div>
+
+            {/* Filters */}
+            <div className='flex flex-wrap items-center gap-3'>
+              <div className='relative min-w-50 flex-1'>
+                <Search className='absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-zinc-500' />
+                <Input
+                  type='search'
+                  placeholder='Search bounties...'
+                  value={searchQuery}
+                  onChange={e => setSearchQuery(e.target.value)}
+                  className='focus:border-primary focus:ring-primary/20 h-10 rounded-xl border-zinc-800/50 bg-zinc-900/30 pl-10 text-sm text-white transition-all placeholder:text-zinc-500 hover:border-zinc-700 hover:bg-zinc-900/50'
+                />
+              </div>
+              <Select
+                value={sortBy}
+                onValueChange={value => setSortBy(value as 'newest' | 'oldest')}
+              >
+                <SelectTrigger className='focus:border-primary focus:ring-primary/20 h-10 w-32 rounded-xl border-zinc-800/50 bg-zinc-900/30 text-sm text-white transition-all hover:border-zinc-700 hover:bg-zinc-900/50'>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className='border-zinc-800/50 bg-zinc-950 backdrop-blur-xl'>
+                  <SelectItem
+                    value='newest'
+                    className='text-white focus:bg-zinc-900/50 focus:text-white'
+                  >
+                    Newest
+                  </SelectItem>
+                  <SelectItem
+                    value='oldest'
+                    className='text-white focus:bg-zinc-900/50 focus:text-white'
+                  >
+                    Oldest
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
           </div>
-          <Link href={`/organizations/${organizationId}/bounties/new`}>
-            <BoundlessButton size='lg' className='gap-2'>
-              <Plus className='h-4 w-4' />
-              Host a bounty
-            </BoundlessButton>
-          </Link>
         </div>
 
-        {isLoading ? (
-          <div className='py-20 text-center text-sm text-zinc-400'>
-            Loading bounties…
-          </div>
-        ) : (
-          <div className='space-y-10'>
-            {/* Drafts */}
-            <section>
-              <h2 className='mb-3 flex items-center gap-2 text-sm font-medium text-zinc-300'>
-                <FileText className='h-4 w-4 text-zinc-500' />
-                Drafts
-              </h2>
-              {drafts.length === 0 ? (
-                <p className='rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-sm text-zinc-500'>
-                  No drafts yet. Start one with “Host a bounty”.
-                </p>
-              ) : (
-                <div className='grid gap-3'>
-                  {drafts.map(draft => (
-                    <Link
-                      key={draft.id}
-                      href={`/organizations/${organizationId}/bounties/drafts/${draft.id}`}
-                      className='flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-900/30 p-4 transition-colors hover:border-zinc-700'
-                    >
-                      <div className='min-w-0'>
-                        <p className='truncate text-sm font-medium text-white'>
-                          {draft.data?.scope?.title || 'Untitled bounty'}
-                        </p>
-                        <p className='mt-0.5 text-xs text-zinc-500'>
-                          {draft.modeLabel ?? 'Mode not set'} ·{' '}
-                          {draft.completedSteps?.length ?? 0}/4 sections
-                        </p>
-                      </div>
-                      <div className='flex items-center gap-3'>
-                        <StatusBadge status={draft.status} />
-                        <span className='text-xs text-zinc-400'>Resume</span>
-                      </div>
-                    </Link>
-                  ))}
-                </div>
-              )}
-            </section>
-
-            {/* Published */}
-            <section>
-              <h2 className='mb-3 flex items-center gap-2 text-sm font-medium text-zinc-300'>
-                <Trophy className='h-4 w-4 text-zinc-500' />
-                Published
-              </h2>
-              {published.length === 0 ? (
-                <p className='rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-6 text-sm text-zinc-500'>
-                  No published bounties yet.
-                </p>
-              ) : (
-                <div className='grid gap-3'>
-                  {published.map(bounty => (
+        {/* Content */}
+        <div className='mx-auto max-w-6xl px-6 py-8'>
+          {isLoading ? (
+            <div className='flex flex-col items-center justify-center py-24'>
+              <div className='border-primary mb-4 h-8 w-8 animate-spin rounded-full border-2 border-t-transparent' />
+              <span className='text-sm text-zinc-400'>Loading bounties…</span>
+            </div>
+          ) : tab === 'published' ? (
+            published.length === 0 ? (
+              <EmptyState
+                title='No published bounties yet'
+                organizationId={organizationId}
+              />
+            ) : (
+              <div className='grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3'>
+                {published.map(bounty => {
+                  const { label, className } = statusDisplay(bounty.status);
+                  return (
                     <div
                       key={bounty.id}
-                      className='flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-900/30 p-4'
+                      className='group hover:border-primary/60 hover:shadow-primary/10 relative flex flex-col rounded-2xl border border-zinc-800 bg-zinc-900/30 p-5 shadow-lg transition-all'
                     >
-                      <div className='min-w-0'>
-                        <p className='truncate text-sm font-medium text-white'>
-                          {bounty.title || 'Untitled bounty'}
-                        </p>
-                        {bounty.rewardAmount != null && (
-                          <p className='mt-0.5 text-xs text-zinc-500'>
-                            {bounty.rewardAmount.toLocaleString()}{' '}
-                            {bounty.rewardCurrency ?? ''}
-                          </p>
+                      <div className='mb-3 flex items-center justify-between'>
+                        <Badge
+                          variant='outline'
+                          className={`rounded-full border px-3 py-1 text-xs font-semibold ${className}`}
+                        >
+                          {label}
+                        </Badge>
+                        {bounty.createdAt && (
+                          <span className='flex items-center gap-1.5 text-xs text-zinc-500'>
+                            <Calendar className='h-3 w-3' />
+                            {new Date(bounty.createdAt).toLocaleDateString()}
+                          </span>
                         )}
                       </div>
-                      <StatusBadge status={bounty.status} />
+                      <h3 className='line-clamp-2 min-h-14 text-lg font-bold text-white'>
+                        {bounty.title || 'Untitled bounty'}
+                      </h3>
+                      <div className='mt-4 flex items-end justify-between border-t border-zinc-800 pt-4'>
+                        <div className='flex items-center gap-2'>
+                          <div className='bg-primary/10 flex h-9 w-9 items-center justify-center rounded-lg'>
+                            <Target className='text-primary h-4 w-4' />
+                          </div>
+                          <div>
+                            <p className='text-primary text-base leading-tight font-bold'>
+                              {(bounty.rewardAmount ?? 0).toLocaleString()}{' '}
+                              {bounty.rewardCurrency ?? 'USDC'}
+                            </p>
+                            <p className='text-[11px] text-zinc-500'>reward</p>
+                          </div>
+                        </div>
+                        <span className='flex items-center gap-1 text-xs text-zinc-400'>
+                          <FileText className='h-4 w-4' />
+                          {bounty._count?.submissions ?? 0}
+                        </span>
+                      </div>
                     </div>
-                  ))}
-                </div>
-              )}
-            </section>
-          </div>
-        )}
+                  );
+                })}
+              </div>
+            )
+          ) : drafts.length === 0 ? (
+            <EmptyState title='No drafts yet' organizationId={organizationId} />
+          ) : (
+            <div className='grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3'>
+              {drafts.map(draft => {
+                const title = draft.data?.scope?.title || 'Untitled bounty';
+                const completion = Math.round(
+                  ((draft.completedSteps?.length ?? 0) / 4) * 100
+                );
+                const isPublishing = draft.status === 'draft_awaiting_funding';
+                const prizePool = draftPrizePool(draft);
+                return (
+                  <div
+                    key={draft.id}
+                    className='group hover:border-primary/60 hover:shadow-primary/10 relative flex cursor-pointer flex-col rounded-2xl border border-zinc-800 bg-zinc-900/30 p-5 shadow-lg transition-all'
+                    onClick={() =>
+                      router.push(
+                        `/organizations/${organizationId}/bounties/drafts/${draft.id}`
+                      )
+                    }
+                    tabIndex={0}
+                    role='button'
+                    aria-label={`Edit draft ${title}`}
+                  >
+                    <div className='mb-3 flex items-center justify-between'>
+                      <Badge
+                        variant='outline'
+                        className={
+                          isPublishing
+                            ? 'rounded-full bg-amber-600/80 px-3 py-1 text-xs font-medium text-amber-50'
+                            : 'rounded-full bg-zinc-500 px-3 py-1 text-xs font-medium text-zinc-100'
+                        }
+                      >
+                        {isPublishing ? 'Publishing' : 'Draft'}
+                      </Badge>
+                      <span className='text-xs text-zinc-400'>
+                        {isPublishing ? 'Finalizing…' : `${completion}%`}
+                      </span>
+                    </div>
+                    <h3 className='line-clamp-2 min-h-14 text-lg font-bold text-white'>
+                      {title}
+                    </h3>
+                    <p className='mt-1 truncate text-xs text-zinc-500'>
+                      {draft.modeLabel ?? 'Mode not set'}
+                    </p>
+                    <div className='mt-3 h-1.5 overflow-hidden rounded-full bg-zinc-800'>
+                      <div
+                        className='bg-primary h-full rounded-full transition-all'
+                        style={{ width: `${completion}%` }}
+                      />
+                    </div>
+                    <div className='mt-4 flex items-center gap-2 border-t border-zinc-800 pt-4'>
+                      <div className='bg-primary/10 flex h-9 w-9 items-center justify-center rounded-lg'>
+                        <Target className='text-primary h-4 w-4' />
+                      </div>
+                      <div>
+                        <p className='text-primary text-base leading-tight font-bold'>
+                          {prizePool > 0
+                            ? `${prizePool.toLocaleString()} ${draft.data?.reward?.rewardCurrency ?? 'USDC'}`
+                            : 'No reward set'}
+                        </p>
+                        <p className='text-[11px] text-zinc-500'>reward</p>
+                      </div>
+                    </div>
+                    {!isPublishing && (
+                      <div className='absolute top-3 right-3 z-10 flex gap-2 opacity-0 transition-opacity group-hover:opacity-100'>
+                        <button
+                          onClick={e => {
+                            e.stopPropagation();
+                            setDraftToDelete({ id: draft.id, title });
+                          }}
+                          className='flex h-9 w-9 items-center justify-center rounded-lg border border-zinc-800 bg-zinc-900/70 text-zinc-400 hover:border-red-600 hover:text-red-500'
+                          title='Delete draft'
+                          disabled={deleteDraft.isPending}
+                        >
+                          <Trash2 className='h-4 w-4' />
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
       </div>
+
+      <DeleteBountyDraftDialog
+        open={!!draftToDelete}
+        onOpenChange={open => {
+          if (!open) setDraftToDelete(null);
+        }}
+        draftTitle={draftToDelete?.title ?? ''}
+        isDeleting={deleteDraft.isPending}
+        onConfirm={() => {
+          if (draftToDelete) deleteDraft.mutate(draftToDelete.id);
+        }}
+      />
     </AuthGuard>
+  );
+}
+
+function EmptyState({
+  title,
+  organizationId,
+}: {
+  title: string;
+  organizationId: string;
+}) {
+  return (
+    <div className='flex flex-col items-center justify-center rounded-2xl border border-dashed border-zinc-800 py-24'>
+      <div className='mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-zinc-900'>
+        <Target className='h-8 w-8 text-zinc-600' />
+      </div>
+      <h3 className='mb-2 text-lg font-medium text-white'>{title}</h3>
+      <p className='mb-6 text-sm text-zinc-500'>
+        Host a bounty to get contributors building.
+      </p>
+      <Link href={`/organizations/${organizationId}/bounties/new`}>
+        <BoundlessButton className='gap-2'>
+          <Plus className='h-4 w-4' />
+          Host a bounty
+        </BoundlessButton>
+      </Link>
+    </div>
   );
 }

--- a/components/organization/bounties/DeleteBountyDraftDialog.tsx
+++ b/components/organization/bounties/DeleteBountyDraftDialog.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { AlertTriangle } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+interface DeleteBountyDraftDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  draftTitle: string;
+  onConfirm: () => void;
+  isDeleting?: boolean;
+}
+
+export default function DeleteBountyDraftDialog({
+  open,
+  onOpenChange,
+  draftTitle,
+  onConfirm,
+  isDeleting = false,
+}: DeleteBountyDraftDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className='border-zinc-800 bg-zinc-950'>
+        <AlertDialogHeader className='items-center'>
+          <div className='flex size-12 items-center justify-center rounded-full bg-red-500/10'>
+            <AlertTriangle className='size-6 text-red-500' />
+          </div>
+          <AlertDialogTitle className='text-xl text-white'>
+            Delete this draft?
+          </AlertDialogTitle>
+          <AlertDialogDescription className='text-center text-zinc-400'>
+            {draftTitle ? (
+              <>
+                <span className='font-semibold text-white'>
+                  &quot;{draftTitle}&quot;
+                </span>{' '}
+                will be permanently deleted. This cannot be undone.
+              </>
+            ) : (
+              'This draft will be permanently deleted. This cannot be undone.'
+            )}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel
+            disabled={isDeleting}
+            className='border-zinc-700 bg-zinc-900 text-zinc-300 hover:bg-zinc-800 hover:text-white'
+          >
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={isDeleting}
+            className='bg-red-500 text-white hover:bg-red-600 disabled:cursor-not-allowed disabled:opacity-50'
+          >
+            {isDeleting ? 'Deleting...' : 'Delete draft'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/components/organization/bounties/new/NewBountyTab.tsx
+++ b/components/organization/bounties/new/NewBountyTab.tsx
@@ -8,10 +8,12 @@ import { Tabs, TabsContent } from '@/components/ui/tabs';
 import { useBountySteps } from '@/hooks/use-bounty-steps';
 import { useBountyDraft } from '@/hooks/use-bounty-draft';
 import { useBountyPublish } from '@/hooks/use-bounty-publish';
+import { buildMockBountyData } from './mock-data';
 import ScopeTab from './tabs/ScopeTab';
 import ModeTab from './tabs/ModeTab';
 import SubmissionModelTab from './tabs/SubmissionModelTab';
 import RewardTab from './tabs/RewardTab';
+import ResourcesTab from './tabs/ResourcesTab';
 import ReviewTab from './tabs/ReviewTab';
 import type { ModeSelection } from './tabs/schemas/modeSchema';
 import {
@@ -75,6 +77,7 @@ export default function NewBountyTab({
     isSavingDraft,
     saveDraft,
     saveStep,
+    saveAllSections,
   } = useBountyDraft({
     organizationId: derivedOrgId,
     initialDraftId: resolvedInitialDraftId,
@@ -125,6 +128,7 @@ export default function NewBountyTab({
     mode: false,
     submission: false,
     reward: false,
+    resources: false,
     review: false,
   });
 
@@ -158,12 +162,39 @@ export default function NewBountyTab({
   // Publish via the shared escrow runner. Defaults to MANAGED (the connected
   // custodial wallet funds + the backend signs); the funding-source picker
   // (external wallet / treasury) is a follow-up.
-  const { publish, isPublishing } = useBountyPublish({
+  const { publish, isPublishing, publishResponse } = useBountyPublish({
     organizationId: derivedOrgId || '',
     stepData,
     draftId,
     fundingMode: 'MANAGED',
   });
+
+  // Once the publish finalizes on-chain, leave the wizard for the organizer's
+  // bounty list rather than lingering on the (now read-only) review.
+  const hasRedirectedRef = useRef(false);
+  useEffect(() => {
+    if (publishResponse && derivedOrgId && !hasRedirectedRef.current) {
+      hasRedirectedRef.current = true;
+      router.replace(`/organizations/${derivedOrgId}/bounties`);
+    }
+  }, [publishResponse, derivedOrgId, router]);
+
+  // Dev-only convenience: fill every section with valid mock data, persist it
+  // in one PATCH, and jump to Review. Never rendered in production builds.
+  const isDev = process.env.NODE_ENV === 'development';
+  const [isFillingMock, setIsFillingMock] = useState(false);
+  const handleFillMock = useCallback(async () => {
+    setIsFillingMock(true);
+    try {
+      await saveAllSections(buildMockBountyData());
+      navigateToStep('review');
+      toast.success('Filled the wizard with mock data');
+    } catch {
+      toast.error('Failed to fill mock data');
+    } finally {
+      setIsFillingMock(false);
+    }
+  }, [saveAllSections, navigateToStep]);
 
   if (isLoadingDraft) {
     return (
@@ -189,6 +220,18 @@ export default function NewBountyTab({
       className='bg-background-main-bg mx-auto max-w-6xl flex-1 overflow-hidden px-6 py-8 text-white'
       id={organizationId}
     >
+      {isDev && (
+        <div className='flex justify-end px-6 md:px-20'>
+          <button
+            type='button'
+            onClick={handleFillMock}
+            disabled={isFillingMock}
+            className='flex items-center gap-2 rounded-md border border-dashed border-amber-500/50 bg-amber-500/10 px-3 py-1.5 text-xs font-medium text-amber-300 transition-colors hover:bg-amber-500/20 disabled:opacity-50'
+          >
+            {isFillingMock ? 'Filling...' : '⚡ Fill with mock (dev)'}
+          </button>
+        </div>
+      )}
       <Tabs value={activeTab} className='w-full'>
         <div className='px-6 py-6 md:px-20'>
           <TabsContent value='scope' className='mt-0'>
@@ -204,6 +247,7 @@ export default function NewBountyTab({
             <ModeTab
               onSave={createSaveHandler('mode', 'submission')}
               onContinue={() => navigateToStep('submission')}
+              onBack={() => navigateToStep('scope')}
               initialData={stepData.mode}
               isLoading={loadingStates.mode}
             />
@@ -212,8 +256,10 @@ export default function NewBountyTab({
           <TabsContent value='submission' className='mt-0'>
             <SubmissionModelTab
               mode={modeSelection}
+              category={stepData.scope?.category}
               onSave={createSaveHandler('submission', 'reward')}
               onContinue={() => navigateToStep('reward')}
+              onBack={() => navigateToStep('mode')}
               initialData={stepData.submission}
               isLoading={loadingStates.submission}
             />
@@ -229,10 +275,21 @@ export default function NewBountyTab({
                     }
                   : undefined
               }
-              onSave={createSaveHandler('reward', 'review')}
-              onContinue={() => navigateToStep('review')}
+              onSave={createSaveHandler('reward', 'resources')}
+              onContinue={() => navigateToStep('resources')}
+              onBack={() => navigateToStep('submission')}
               initialData={stepData.reward}
               isLoading={loadingStates.reward}
+            />
+          </TabsContent>
+
+          <TabsContent value='resources' className='mt-0'>
+            <ResourcesTab
+              onSave={createSaveHandler('resources', 'review')}
+              onContinue={() => navigateToStep('review')}
+              onBack={() => navigateToStep('reward')}
+              initialData={stepData.resources}
+              isLoading={loadingStates.resources}
             />
           </TabsContent>
 
@@ -240,6 +297,7 @@ export default function NewBountyTab({
             <ReviewTab
               allData={stepData}
               onEdit={navigateToStep}
+              onBack={() => navigateToStep('resources')}
               onSaveDraft={saveDraft}
               isSavingDraft={isSavingDraft}
               onPublish={async () => {

--- a/components/organization/bounties/new/constants.ts
+++ b/components/organization/bounties/new/constants.ts
@@ -2,10 +2,17 @@ import type { ModeFormData } from './tabs/schemas/modeSchema';
 import type { SubmissionModelFormData } from './tabs/schemas/submissionModelSchema';
 import type { ScopeFormData } from './tabs/schemas/scopeSchema';
 import type { RewardFormData } from './tabs/schemas/rewardSchema';
+import type { ResourcesFormData } from './tabs/schemas/resourcesSchema';
 
 export type StepStatus = 'pending' | 'active' | 'completed';
 
-export type StepKey = 'scope' | 'mode' | 'submission' | 'reward' | 'review';
+export type StepKey =
+  | 'scope'
+  | 'mode'
+  | 'submission'
+  | 'reward'
+  | 'resources'
+  | 'review';
 
 export interface StepData {
   status: StepStatus;
@@ -13,12 +20,14 @@ export interface StepData {
   data?: Record<string, unknown>;
 }
 
-/** The five wizard steps, in order. `review` carries no editable section. */
+/** The wizard steps, in order. `resources` is optional; `review` carries no
+ * editable section. */
 export const STEP_ORDER: StepKey[] = [
   'scope',
   'mode',
   'submission',
   'reward',
+  'resources',
   'review',
 ];
 
@@ -31,6 +40,7 @@ export interface BountyFormData {
   mode?: ModeFormData;
   submission?: SubmissionModelFormData;
   reward?: RewardFormData;
+  resources?: ResourcesFormData;
 }
 
 /**
@@ -60,6 +70,9 @@ export const isBountyStepDataValid = (
         reward?.rewardCurrency && (reward?.prizeTiers?.length ?? 0) > 0
       );
     }
+    case 'resources':
+      // Optional step: never blocks the resume from advancing to review.
+      return true;
     case 'review':
       return false;
     default:

--- a/components/organization/bounties/new/mock-data.ts
+++ b/components/organization/bounties/new/mock-data.ts
@@ -1,0 +1,66 @@
+import type { BountyFormData } from './constants';
+
+/** A `datetime-local` string (YYYY-MM-DDTHH:mm) `days` from now. */
+function futureLocal(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  d.setSeconds(0, 0);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(
+    d.getDate()
+  )}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/**
+ * A complete, publish-valid bounty configuration for the dev-only "Fill with
+ * mock" button. Uses the simplest valid mode (open, single claim) so every
+ * section passes its schema and the publish gate. Development category, so the
+ * GitHub issue URL is present; reputation matches the development floor.
+ */
+export function buildMockBountyData(): BountyFormData {
+  return {
+    scope: {
+      title: 'Build a Soroban faucet bot',
+      description:
+        '## Overview\n\nMock bounty generated for local testing.\n\n' +
+        '### What needs to be built\n\n' +
+        '- A Telegram bot that drips testnet XLM\n' +
+        '- Rate limiting per user\n' +
+        '- A simple `/faucet` command\n\n' +
+        '**Done looks like:** a deployed bot with a short README.',
+      category: 'DEVELOPMENT',
+      country: 'United States',
+      githubIssueUrl: 'https://github.com/boundlessfi/boundless/issues/1',
+      projectId: null,
+      bountyWindowId: null,
+    },
+    mode: {
+      entryType: 'OPEN',
+      claimType: 'SINGLE_CLAIM',
+      winnerCount: 1,
+    },
+    submission: {
+      submissionDeadline: futureLocal(30),
+      submissionVisibility: 'ORGANIZER_ONLY',
+      reputationMinimum: 50,
+      applicationWindowCloseAt: null,
+      maxApplicants: null,
+      shortlistSize: null,
+      applicationCreditCost: null,
+    },
+    reward: {
+      rewardCurrency: 'USDC',
+      prizeTiers: [{ position: 1, amount: '100', passMark: null }],
+    },
+    resources: {
+      resources: [
+        {
+          id: 'resource-mock-1',
+          link: 'https://developers.stellar.org/docs',
+          description: 'Stellar developer documentation',
+          file: undefined,
+        },
+      ],
+    },
+  };
+}

--- a/components/organization/bounties/new/tabs/ModeTab.tsx
+++ b/components/organization/bounties/new/tabs/ModeTab.tsx
@@ -11,6 +11,7 @@ import {
   Loader2,
   Minus,
   Plus,
+  ArrowLeft,
 } from 'lucide-react';
 
 import { BoundlessButton } from '@/components/buttons';
@@ -28,6 +29,7 @@ import {
 
 interface ModeTabProps {
   onContinue?: () => void;
+  onBack?: () => void;
   onSave?: (data: ModeFormData) => Promise<void>;
   initialData?: Partial<ModeFormData>;
   isLoading?: boolean;
@@ -87,6 +89,7 @@ const defaultValues: ModeFormData = {
 
 export default function ModeTab({
   onContinue,
+  onBack,
   onSave,
   initialData,
   isLoading = false,
@@ -314,7 +317,21 @@ export default function ModeTab({
           </p>
         </div>
 
-        <div className='flex justify-end pt-4'>
+        <div className='flex items-center justify-between pt-4'>
+          {onBack ? (
+            <BoundlessButton
+              type='button'
+              variant='outline'
+              size='lg'
+              onClick={onBack}
+              disabled={isLoading}
+            >
+              <ArrowLeft className='mr-2 h-4 w-4' />
+              Back
+            </BoundlessButton>
+          ) : (
+            <span />
+          )}
           <BoundlessButton
             type='submit'
             size='lg'

--- a/components/organization/bounties/new/tabs/ResourcesTab.tsx
+++ b/components/organization/bounties/new/tabs/ResourcesTab.tsx
@@ -1,0 +1,316 @@
+import React from 'react';
+import { useForm, useFieldArray } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import type { Control } from 'react-hook-form';
+import {
+  ArrowLeft,
+  FileText,
+  Link as LinkIcon,
+  Loader2,
+  Plus,
+  Trash2,
+} from 'lucide-react';
+
+import { BoundlessButton } from '@/components/buttons';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import ResourceFileUpload from '@/components/organization/hackathons/new/tabs/components/ResourceFileUpload';
+import { resourcesSchema, ResourcesFormData } from './schemas/resourcesSchema';
+
+interface ResourcesTabProps {
+  onContinue?: () => void;
+  onBack?: () => void;
+  onSave?: (data: ResourcesFormData) => Promise<void>;
+  initialData?: ResourcesFormData;
+  isLoading?: boolean;
+}
+
+interface ResourceRowProps {
+  index: number;
+  onRemove: (index: number) => void;
+  control: Control<ResourcesFormData>;
+}
+
+const ResourceRow = ({ index, onRemove, control }: ResourceRowProps) => {
+  return (
+    <div className='group space-y-4 rounded-lg border border-zinc-800 bg-zinc-900/30 p-4'>
+      <div className='flex items-start justify-between gap-4'>
+        <div className='flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-zinc-800'>
+          <FileText className='h-5 w-5 text-zinc-500' />
+        </div>
+        <div className='flex-1 space-y-4'>
+          {/* Link */}
+          <FormField
+            control={control}
+            name={`resources.${index}.link`}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className='text-sm font-medium text-white'>
+                  Link <span className='text-zinc-500'>(optional)</span>
+                </FormLabel>
+                <FormControl>
+                  <div className='relative'>
+                    <LinkIcon className='absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-zinc-500' />
+                    <Input
+                      {...field}
+                      type='url'
+                      placeholder='https://example.com/resource'
+                      value={field.value || ''}
+                      className='h-11 border-zinc-800 bg-zinc-900/50 pl-10 text-white placeholder:text-zinc-600'
+                    />
+                  </div>
+                </FormControl>
+                <FormMessage className='text-xs text-red-500' />
+              </FormItem>
+            )}
+          />
+
+          {/* Description */}
+          <FormField
+            control={control}
+            name={`resources.${index}.description`}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className='text-sm font-medium text-white'>
+                  Description <span className='text-zinc-500'>(optional)</span>
+                </FormLabel>
+                <FormControl>
+                  <Textarea
+                    {...field}
+                    value={field.value || ''}
+                    placeholder='Describe this resource for contributors...'
+                    className='min-h-24 resize-none border-zinc-800 bg-zinc-900/50 text-white placeholder:text-zinc-600'
+                  />
+                </FormControl>
+                <FormMessage className='text-xs text-red-500' />
+              </FormItem>
+            )}
+          />
+
+          {/* File upload */}
+          <FormField
+            control={control}
+            name={`resources.${index}.file`}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className='text-sm font-medium text-white'>
+                  File <span className='text-zinc-500'>(optional)</span>
+                </FormLabel>
+                <FormControl>
+                  <ResourceFileUpload
+                    value={field.value}
+                    onChange={field.onChange}
+                    folder='boundless/bounties/resources'
+                    tags={['bounty', 'resource']}
+                    allowedExtensions={[
+                      '.pdf',
+                      '.doc',
+                      '.docx',
+                      '.ppt',
+                      '.pptx',
+                      '.md',
+                      '.markdown',
+                    ]}
+                    allowedMimeTypes={[
+                      'application/pdf',
+                      'application/msword',
+                      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                      'application/vnd.ms-powerpoint',
+                      'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+                      'text/markdown',
+                      'text/x-markdown',
+                      'text/plain',
+                    ]}
+                  />
+                </FormControl>
+                <p className='text-xs text-zinc-500'>
+                  Upload a PDF, Word, PowerPoint, or Markdown (.md) file (Max
+                  10MB)
+                </p>
+                <FormMessage className='text-xs text-red-500' />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <Button
+          type='button'
+          variant='ghost'
+          size='icon'
+          onClick={() => onRemove(index)}
+          className='shrink-0 text-zinc-500 opacity-0 transition-all group-hover:opacity-100 hover:bg-red-500/10 hover:text-red-400'
+        >
+          <Trash2 className='h-4 w-4' />
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default function ResourcesTab({
+  onContinue,
+  onBack,
+  onSave,
+  initialData,
+  isLoading = false,
+}: ResourcesTabProps) {
+  const form = useForm<ResourcesFormData>({
+    resolver: zodResolver(resourcesSchema),
+    mode: 'onChange',
+    defaultValues: initialData || { resources: [] },
+  });
+
+  React.useEffect(() => {
+    if (initialData) form.reset(initialData);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialData]);
+
+  // Whether the organizer has added anything yet; drives the "Skip" vs
+  // "Continue" label so the step reads as clearly optional.
+  const hasResources = (form.watch('resources')?.length ?? 0) > 0;
+  const hadInitialResources = (initialData?.resources?.length ?? 0) > 0;
+
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: 'resources',
+  });
+
+  const handleAdd = () => {
+    append({
+      id: `resource-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
+      link: '',
+      description: '',
+      file: undefined,
+    });
+  };
+
+  const handleRemove = (index: number) => {
+    remove(index);
+    toast.success('Resource removed');
+  };
+
+  const onSubmit = async (data: ResourcesFormData) => {
+    try {
+      // Optional step: only persist when there's something to save or a prior
+      // set to clear. Otherwise just advance without a wasted request.
+      const shouldSave =
+        (data.resources?.length ?? 0) > 0 || hadInitialResources;
+      if (onSave && shouldSave) await onSave(data);
+      if (onContinue) onContinue();
+    } catch (error: unknown) {
+      const err = error as {
+        response?: { data?: { message?: string | string[] } };
+        message?: string;
+      };
+      const message = err.response?.data?.message || err.message;
+      const errorMessage = Array.isArray(message) ? message[0] : message;
+      toast.error(
+        errorMessage || 'Failed to save resources. Please try again.'
+      );
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-6'>
+        <div>
+          <h3 className='text-lg font-medium text-white'>
+            Resources for contributors
+          </h3>
+          <p className='mt-1 text-sm text-zinc-500'>
+            Share helpful links, documentation, or files to help contributors
+            succeed. This step is optional.
+          </p>
+        </div>
+
+        <div className='space-y-4'>
+          {fields.length === 0 ? (
+            <div className='flex flex-col items-center justify-center rounded-lg border border-dashed border-zinc-800 bg-zinc-900/30 p-12'>
+              <FileText className='mb-4 h-12 w-12 text-zinc-600' />
+              <p className='mb-2 text-sm font-medium text-white'>
+                No resources added yet
+              </p>
+              <p className='mb-4 text-sm text-zinc-500'>
+                Add links or files to give contributors everything they need.
+              </p>
+              <Button
+                type='button'
+                variant='outline'
+                onClick={handleAdd}
+                className='hover:border-primary hover:bg-primary/5 hover:text-primary border-zinc-700'
+              >
+                <Plus className='mr-2 h-4 w-4' />
+                Add resource
+              </Button>
+            </div>
+          ) : (
+            <>
+              {fields.map((resource, index) => (
+                <ResourceRow
+                  key={resource.id}
+                  index={index}
+                  onRemove={handleRemove}
+                  control={form.control}
+                />
+              ))}
+
+              <Button
+                type='button'
+                variant='outline'
+                onClick={handleAdd}
+                className='hover:border-primary hover:bg-primary/5 hover:text-primary h-11 w-full border-dashed border-zinc-700 text-zinc-400'
+              >
+                <Plus className='mr-2 h-4 w-4' />
+                Add more resources
+              </Button>
+            </>
+          )}
+        </div>
+
+        <div className='flex items-center justify-between pt-4'>
+          {onBack ? (
+            <BoundlessButton
+              type='button'
+              variant='outline'
+              size='lg'
+              onClick={onBack}
+              disabled={isLoading}
+            >
+              <ArrowLeft className='mr-2 h-4 w-4' />
+              Back
+            </BoundlessButton>
+          ) : (
+            <span />
+          )}
+          <BoundlessButton
+            type='submit'
+            size='lg'
+            disabled={isLoading}
+            className='min-w-32'
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                Saving...
+              </>
+            ) : hasResources ? (
+              'Continue'
+            ) : (
+              'Skip for now'
+            )}
+          </BoundlessButton>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/components/organization/bounties/new/tabs/ReviewTab.tsx
+++ b/components/organization/bounties/new/tabs/ReviewTab.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { toast } from 'sonner';
-import { AlertTriangle, CheckCircle2, Loader2, Pencil } from 'lucide-react';
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CheckCircle2,
+  Loader2,
+  Pencil,
+} from 'lucide-react';
 
 import { BoundlessButton } from '@/components/buttons';
 import {
@@ -11,7 +17,11 @@ import {
 } from '@/lib/utils/bounty-escrow';
 import type { BountyFormData, StepKey } from '../constants';
 import { computeBountyModeLabel } from './schemas/modeSchema';
-import { scopeSchema } from './schemas/scopeSchema';
+import {
+  CATEGORY_LABELS,
+  CATEGORY_REPUTATION_BASELINE,
+  scopeSchema,
+} from './schemas/scopeSchema';
 import { modeSchema } from './schemas/modeSchema';
 import { makeSubmissionModelSchema } from './schemas/submissionModelSchema';
 import { makeRewardSchema } from './schemas/rewardSchema';
@@ -19,6 +29,7 @@ import { makeRewardSchema } from './schemas/rewardSchema';
 interface ReviewTabProps {
   allData: BountyFormData;
   onEdit?: (step: StepKey) => void;
+  onBack?: () => void;
   onPublish?: () => Promise<void> | void;
   onSaveDraft?: () => Promise<void>;
   isLoading?: boolean;
@@ -58,7 +69,10 @@ function validateAll(data: BountyFormData): {
       modeOk && data.mode
         ? makeSubmissionModelSchema(
             data.mode.entryType,
-            data.mode.claimType
+            data.mode.claimType,
+            data.scope?.category
+              ? CATEGORY_REPUTATION_BASELINE[data.scope.category]
+              : 0
           ).safeParse(data.submission).success
         : false,
   });
@@ -125,6 +139,7 @@ function SummaryCard({
 export default function ReviewTab({
   allData,
   onEdit,
+  onBack,
   onPublish,
   onSaveDraft,
   isLoading = false,
@@ -200,6 +215,15 @@ export default function ReviewTab({
       <SummaryCard title='Scope' step='scope' onEdit={onEdit}>
         <Row label='Title' value={allData.scope?.title} />
         <Row label='Description' value={allData.scope?.description} />
+        <Row
+          label='Category'
+          value={
+            allData.scope?.category
+              ? CATEGORY_LABELS[allData.scope.category]
+              : undefined
+          }
+        />
+        <Row label='Country' value={allData.scope?.country} />
         <Row label='GitHub issue' value={allData.scope?.githubIssueUrl} />
       </SummaryCard>
 
@@ -260,35 +284,63 @@ export default function ReviewTab({
         </div>
       </SummaryCard>
 
+      {(allData.resources?.resources?.length ?? 0) > 0 && (
+        <SummaryCard title='Resources' step='resources' onEdit={onEdit}>
+          {allData.resources?.resources?.map((r, i) => (
+            <Row
+              key={r.id ?? i}
+              label={r.description || r.file?.name || `Resource ${i + 1}`}
+              value={r.link || r.file?.name || '—'}
+            />
+          ))}
+        </SummaryCard>
+      )}
+
       {/* Publish CTA — disabled until every section is valid. */}
-      <div className='flex justify-end gap-3 pt-2'>
-        {onSaveDraft && (
+      <div className='flex items-center justify-between gap-3 pt-2'>
+        {onBack ? (
           <BoundlessButton
             type='button'
             variant='outline'
             size='lg'
-            onClick={handleSaveDraft}
-            disabled={isSavingDraft}
+            onClick={onBack}
+            disabled={isLoading || isSavingDraft}
           >
-            {isSavingDraft ? 'Saving...' : 'Save draft'}
+            <ArrowLeft className='mr-2 h-4 w-4' />
+            Back
           </BoundlessButton>
+        ) : (
+          <span />
         )}
-        <BoundlessButton
-          type='button'
-          size='lg'
-          className='min-w-32'
-          onClick={handlePublish}
-          disabled={!isValid || isLoading || !onPublish}
-        >
-          {isLoading ? (
-            <>
-              <Loader2 className='mr-2 h-4 w-4 animate-spin' />
-              Publishing...
-            </>
-          ) : (
-            'Publish'
+        <div className='flex gap-3'>
+          {onSaveDraft && (
+            <BoundlessButton
+              type='button'
+              variant='outline'
+              size='lg'
+              onClick={handleSaveDraft}
+              disabled={isSavingDraft}
+            >
+              {isSavingDraft ? 'Saving...' : 'Save draft'}
+            </BoundlessButton>
           )}
-        </BoundlessButton>
+          <BoundlessButton
+            type='button'
+            size='lg'
+            className='min-w-32'
+            onClick={handlePublish}
+            disabled={!isValid || isLoading || !onPublish}
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                Publishing...
+              </>
+            ) : (
+              'Publish'
+            )}
+          </BoundlessButton>
+        </div>
       </div>
     </div>
   );

--- a/components/organization/bounties/new/tabs/RewardTab.tsx
+++ b/components/organization/bounties/new/tabs/RewardTab.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useForm, useFieldArray } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { toast } from 'sonner';
-import { Loader2 } from 'lucide-react';
+import { ArrowLeft, Loader2 } from 'lucide-react';
 
 import { BoundlessButton } from '@/components/buttons';
 import {
@@ -14,6 +14,14 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { AssetIcon } from '@/components/wallet/AssetIcon';
 import {
   PLATFORM_FEE,
   getBountyPlatformFee,
@@ -27,10 +35,17 @@ interface RewardTabProps {
   /** The claim type + winner count chosen in ModeTab; drives the tier count. */
   mode?: { claimType: BountyClaimType; winnerCount?: number };
   onContinue?: () => void;
+  onBack?: () => void;
   onSave?: (data: RewardFormData) => Promise<void>;
   initialData?: Partial<RewardFormData>;
   isLoading?: boolean;
 }
+
+/** Supported reward currencies. Only USDC is live today; XLM is coming soon. */
+const REWARD_CURRENCIES = [
+  { code: 'USDC', label: 'USDC', disabled: false },
+  { code: 'XLM', label: 'XLM', disabled: true },
+] as const;
 
 const ordinal = (n: number): string => {
   const s = ['th', 'st', 'nd', 'rd'];
@@ -41,6 +56,7 @@ const ordinal = (n: number): string => {
 export default function RewardTab({
   mode,
   onContinue,
+  onBack,
   onSave,
   initialData,
   isLoading = false,
@@ -113,14 +129,35 @@ export default function RewardTab({
               <FormLabel className='text-sm font-medium text-white'>
                 Reward currency<span className='text-red-500'>*</span>
               </FormLabel>
-              <FormControl>
-                <Input
-                  placeholder='USDC'
-                  className='h-10 rounded-lg border-zinc-800 bg-zinc-900/50 text-white'
-                  {...field}
-                  value={field.value ?? ''}
-                />
-              </FormControl>
+              <Select
+                value={field.value ?? 'USDC'}
+                onValueChange={field.onChange}
+              >
+                <FormControl>
+                  <SelectTrigger className='h-10 rounded-lg border-zinc-800 bg-zinc-900/50 text-white'>
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent className='border-zinc-800 bg-zinc-950 text-white'>
+                  {REWARD_CURRENCIES.map(c => (
+                    <SelectItem
+                      key={c.code}
+                      value={c.code}
+                      disabled={c.disabled}
+                    >
+                      <span className='flex items-center gap-2'>
+                        <AssetIcon assetCode={c.code} size={18} />
+                        {c.label}
+                        {c.disabled && (
+                          <span className='text-xs text-zinc-500'>
+                            (coming soon)
+                          </span>
+                        )}
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               <FormMessage className='text-xs text-red-500' />
             </FormItem>
           )}
@@ -204,7 +241,21 @@ export default function RewardTab({
           </div>
         </div>
 
-        <div className='flex justify-end pt-4'>
+        <div className='flex items-center justify-between pt-4'>
+          {onBack ? (
+            <BoundlessButton
+              type='button'
+              variant='outline'
+              size='lg'
+              onClick={onBack}
+              disabled={isLoading}
+            >
+              <ArrowLeft className='mr-2 h-4 w-4' />
+              Back
+            </BoundlessButton>
+          ) : (
+            <span />
+          )}
           <BoundlessButton
             type='submit'
             size='lg'

--- a/components/organization/bounties/new/tabs/ScopeTab.tsx
+++ b/components/organization/bounties/new/tabs/ScopeTab.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import dynamic from 'next/dynamic';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { toast } from 'sonner';
-import { Loader2 } from 'lucide-react';
+import { Check, ChevronsUpDown, Loader2 } from 'lucide-react';
 
 import { BoundlessButton } from '@/components/buttons';
 import {
@@ -14,8 +15,41 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { scopeSchema, type ScopeFormData } from './schemas/scopeSchema';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+import { loadCountries, type Country } from '@/lib/country-utils';
+import {
+  BOUNTY_CATEGORIES,
+  CATEGORY_LABELS,
+  scopeSchema,
+  type BountyCategory,
+  type ScopeFormData,
+} from './schemas/scopeSchema';
+
+// Markdown editor for the description, matching the hackathon Info step.
+const MDEditor = dynamic(
+  () => import('@uiw/react-md-editor').then(mod => mod.default),
+  {
+    ssr: false,
+    loading: () => (
+      <div className='flex h-32 w-full items-center justify-center rounded-xl border border-zinc-800 bg-zinc-900/30'>
+        <Loader2 className='h-6 w-6 animate-spin text-zinc-500' />
+      </div>
+    ),
+  }
+);
 
 interface ScopeTabProps {
   onContinue?: () => void;
@@ -24,12 +58,112 @@ interface ScopeTabProps {
   isLoading?: boolean;
 }
 
-const defaultValues: ScopeFormData = {
+const defaultValues: Partial<ScopeFormData> = {
   title: '',
   description: '',
+  country: null,
   githubIssueUrl: null,
-  githubIssueNumber: null,
 };
+
+/** Searchable country dropdown; stores the country name. */
+/** ISO2 country code -> emoji flag (regional indicator symbols). */
+function flagEmoji(iso2: string): string {
+  if (!iso2 || iso2.length !== 2) return '';
+  const A = 0x1f1e6;
+  const code = iso2.toUpperCase();
+  return String.fromCodePoint(
+    A + code.charCodeAt(0) - 65,
+    A + code.charCodeAt(1) - 65
+  );
+}
+
+function CountryCombobox({
+  value,
+  onChange,
+}: {
+  value: string | null | undefined;
+  onChange: (value: string | null) => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const [countries, setCountries] = React.useState<Country[]>([]);
+  const selectedCountry = countries.find(c => c.name === value);
+
+  React.useEffect(() => {
+    let active = true;
+    loadCountries()
+      .then(list => {
+        if (active) setCountries(list);
+      })
+      .catch(() => {
+        /* non-fatal: the field just shows no options */
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type='button'
+          role='combobox'
+          aria-expanded={open}
+          className='flex h-10 w-full items-center justify-between rounded-lg border border-zinc-800 bg-zinc-900/50 px-3 text-sm text-white'
+        >
+          <span
+            className={cn('flex items-center gap-2', !value && 'text-zinc-500')}
+          >
+            {selectedCountry && (
+              <span aria-hidden className='text-base leading-none'>
+                {flagEmoji(selectedCountry.iso2)}
+              </span>
+            )}
+            {value || 'Select country'}
+          </span>
+          <ChevronsUpDown className='h-4 w-4 text-zinc-500' />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className='w-[--radix-popover-trigger-width] border-zinc-800 bg-zinc-950 p-0'>
+        <Command className='bg-zinc-950'>
+          <CommandInput
+            placeholder='Search country...'
+            className='text-white'
+          />
+          <CommandList>
+            <CommandEmpty className='py-4 text-center text-sm text-zinc-500'>
+              No country found.
+            </CommandEmpty>
+            <CommandGroup>
+              {countries.map(country => (
+                <CommandItem
+                  key={country.iso2 || country.name}
+                  value={country.name}
+                  onSelect={() => {
+                    onChange(country.name);
+                    setOpen(false);
+                  }}
+                  className='text-white'
+                >
+                  <Check
+                    className={cn(
+                      'mr-2 h-4 w-4',
+                      value === country.name ? 'opacity-100' : 'opacity-0'
+                    )}
+                  />
+                  <span aria-hidden className='mr-2 text-base leading-none'>
+                    {flagEmoji(country.iso2)}
+                  </span>
+                  {country.name}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
 
 export default function ScopeTab({
   onContinue,
@@ -46,6 +180,9 @@ export default function ScopeTab({
     if (initialData) form.reset({ ...defaultValues, ...initialData });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialData]);
+
+  const category = form.watch('category');
+  const isDevelopment = category === 'DEVELOPMENT';
 
   const onSubmit = async (data: ScopeFormData) => {
     try {
@@ -95,35 +232,92 @@ export default function ScopeTab({
                 Description<span className='text-red-500'>*</span>
               </FormLabel>
               <FormControl>
-                <Textarea
-                  rows={6}
-                  placeholder='What needs to be built, and what does done look like?'
-                  className='rounded-lg border-zinc-800 bg-zinc-900/50 text-white'
-                  {...field}
-                  value={field.value ?? ''}
-                />
+                <div className='overflow-hidden rounded-xl border border-zinc-800'>
+                  <MDEditor
+                    value={field.value ?? ''}
+                    onChange={value => field.onChange(value || '')}
+                    height={300}
+                    data-color-mode='dark'
+                    preview='edit'
+                    hideToolbar={false}
+                    visibleDragbar={true}
+                    textareaProps={{
+                      placeholder:
+                        'What needs to be built, and what does done look like?\n\nUse markdown for formatting: headings, lists, links, and more.',
+                      style: {
+                        fontSize: 14,
+                        lineHeight: 1.6,
+                        color: '#ffffff',
+                        backgroundColor: '#18181b',
+                        fontFamily: 'inherit',
+                        border: 'none',
+                      },
+                    }}
+                    style={{
+                      backgroundColor: '#18181b',
+                      color: '#ffffff',
+                      border: 'none',
+                    }}
+                  />
+                </div>
               </FormControl>
               <FormMessage className='text-xs text-red-500' />
             </FormItem>
           )}
         />
 
+        {/* Category */}
+        <FormField
+          control={form.control}
+          name='category'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className='text-sm font-medium text-white'>
+                Category<span className='text-red-500'>*</span>
+              </FormLabel>
+              <p className='text-sm text-zinc-500'>
+                What kind of work is this bounty for?
+              </p>
+              <div className='mt-2 flex flex-wrap gap-1.5'>
+                {BOUNTY_CATEGORIES.map(c => {
+                  const on = field.value === c;
+                  return (
+                    <button
+                      key={c}
+                      type='button'
+                      onClick={() => field.onChange(c as BountyCategory)}
+                      className={cn(
+                        'flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs transition-colors',
+                        on
+                          ? 'border-primary bg-primary/15 text-primary'
+                          : 'border-zinc-700 text-zinc-400 hover:border-zinc-600 hover:text-zinc-200'
+                      )}
+                    >
+                      {on && <Check className='h-3 w-3' strokeWidth={3} />}
+                      {CATEGORY_LABELS[c]}
+                    </button>
+                  );
+                })}
+              </div>
+              <FormMessage className='text-xs text-red-500' />
+            </FormItem>
+          )}
+        />
+
         <div className='grid gap-6 sm:grid-cols-2'>
+          {/* Country */}
           <FormField
             control={form.control}
-            name='githubIssueUrl'
+            name='country'
             render={({ field }) => (
               <FormItem>
                 <FormLabel className='text-sm font-medium text-white'>
-                  GitHub issue URL{' '}
-                  <span className='text-zinc-500'>(optional)</span>
+                  Country <span className='text-zinc-500'>(optional)</span>
                 </FormLabel>
                 <FormControl>
-                  <Input
-                    placeholder='https://github.com/org/repo/issues/123'
-                    className='h-10 rounded-lg border-zinc-800 bg-zinc-900/50 text-white'
-                    value={field.value ?? ''}
-                    onChange={e => field.onChange(e.target.value || null)}
+                  <CountryCombobox
+                    value={field.value}
+                    onChange={field.onChange}
                   />
                 </FormControl>
                 <FormMessage className='text-xs text-red-500' />
@@ -131,32 +325,29 @@ export default function ScopeTab({
             )}
           />
 
-          <FormField
-            control={form.control}
-            name='githubIssueNumber'
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel className='text-sm font-medium text-white'>
-                  GitHub issue number{' '}
-                  <span className='text-zinc-500'>(optional)</span>
-                </FormLabel>
-                <FormControl>
-                  <Input
-                    type='number'
-                    min={1}
-                    placeholder='123'
-                    className='h-10 rounded-lg border-zinc-800 bg-zinc-900/50 text-white'
-                    value={field.value ?? ''}
-                    onChange={e => {
-                      const n = parseInt(e.target.value, 10);
-                      field.onChange(Number.isNaN(n) ? null : n);
-                    }}
-                  />
-                </FormControl>
-                <FormMessage className='text-xs text-red-500' />
-              </FormItem>
-            )}
-          />
+          {/* GitHub issue URL — only for development bounties, where it's required */}
+          {isDevelopment && (
+            <FormField
+              control={form.control}
+              name='githubIssueUrl'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className='text-sm font-medium text-white'>
+                    GitHub issue URL<span className='text-red-500'>*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder='https://github.com/org/repo/issues/123'
+                      className='h-10 rounded-lg border-zinc-800 bg-zinc-900/50 text-white'
+                      value={field.value ?? ''}
+                      onChange={e => field.onChange(e.target.value || null)}
+                    />
+                  </FormControl>
+                  <FormMessage className='text-xs text-red-500' />
+                </FormItem>
+              )}
+            />
+          )}
         </div>
 
         <div className='flex justify-end pt-4'>

--- a/components/organization/bounties/new/tabs/SubmissionModelTab.tsx
+++ b/components/organization/bounties/new/tabs/SubmissionModelTab.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { toast } from 'sonner';
-import { EyeOff, Lock, Loader2 } from 'lucide-react';
+import { ArrowLeft, EyeOff, Lock, Loader2 } from 'lucide-react';
 
 import { BoundlessButton } from '@/components/buttons';
 import {
@@ -23,11 +23,19 @@ import {
   makeSubmissionModelSchema,
   SubmissionModelFormData,
 } from './schemas/submissionModelSchema';
+import {
+  CATEGORY_LABELS,
+  CATEGORY_REPUTATION_BASELINE,
+  type BountyCategory,
+} from './schemas/scopeSchema';
 
 interface SubmissionModelTabProps {
   /** The mode chosen in ModeTab; drives which fields show and how they validate. */
   mode?: ModeSelection;
+  /** The category chosen in ScopeTab; sets the floor for the reputation minimum. */
+  category?: BountyCategory;
   onContinue?: () => void;
+  onBack?: () => void;
   onSave?: (data: SubmissionModelFormData) => Promise<void>;
   initialData?: Partial<SubmissionModelFormData>;
   isLoading?: boolean;
@@ -48,7 +56,9 @@ const toNumberOrNull = (raw: string): number | null => {
 
 export default function SubmissionModelTab({
   mode,
+  category,
   onContinue,
+  onBack,
   onSave,
   initialData,
   isLoading = false,
@@ -64,16 +74,22 @@ export default function SubmissionModelTab({
     effectiveMode.claimType
   );
 
+  // The category sets the lowest reputation the organizer can require; they may
+  // raise it but not drop below it.
+  const reputationFloor = category ? CATEGORY_REPUTATION_BASELINE[category] : 0;
+
   const form = useForm<SubmissionModelFormData>({
     resolver: zodResolver(
       makeSubmissionModelSchema(
         effectiveMode.entryType,
-        effectiveMode.claimType
+        effectiveMode.claimType,
+        reputationFloor
       )
     ),
     defaultValues: {
       submissionDeadline: '',
-      reputationMinimum: null,
+      reputationMinimum:
+        fields.reputationMinimum === 'hidden' ? null : reputationFloor || null,
       applicationWindowCloseAt: null,
       maxApplicants: null,
       shortlistSize: null,
@@ -89,6 +105,17 @@ export default function SubmissionModelTab({
     form.setValue('submissionVisibility', fields.submissionVisibility);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fields.submissionVisibility]);
+
+  // Default the reputation minimum to the category floor, and bump it up if a
+  // saved/typed value sits below the floor (e.g. after switching category).
+  React.useEffect(() => {
+    if (fields.reputationMinimum === 'hidden') return;
+    const current = form.getValues('reputationMinimum');
+    if (current == null || current < reputationFloor) {
+      form.setValue('reputationMinimum', reputationFloor || null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reputationFloor, fields.reputationMinimum]);
 
   if (!mode) {
     return (
@@ -183,7 +210,7 @@ export default function SubmissionModelTab({
                 <FormControl>
                   <Input
                     type='number'
-                    min={0}
+                    min={reputationFloor}
                     className='h-10 rounded-lg border-zinc-800 bg-zinc-900/50 text-white'
                     value={field.value ?? ''}
                     onChange={e =>
@@ -191,6 +218,12 @@ export default function SubmissionModelTab({
                     }
                   />
                 </FormControl>
+                {reputationFloor > 0 && category && (
+                  <p className='text-xs text-zinc-500'>
+                    {CATEGORY_LABELS[category]} bounties start at{' '}
+                    {reputationFloor}. You can raise this, but not lower it.
+                  </p>
+                )}
                 <FormMessage className='text-xs text-red-500' />
               </FormItem>
             )}
@@ -311,7 +344,21 @@ export default function SubmissionModelTab({
           </p>
         </div>
 
-        <div className='flex justify-end pt-4'>
+        <div className='flex items-center justify-between pt-4'>
+          {onBack ? (
+            <BoundlessButton
+              type='button'
+              variant='outline'
+              size='lg'
+              onClick={onBack}
+              disabled={isLoading}
+            >
+              <ArrowLeft className='mr-2 h-4 w-4' />
+              Back
+            </BoundlessButton>
+          ) : (
+            <span />
+          )}
           <BoundlessButton
             type='submit'
             size='lg'

--- a/components/organization/bounties/new/tabs/schemas/resourcesSchema.ts
+++ b/components/organization/bounties/new/tabs/schemas/resourcesSchema.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+/**
+ * Resources step: optional links and/or uploaded files (PDF/DOC/PPT) the
+ * organizer shares with contributors. Mirrors the hackathon resources schema.
+ * Each row needs either a link or a file; the step itself is optional.
+ */
+export const resourceItemSchema = z
+  .object({
+    id: z.string(),
+    link: z.string().optional().or(z.literal('')),
+    description: z.string().trim().optional().or(z.literal('')),
+    file: z
+      .object({
+        url: z.string().url(),
+        name: z.string(),
+      })
+      .optional(),
+  })
+  .refine(data => (data.link && data.link.trim() !== '') || !!data.file, {
+    message: 'Either a link or a file must be provided',
+    path: ['link'],
+  })
+  .refine(
+    data => {
+      if (!data.link || data.link.trim() === '') return true;
+      try {
+        new URL(data.link);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { message: 'Please enter a valid URL', path: ['link'] }
+  );
+
+export const resourcesSchema = z.object({
+  resources: z.array(resourceItemSchema).default([]),
+});
+
+export type ResourceItem = z.infer<typeof resourceItemSchema>;
+export type ResourcesFormData = z.input<typeof resourcesSchema>;

--- a/components/organization/bounties/new/tabs/schemas/scopeSchema.ts
+++ b/components/organization/bounties/new/tabs/schemas/scopeSchema.ts
@@ -1,31 +1,74 @@
 import { z } from 'zod';
 
 /**
- * Scope step: the bounty's identity. Mirrors the backend BountyScopeSection
- * (title / description / optional GitHub issue / optional project + window).
- * The reward currency lives in the Reward step alongside the prize tiers it
- * denominates (that is the section the backend persists it under).
+ * Bounty disciplines (organizer-facing; off-chain). Mirrors the backend
+ * BountyCategory enum. `development` additionally requires a GitHub issue URL.
  */
-export const scopeSchema = z.object({
-  title: z
-    .string()
-    .trim()
-    .min(1, 'Title is required')
-    .max(200, 'Title must be 200 characters or fewer'),
-  description: z
-    .string()
-    .trim()
-    .min(1, 'Description is required')
-    .max(5000, 'Description must be 5000 characters or fewer'),
-  githubIssueUrl: z
-    .union([z.string().url('Enter a valid URL'), z.literal(''), z.null()])
-    .optional()
-    .transform(v => (v === '' ? null : v)),
-  githubIssueNumber: z
-    .union([z.number().int().positive(), z.null()])
-    .optional(),
-  projectId: z.union([z.string(), z.null()]).optional(),
-  bountyWindowId: z.union([z.string(), z.null()]).optional(),
-});
+export const BOUNTY_CATEGORIES = [
+  'DESIGN',
+  'DEVELOPMENT',
+  'CONTENT',
+  'GROWTH',
+  'COMMUNITY',
+] as const;
+export type BountyCategory = (typeof BOUNTY_CATEGORIES)[number];
+
+export const CATEGORY_LABELS: Record<BountyCategory, string> = {
+  DESIGN: 'Design',
+  DEVELOPMENT: 'Development',
+  CONTENT: 'Content',
+  GROWTH: 'Growth',
+  COMMUNITY: 'Community',
+};
+
+/**
+ * Baseline minimum reputation a claimant needs, per category. The organizer can
+ * raise this in the Submission step but not drop below it. Development is the
+ * highest bar (it carries the most risk of low-quality / AI-generated work).
+ */
+export const CATEGORY_REPUTATION_BASELINE: Record<BountyCategory, number> = {
+  DEVELOPMENT: 50,
+  DESIGN: 25,
+  GROWTH: 20,
+  CONTENT: 15,
+  COMMUNITY: 10,
+};
+
+/**
+ * Scope step: the bounty's identity. Mirrors the backend BountyScopeSection
+ * (title / description / category / country / optional GitHub issue + project).
+ * The reward currency lives in the Reward step. GitHub issue URL is required
+ * only for development bounties.
+ */
+export const scopeSchema = z
+  .object({
+    title: z
+      .string()
+      .trim()
+      .min(1, 'Title is required')
+      .max(200, 'Title must be 200 characters or fewer'),
+    description: z
+      .string()
+      .trim()
+      .min(1, 'Description is required')
+      .max(5000, 'Description must be 5000 characters or fewer'),
+    category: z.enum(BOUNTY_CATEGORIES),
+    country: z.union([z.string(), z.null()]).optional(),
+    githubIssueUrl: z
+      .union([z.string().url('Enter a valid URL'), z.literal(''), z.null()])
+      .optional()
+      .transform(v => (v === '' ? null : v)),
+    projectId: z.union([z.string(), z.null()]).optional(),
+    bountyWindowId: z.union([z.string(), z.null()]).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.category === 'DEVELOPMENT' && !data.githubIssueUrl) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['githubIssueUrl'],
+        message: 'A GitHub issue URL is required for development bounties',
+      });
+    }
+  });
 
 export type ScopeFormData = z.input<typeof scopeSchema>;

--- a/components/organization/bounties/new/tabs/schemas/submissionModelSchema.ts
+++ b/components/organization/bounties/new/tabs/schemas/submissionModelSchema.ts
@@ -38,21 +38,27 @@ const isSet = (v: unknown): boolean => v !== null && v !== undefined;
  */
 export function makeSubmissionModelSchema(
   entryType: BountyEntryType,
-  claimType: BountyClaimType
+  claimType: BountyClaimType,
+  reputationFloor = 0
 ) {
   const fields = getModeFields(entryType, claimType);
 
   return submissionModelBase.superRefine((data, ctx) => {
-    if (
-      fields.reputationMinimum === 'required' &&
-      !isSet(data.reputationMinimum)
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          'Reputation minimum is required for open single-claim bounties',
-        path: ['reputationMinimum'],
-      });
+    if (fields.reputationMinimum === 'required') {
+      if (!isSet(data.reputationMinimum)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'Reputation minimum is required for open single-claim bounties',
+          path: ['reputationMinimum'],
+        });
+      } else if ((data.reputationMinimum as number) < reputationFloor) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Minimum reputation for this category is ${reputationFloor}`,
+          path: ['reputationMinimum'],
+        });
+      }
     }
 
     if (

--- a/components/organization/hackathons/new/tabs/components/ResourceFileUpload.tsx
+++ b/components/organization/hackathons/new/tabs/components/ResourceFileUpload.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useId, useRef, useState } from 'react';
 import React from 'react';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
@@ -17,9 +17,17 @@ interface ResourceFileUploadProps {
   value?: { url: string; name: string };
   onChange: (file: { url: string; name: string } | undefined) => void;
   disabled?: boolean;
+  /** Cloudinary folder the upload lands in. */
+  folder?: string;
+  /** Tags applied to the uploaded asset. */
+  tags?: string[];
+  /** Accepted MIME types. Defaults to PDF / PowerPoint / Word. */
+  allowedMimeTypes?: string[];
+  /** Accepted file extensions (incl. leading dot). Defaults to PDF/PPT/DOC. */
+  allowedExtensions?: string[];
 }
 
-const ALLOWED_FILE_TYPES = [
+const DEFAULT_ALLOWED_MIME_TYPES = [
   'application/pdf',
   'application/vnd.ms-powerpoint',
   'application/vnd.openxmlformats-officedocument.presentationml.presentation',
@@ -27,7 +35,7 @@ const ALLOWED_FILE_TYPES = [
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
 ];
 
-const ALLOWED_EXTENSIONS = ['.pdf', '.ppt', '.pptx', '.doc', '.docx'];
+const DEFAULT_ALLOWED_EXTENSIONS = ['.pdf', '.ppt', '.pptx', '.doc', '.docx'];
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
@@ -42,6 +50,9 @@ const getFileIcon = (fileName: string) => {
   if (extension === 'doc' || extension === 'docx') {
     return <File className='h-5 w-5 text-blue-500' />;
   }
+  if (extension === 'md' || extension === 'markdown') {
+    return <FileText className='h-5 w-5 text-purple-400' />;
+  }
   return <FileText className='h-5 w-5 text-zinc-500' />;
 };
 
@@ -49,21 +60,32 @@ export default function ResourceFileUpload({
   value,
   onChange,
   disabled = false,
+  folder = 'boundless/hackathons/resources',
+  tags = ['hackathon', 'resource'],
+  allowedMimeTypes = DEFAULT_ALLOWED_MIME_TYPES,
+  allowedExtensions = DEFAULT_ALLOWED_EXTENSIONS,
 }: ResourceFileUploadProps) {
   const [isUploading, setIsUploading] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // Unique per instance so multiple resource rows don't share one input id
+  // (a duplicate id would make every label trigger the first row's input).
+  const inputId = useId();
+
+  // Human-readable list of accepted formats (e.g. "PDF, PPT, DOC, MD").
+  const acceptLabel = allowedExtensions
+    .map(ext => ext.replace('.', '').toUpperCase())
+    .join(', ');
 
   const validateFile = (file: File): boolean => {
-    // Check file type
+    // Check file type. Markdown often arrives with an empty or generic MIME
+    // type, so the extension check is the reliable signal.
     const isValidType =
-      ALLOWED_FILE_TYPES.includes(file.type) ||
-      ALLOWED_EXTENSIONS.some(ext => file.name.toLowerCase().endsWith(ext));
+      allowedMimeTypes.includes(file.type) ||
+      allowedExtensions.some(ext => file.name.toLowerCase().endsWith(ext));
 
     if (!isValidType) {
-      toast.error(
-        'Please upload a PDF, PowerPoint (.ppt, .pptx), or Word document (.doc, .docx)'
-      );
+      toast.error(`Please upload one of: ${acceptLabel}`);
       return false;
     }
 
@@ -89,8 +111,8 @@ export default function ResourceFileUpload({
     setIsUploading(true);
     try {
       const uploadResult = await uploadService.uploadSingle(file, {
-        folder: 'boundless/hackathons/resources',
-        tags: ['hackathon', 'resource'],
+        folder,
+        tags,
       });
 
       if (uploadResult.success) {
@@ -142,8 +164,8 @@ export default function ResourceFileUpload({
       setIsUploading(true);
       try {
         const uploadResult = await uploadService.uploadSingle(file, {
-          folder: 'boundless/hackathons/resources',
-          tags: ['hackathon', 'resource'],
+          folder,
+          tags,
         });
 
         if (uploadResult.success) {
@@ -174,9 +196,9 @@ export default function ResourceFileUpload({
       <input
         ref={fileInputRef}
         type='file'
-        accept='.pdf,.ppt,.pptx,.doc,.docx'
+        accept={allowedExtensions.join(',')}
         className='hidden'
-        id='resource-file-upload'
+        id={inputId}
         onChange={handleFileUpload}
         disabled={disabled || isUploading}
       />
@@ -203,7 +225,7 @@ export default function ResourceFileUpload({
         </div>
       ) : (
         <label
-          htmlFor='resource-file-upload'
+          htmlFor={inputId}
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
@@ -236,7 +258,7 @@ export default function ResourceFileUpload({
                     {isDragOver ? 'Drop file here' : 'Upload file'}
                   </p>
                   <p className='text-xs text-zinc-500'>
-                    PDF, PPT, PPTX, DOC, DOCX • Max 10MB
+                    {acceptLabel} • Max 10MB
                   </p>
                 </div>
               </>

--- a/features/bounties/api/core.ts
+++ b/features/bounties/api/core.ts
@@ -13,6 +13,7 @@ export interface OrganizationBountyListItem {
   rewardAmount?: number;
   rewardCurrency?: string;
   createdAt?: string;
+  _count?: { submissions?: number };
 }
 
 /** List an organization's bounties, newest first. */

--- a/features/bounties/types.ts
+++ b/features/bounties/types.ts
@@ -33,12 +33,13 @@ export type BountySubmissionVisibility = NonNullable<
   BountySubmissionSection['submissionVisibility']
 >;
 
-/** The four editable wizard sections, in order. */
+/** The editable wizard sections, in order. `resources` is optional. */
 export const DRAFT_SECTIONS = [
   'scope',
   'mode',
   'submission',
   'reward',
+  'resources',
 ] as const;
 export type DraftSection = (typeof DRAFT_SECTIONS)[number];
 

--- a/hooks/use-bounty-draft.ts
+++ b/hooks/use-bounty-draft.ts
@@ -31,11 +31,35 @@ export const transformBountyFromApi = (draft: BountyDraft): BountyFormData => {
   const mode = draft.data?.mode;
   const submission = draft.data?.submission;
   const reward = draft.data?.reward;
+  // `resources` is read via a cast until `npm run codegen` runs against the
+  // updated backend (the generated BountyDraftData picks it up then).
+  const resources = (
+    draft.data as { resources?: BountyFormData['resources'] } | undefined
+  )?.resources;
 
   const winnerCount = reward?.prizeTiers?.length || 1;
 
+  // category/country are read via a cast until `npm run codegen` runs against
+  // the updated backend (the generated BountyScopeSection picks them up then).
+  const scopeExtra = scope as
+    | {
+        category?: NonNullable<BountyFormData['scope']>['category'];
+        country?: string | null;
+      }
+    | undefined;
+
   return {
-    scope: scope ? { ...scope } : undefined,
+    scope: scope
+      ? ({
+          title: scope.title,
+          description: scope.description,
+          category: scopeExtra?.category ?? undefined,
+          country: scopeExtra?.country ?? null,
+          githubIssueUrl: scope.githubIssueUrl ?? null,
+          projectId: scope.projectId ?? null,
+          bountyWindowId: scope.bountyWindowId ?? null,
+        } as NonNullable<BountyFormData['scope']>)
+      : undefined,
     mode:
       mode?.entryType && mode?.claimType
         ? {
@@ -60,6 +84,10 @@ export const transformBountyFromApi = (draft: BountyDraft): BountyFormData => {
         }
       : undefined,
     reward: reward ? { ...reward } : undefined,
+    resources:
+      resources && Array.isArray(resources.resources)
+        ? { resources: resources.resources }
+        : undefined,
   };
 };
 
@@ -146,6 +174,31 @@ export const useBountyDraft = ({
   };
 
   /**
+   * Persist every provided section in a single PATCH and replace the local
+   * snapshot. Used by the dev-only "Fill with mock" tool to populate the whole
+   * wizard at once.
+   */
+  const saveAllSections = async (data: BountyFormData) => {
+    if (!organizationId) {
+      toast.error('Organization ID is required');
+      return;
+    }
+    const id = await ensureDraftId();
+    const body: Record<string, unknown> = {};
+    for (const section of DRAFT_SECTIONS) {
+      const value = data[section];
+      if (value !== undefined) body[section] = value;
+    }
+    if (Object.keys(body).length > 0) {
+      await updateDraft.mutateAsync({
+        id,
+        body: body as UpdateBountyDraftBody,
+      });
+    }
+    setStepData(data);
+  };
+
+  /**
    * Persist one section. `data` is the section's form snapshot; extra UI-only
    * fields (e.g. mode.winnerCount) are stripped by the backend Zod section
    * schema, so we can send the form value as-is.
@@ -179,5 +232,6 @@ export const useBountyDraft = ({
     isSavingDraft: createDraft.isPending || updateDraft.isPending,
     saveDraft,
     saveStep,
+    saveAllSections,
   };
 };

--- a/hooks/use-bounty-steps.ts
+++ b/hooks/use-bounty-steps.ts
@@ -51,6 +51,7 @@ export const useBountySteps = (
     mode: { status: 'pending', isCompleted: false },
     submission: { status: 'pending', isCompleted: false },
     reward: { status: 'pending', isCompleted: false },
+    resources: { status: 'pending', isCompleted: false },
     review: { status: 'pending', isCompleted: false },
   });
 


### PR DESCRIPTION
## What

Frontend enhancements to the bounty Configure wizard and a redesigned organization bounty list page.

### Wizard
- **Resources step (optional):** new step for organizer-supplied links and uploaded files (PDF/DOC/PPT/MD), mirroring the hackathon resources tab. Never blocks publish. Reuses a now-configurable `ResourceFileUpload` (folder/tags/accepted-types props; unique input id per row).
- **Reward currency:** dropdown of **USDC** (default) / **XLM** (disabled, coming soon) with real token logos, replacing the free-text field.
- **Reputation:** per-category minimum floor (development highest); the organizer can raise it but not drop below the category baseline.
- **Navigation:** a **Back** button on every step after the first.
- **Scope:** category chips, searchable country dropdown with flags, and a markdown description; GitHub issue URL required only for development bounties.
- **Publish:** redirects to the organizer's bounty list once publish finalizes on-chain (no longer lingers on the read-only review).
- **Dev-only "Fill with mock"** button (`NODE_ENV === 'development'`) to populate every section at once.

### List page
- Rebuilt the org bounty list in the hackathon style: sticky header with stats, Published/Drafts tabs, search + sort, banner-less reward-focused card grid (draft cards show a progress bar + resume link).
- **Delete a draft now requires confirmation** (`DeleteBountyDraftDialog`) instead of deleting on the first click.

## Notes

- Backend counterpart for the resources persistence is boundlessfi/boundless-nestjs#329 (targets `v2`). Resources are read via a cast here until codegen runs against that backend; the generated `schema.d.ts` is intentionally **not** regenerated in this PR to avoid a large unrelated diff.
- No smart-contract surface touched; the new fields are off-chain.

## Testing

- `tsc`, `eslint`, `prettier`, and the production build all pass (pre-commit hooks).