### PR TITLE
feat(bounty): bounty detail page (/bounties/[id])

### DIFF
--- a/app/(landing)/bounties/[id]/page.tsx
+++ b/app/(landing)/bounties/[id]/page.tsx
@@ -1,0 +1,22 @@
+import { Metadata } from 'next';
+
+import { generatePageMetadata } from '@/lib/metadata';
+import BountyDetail from '@/components/bounties/detail/BountyDetail';
+
+export const metadata: Metadata = generatePageMetadata('bounties');
+
+interface BountyDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function BountyDetailPageRoute({
+  params,
+}: BountyDetailPageProps) {
+  const { id } = await params;
+
+  return (
+    <div className='relative mx-auto min-h-screen max-w-[1440px] px-5 py-8 md:px-[50px] lg:px-[100px]'>
+      <BountyDetail id={id} />
+    </div>
+  );
+}

--- a/app/(landing)/bounties/page.tsx
+++ b/app/(landing)/bounties/page.tsx
@@ -1,16 +1,14 @@
-import { redirect } from 'next/navigation';
 import { Metadata } from 'next';
+
 import { generatePageMetadata } from '@/lib/metadata';
+import BountiesPage from '@/components/bounties/marketplace/BountiesPage';
 
-export const metadata: Metadata = generatePageMetadata('grants');
+export const metadata: Metadata = generatePageMetadata('bounties');
 
-const GrantPage = () => {
-  redirect('/coming-soon');
+export default function BountiesPageRoute() {
   return (
-    <div className='mx-auto mt-10 max-w-[1440px] px-5 py-5 text-center text-4xl font-bold text-white md:px-[50px] lg:px-[100px]'>
-      Bounties Page
+    <div className='relative mx-auto min-h-screen max-w-[1440px] px-5 py-8 md:px-[50px] lg:px-[100px]'>
+      <BountiesPage />
     </div>
   );
-};
-
-export default GrantPage;
+}

--- a/components/bounties/detail/BountyDetail.tsx
+++ b/components/bounties/detail/BountyDetail.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import React from 'react';
+import dynamic from 'next/dynamic';
+import Link from 'next/link';
+import {
+  ArrowLeft,
+  Award,
+  Calendar,
+  Loader2,
+  Target,
+  Users,
+} from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import EmptyState from '@/components/EmptyState';
+import { computeBountyModeLabel } from '@/components/organization/bounties/new/tabs/schemas/modeSchema';
+import { useBounty, useMyBountyApplication } from '@/features/bounties';
+import { BountyEntryCta } from './BountyEntryCta';
+
+// Markdown renderer (matches the wizard's editor package).
+const Markdown = dynamic(
+  () => import('@uiw/react-md-editor').then(mod => mod.default.Markdown),
+  { ssr: false }
+);
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+const ordinal = (n: number): string => {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  return `${n}${s[(v - 20) % 10] ?? s[v] ?? s[0]}`;
+};
+
+export default function BountyDetail({ id }: { id: string }) {
+  const { data: bounty, isLoading, error } = useBounty(id);
+  const { data: myApplication } = useMyBountyApplication(id);
+
+  if (isLoading) {
+    return (
+      <div className='flex min-h-[50vh] items-center justify-center'>
+        <Loader2 className='h-6 w-6 animate-spin text-zinc-500' />
+      </div>
+    );
+  }
+
+  if (error || !bounty) {
+    return (
+      <div className='py-20'>
+        <EmptyState
+          title='Bounty not found'
+          description='This bounty may have been removed or is not public.'
+          type='compact'
+        />
+        <div className='mt-4 text-center'>
+          <Link
+            href='/bounties'
+            className='text-primary text-sm hover:underline'
+          >
+            Back to bounties
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const modeLabel =
+    bounty.entryType && bounty.claimType
+      ? computeBountyModeLabel(bounty.entryType, bounty.claimType)
+      : 'Bounty';
+  const currency = bounty.rewardCurrency;
+
+  return (
+    <div>
+      <Link
+        href='/bounties'
+        className='mb-6 inline-flex items-center gap-1.5 text-sm text-zinc-400 transition-colors hover:text-white'
+      >
+        <ArrowLeft className='h-4 w-4' />
+        Back to bounties
+      </Link>
+
+      <div className='grid gap-8 lg:grid-cols-[1fr_360px]'>
+        {/* Main */}
+        <div className='min-w-0'>
+          <div className='mb-4 flex flex-wrap items-center gap-2'>
+            <Badge
+              variant='outline'
+              className='rounded-full border-zinc-700 bg-zinc-800/60 px-3 py-1 text-xs font-medium text-zinc-200'
+            >
+              {modeLabel}
+            </Badge>
+            <Badge
+              variant='outline'
+              className='rounded-full border-zinc-700 bg-zinc-800/60 px-3 py-1 text-xs font-medium text-zinc-300 capitalize'
+            >
+              {bounty.status.replace(/_/g, ' ')}
+            </Badge>
+          </div>
+
+          <h1 className='text-2xl font-bold tracking-tight text-white sm:text-3xl'>
+            {bounty.title}
+          </h1>
+          <p className='mt-2 text-sm text-zinc-400'>
+            by <span className='text-zinc-200'>{bounty.organization.name}</span>
+          </p>
+
+          {/* Description (markdown) */}
+          <div className='boundless-markdown mt-8' data-color-mode='dark'>
+            <Markdown
+              source={bounty.description}
+              style={{ background: 'transparent', color: '#e4e4e7' }}
+            />
+          </div>
+
+          {/* Prize tiers */}
+          {bounty.prizeTiers.length > 0 && (
+            <div className='mt-10'>
+              <h2 className='mb-3 flex items-center gap-2 text-lg font-semibold text-white'>
+                <Award className='text-primary h-5 w-5' />
+                Prize tiers
+              </h2>
+              <div className='space-y-2'>
+                {bounty.prizeTiers
+                  .slice()
+                  .sort((a, b) => a.position - b.position)
+                  .map(tier => (
+                    <div
+                      key={tier.position}
+                      className='flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-900/30 px-4 py-3'
+                    >
+                      <span className='text-sm font-medium text-zinc-300'>
+                        {ordinal(tier.position)} place
+                      </span>
+                      <span className='text-primary text-sm font-semibold'>
+                        {Number(tier.amount).toLocaleString()} {currency}
+                      </span>
+                    </div>
+                  ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Sidebar */}
+        <aside className='space-y-4 lg:sticky lg:top-6 lg:self-start'>
+          {/* Reward */}
+          <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5'>
+            <div className='flex items-center gap-3'>
+              <div className='bg-primary/10 flex h-11 w-11 items-center justify-center rounded-xl'>
+                <Target className='text-primary h-5 w-5' />
+              </div>
+              <div>
+                <p className='text-primary text-xl font-bold'>
+                  {bounty.rewardAmount > 0
+                    ? `${bounty.rewardAmount.toLocaleString()} ${currency}`
+                    : 'No reward set'}
+                </p>
+                <p className='text-xs text-zinc-500'>total reward pool</p>
+              </div>
+            </div>
+
+            {/* Eligibility / mode facts */}
+            <dl className='mt-4 space-y-2 border-t border-zinc-800 pt-4 text-sm'>
+              {bounty.entryType === 'OPEN' &&
+                bounty.claimType === 'SINGLE_CLAIM' &&
+                bounty.reputationMinimum != null && (
+                  <Row
+                    label='Minimum reputation'
+                    value={String(bounty.reputationMinimum)}
+                  />
+                )}
+              {bounty.applicationWindowCloseAt && (
+                <Row
+                  icon={<Calendar className='h-3.5 w-3.5' />}
+                  label='Applications close'
+                  value={formatDate(bounty.applicationWindowCloseAt)}
+                />
+              )}
+              {bounty.maxApplicants != null && (
+                <Row
+                  icon={<Users className='h-3.5 w-3.5' />}
+                  label='Max applicants'
+                  value={String(bounty.maxApplicants)}
+                />
+              )}
+              {bounty.shortlistSize != null && (
+                <Row
+                  label='Shortlist size'
+                  value={String(bounty.shortlistSize)}
+                />
+              )}
+            </dl>
+          </div>
+
+          {/* Mode-aware CTA + caller status */}
+          <BountyEntryCta
+            bounty={bounty}
+            myApplication={myApplication ?? null}
+          />
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function Row({
+  label,
+  value,
+  icon,
+}: {
+  label: string;
+  value: string;
+  icon?: React.ReactNode;
+}) {
+  return (
+    <div className='flex items-center justify-between gap-3'>
+      <dt className='flex items-center gap-1.5 text-zinc-400'>
+        {icon}
+        {label}
+      </dt>
+      <dd className='text-right font-medium text-white'>{value}</dd>
+    </div>
+  );
+}

--- a/components/bounties/detail/BountyEntryCta.tsx
+++ b/components/bounties/detail/BountyEntryCta.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { toast } from 'sonner';
+import { CheckCircle2, Lock } from 'lucide-react';
+
+import { BoundlessButton } from '@/components/buttons';
+import { Badge } from '@/components/ui/badge';
+import type { BountyPublic, MyBountyApplication } from '@/features/bounties';
+
+/** Statuses where a bounty still accepts new entries. */
+const ACCEPTING_STATUSES = new Set([
+  'open',
+  'open_for_applications',
+  'upcoming',
+]);
+
+type EntryKind = 'claim' | 'join' | 'apply' | 'view';
+
+function entryKind(b: BountyPublic): { kind: EntryKind; label: string } {
+  const open = b.entryType === 'OPEN';
+  const application =
+    b.entryType === 'APPLICATION_LIGHT' || b.entryType === 'APPLICATION_FULL';
+  if (open && b.claimType === 'SINGLE_CLAIM')
+    return { kind: 'claim', label: 'Claim this bounty' };
+  if (open && b.claimType === 'COMPETITION')
+    return { kind: 'join', label: 'Join competition' };
+  if (application) return { kind: 'apply', label: 'Apply' };
+  return { kind: 'view', label: 'View' };
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  SUBMITTED: 'Application submitted',
+  SHORTLISTED: 'Shortlisted',
+  SELECTED: 'Selected',
+  DECLINED: 'Not selected',
+  WITHDRAWN: 'Withdrawn',
+};
+
+const STATUS_CLASS: Record<string, string> = {
+  SUBMITTED: 'border-blue-500/30 bg-blue-500/10 text-blue-400',
+  SHORTLISTED: 'border-amber-500/30 bg-amber-500/10 text-amber-400',
+  SELECTED: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400',
+  DECLINED: 'border-red-500/30 bg-red-500/10 text-red-400',
+  WITHDRAWN: 'border-zinc-700 bg-zinc-800/60 text-zinc-300',
+};
+
+export function BountyEntryCta({
+  bounty,
+  myApplication,
+}: {
+  bounty: BountyPublic;
+  myApplication: MyBountyApplication | null;
+}) {
+  const { label } = entryKind(bounty);
+
+  const deadlinePassed =
+    !!bounty.applicationWindowCloseAt &&
+    new Date(bounty.applicationWindowCloseAt).getTime() < Date.now();
+  const accepting = ACCEPTING_STATUSES.has(bounty.status);
+
+  // An active (non-withdrawn) application means the caller is already in.
+  const activeStatus =
+    myApplication && myApplication.applicationStatus !== 'WITHDRAWN'
+      ? myApplication.applicationStatus
+      : null;
+
+  // The real entry flow (forms / on-chain op) ships in #624; the CTA here is
+  // mode-aware and correctly gated, and hands off to that flow.
+  const onEntry = () =>
+    toast.info('The entry flow is coming in the next step (apply/join/claim).');
+
+  return (
+    <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5'>
+      {activeStatus ? (
+        <div className='space-y-3'>
+          <div className='flex items-center gap-2'>
+            <CheckCircle2 className='text-primary h-4 w-4' />
+            <span className='text-sm font-medium text-white'>
+              You&apos;re in this bounty
+            </span>
+          </div>
+          <Badge
+            variant='outline'
+            className={`rounded-full px-3 py-1 text-xs font-medium ${
+              STATUS_CLASS[activeStatus] ??
+              'border-zinc-700 bg-zinc-800/60 text-zinc-300'
+            }`}
+          >
+            {STATUS_LABEL[activeStatus] ?? activeStatus}
+          </Badge>
+        </div>
+      ) : (
+        <>
+          <BoundlessButton
+            size='lg'
+            className='w-full'
+            disabled={!accepting || deadlinePassed}
+            onClick={onEntry}
+          >
+            {label}
+          </BoundlessButton>
+          <p className='mt-2 flex items-center justify-center gap-1.5 text-center text-xs text-zinc-500'>
+            {!accepting ? (
+              <>
+                <Lock className='h-3.5 w-3.5' />
+                This bounty is not accepting entries.
+              </>
+            ) : deadlinePassed ? (
+              <>
+                <Lock className='h-3.5 w-3.5' />
+                Applications have closed.
+              </>
+            ) : myApplication?.applicationStatus === 'WITHDRAWN' ? (
+              'You withdrew earlier — you can enter again.'
+            ) : (
+              'Funds are held in escrow and paid on-chain to winners.'
+            )}
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/bounties/marketplace/BountiesFiltersHeader.tsx
+++ b/components/bounties/marketplace/BountiesFiltersHeader.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { Search } from 'lucide-react';
+
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+export const STATUS_OPTIONS = [
+  { value: 'all', label: 'All statuses' },
+  { value: 'open', label: 'Open' },
+  { value: 'in_progress', label: 'In progress' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'cancelled', label: 'Cancelled' },
+] as const;
+
+export const MODE_OPTIONS = [
+  { value: 'all', label: 'All modes' },
+  { value: 'single_claim', label: 'Single claim' },
+  { value: 'competition', label: 'Competition' },
+  { value: 'application', label: 'Application' },
+] as const;
+
+export type ModeFilter = (typeof MODE_OPTIONS)[number]['value'];
+
+interface BountiesFiltersHeaderProps {
+  search: string;
+  status: string;
+  mode: ModeFilter;
+  totalCount: number;
+  onSearch: (value: string) => void;
+  onStatus: (value: string) => void;
+  onMode: (value: ModeFilter) => void;
+}
+
+export default function BountiesFiltersHeader({
+  search,
+  status,
+  mode,
+  totalCount,
+  onSearch,
+  onStatus,
+  onMode,
+}: BountiesFiltersHeaderProps) {
+  return (
+    <div className='mb-8'>
+      <div className='mb-2 flex items-end justify-between gap-4'>
+        <div>
+          <h1 className='text-3xl font-bold tracking-tight text-white'>
+            Bounties
+          </h1>
+          <p className='mt-1 text-sm text-zinc-400'>
+            Discover open bounties and start earning.
+          </p>
+        </div>
+        <span className='shrink-0 text-sm text-zinc-500'>
+          {totalCount} bount{totalCount === 1 ? 'y' : 'ies'}
+        </span>
+      </div>
+
+      <div className='mt-4 flex flex-wrap items-center gap-3'>
+        <div className='relative min-w-52 flex-1'>
+          <Search className='absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-zinc-500' />
+          <Input
+            type='search'
+            placeholder='Search bounties...'
+            value={search}
+            onChange={e => onSearch(e.target.value)}
+            className='focus:border-primary h-10 rounded-xl border-zinc-800/50 bg-zinc-900/30 pl-10 text-sm text-white placeholder:text-zinc-500 hover:border-zinc-700'
+          />
+        </div>
+
+        <Select value={status} onValueChange={onStatus}>
+          <SelectTrigger className='h-10 w-40 rounded-xl border-zinc-800/50 bg-zinc-900/30 text-sm text-white hover:border-zinc-700'>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent className='border-zinc-800/50 bg-zinc-950'>
+            {STATUS_OPTIONS.map(o => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={mode} onValueChange={v => onMode(v as ModeFilter)}>
+          <SelectTrigger className='h-10 w-40 rounded-xl border-zinc-800/50 bg-zinc-900/30 text-sm text-white hover:border-zinc-700'>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent className='border-zinc-800/50 bg-zinc-950'>
+            {MODE_OPTIONS.map(o => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/components/bounties/marketplace/BountiesPage.tsx
+++ b/components/bounties/marketplace/BountiesPage.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+
+import EmptyState from '@/components/EmptyState';
+import LoadingSpinner from '@/components/LoadingSpinner';
+import { BoundlessButton } from '@/components/buttons';
+import { useInfiniteScroll } from '@/hooks/use-infinite-scroll';
+import type { BountyPublic } from '@/features/bounties';
+import { BountyCard } from './BountyCard';
+import BountiesFiltersHeader, {
+  type ModeFilter,
+} from './BountiesFiltersHeader';
+import { useInfiniteBounties } from './use-bounties-marketplace';
+
+/** Client-side mode narrowing (the public list endpoint doesn't filter on mode). */
+function matchesMode(b: BountyPublic, mode: ModeFilter): boolean {
+  switch (mode) {
+    case 'single_claim':
+      return b.claimType === 'SINGLE_CLAIM';
+    case 'competition':
+      return b.claimType === 'COMPETITION';
+    case 'application':
+      return (
+        b.entryType === 'APPLICATION_LIGHT' ||
+        b.entryType === 'APPLICATION_FULL'
+      );
+    default:
+      return true;
+  }
+}
+
+export default function BountiesPage() {
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [status, setStatus] = useState('all');
+  const [mode, setMode] = useState<ModeFilter>('all');
+
+  // Debounce the search so we don't refetch on every keystroke.
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search.trim()), 300);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  const {
+    bounties,
+    totalCount,
+    loading,
+    loadingMore,
+    error,
+    hasMore,
+    loadMore,
+  } = useInfiniteBounties({
+    status: status === 'all' ? undefined : status,
+    search: debouncedSearch || undefined,
+  });
+
+  const visible = useMemo(
+    () => bounties.filter(b => matchesMode(b, mode)),
+    [bounties, mode]
+  );
+
+  const [sentinel, setSentinel] = useState<HTMLDivElement | null>(null);
+  useInfiniteScroll(sentinel, {
+    onLoadMore: loadMore,
+    hasMore: !!hasMore,
+    loading: loadingMore,
+    rootMargin: '0px 0px 1200px 0px',
+  });
+
+  const hasFilters = !!debouncedSearch || status !== 'all' || mode !== 'all';
+  const clearFilters = () => {
+    setSearch('');
+    setStatus('all');
+    setMode('all');
+  };
+
+  return (
+    <div id='explore-bounties'>
+      <BountiesFiltersHeader
+        search={search}
+        status={status}
+        mode={mode}
+        totalCount={totalCount}
+        onSearch={setSearch}
+        onStatus={setStatus}
+        onMode={setMode}
+      />
+
+      {loading && (
+        <div className='flex items-center justify-center py-24'>
+          <LoadingSpinner size='md' variant='spinner' color='white' />
+        </div>
+      )}
+
+      {!loading && error && (
+        <div className='py-16'>
+          <EmptyState
+            title="Couldn't load bounties"
+            description={error}
+            type='compact'
+          />
+        </div>
+      )}
+
+      {!loading && !error && visible.length === 0 && (
+        <div className='py-16 text-center'>
+          <EmptyState
+            title='No bounties found'
+            description={
+              hasFilters
+                ? 'Try adjusting your filters to see more bounties.'
+                : 'No bounties are available right now.'
+            }
+            type='compact'
+          />
+          {hasFilters && (
+            <div className='mt-3'>
+              <BoundlessButton
+                variant='outline'
+                onClick={clearFilters}
+                className='border-primary text-primary hover:bg-primary/10'
+              >
+                Clear filters
+              </BoundlessButton>
+            </div>
+          )}
+        </div>
+      )}
+
+      {!loading && !error && visible.length > 0 && (
+        <>
+          <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3'>
+            {visible.map(b => (
+              <BountyCard key={b.id} bounty={b} />
+            ))}
+          </div>
+
+          <div ref={setSentinel} className='h-px w-full' aria-hidden />
+
+          {loadingMore && (
+            <div className='mt-6 flex items-center justify-center gap-2 py-4 text-zinc-400'>
+              <LoadingSpinner size='sm' variant='spinner' color='white' />
+              <span className='text-sm'>Loading more...</span>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/bounties/marketplace/BountyCard.tsx
+++ b/components/bounties/marketplace/BountyCard.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import Link from 'next/link';
+import { Calendar, Target } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { computeBountyModeLabel } from '@/components/organization/bounties/new/tabs/schemas/modeSchema';
+import type { BountyPublic } from '@/features/bounties';
+
+/** Plain-language mode label (single claim / competition / application). */
+function modeLabel(b: BountyPublic): string {
+  if (b.entryType && b.claimType) {
+    return computeBountyModeLabel(b.entryType, b.claimType);
+  }
+  return 'Bounty';
+}
+
+const STATUS_CLASS: Record<string, string> = {
+  open: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400',
+  in_progress: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400',
+  completed: 'border-primary/30 bg-primary/10 text-primary',
+  cancelled: 'border-zinc-700 bg-zinc-800/60 text-zinc-300',
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+export function BountyCard({ bounty }: { bounty: BountyPublic }) {
+  const reward = bounty.rewardAmount > 0;
+  const statusClass =
+    STATUS_CLASS[bounty.status] ??
+    'border-zinc-700 bg-zinc-800/60 text-zinc-300';
+
+  return (
+    <Link
+      href={`/bounties/${bounty.id}`}
+      className='group hover:border-primary/40 flex w-full flex-col rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5 transition-colors hover:bg-zinc-900/70'
+      aria-label={`View bounty ${bounty.title}`}
+    >
+      <div className='mb-3 flex items-center justify-between gap-2'>
+        <Badge
+          variant='outline'
+          className='rounded-full border-zinc-700 bg-zinc-800/60 px-3 py-1 text-xs font-medium text-zinc-200'
+        >
+          {modeLabel(bounty)}
+        </Badge>
+        <Badge
+          variant='outline'
+          className={`rounded-full px-3 py-1 text-xs font-medium capitalize ${statusClass}`}
+        >
+          {bounty.status.replace(/_/g, ' ')}
+        </Badge>
+      </div>
+
+      <h3 className='group-hover:text-primary line-clamp-2 min-h-12 text-lg font-bold text-white transition-colors'>
+        {bounty.title}
+      </h3>
+      {bounty.description && (
+        <p className='mt-1 line-clamp-2 text-sm text-zinc-400'>
+          {bounty.description}
+        </p>
+      )}
+
+      {bounty.applicationWindowCloseAt && (
+        <p className='mt-3 flex items-center gap-1.5 text-xs text-zinc-500'>
+          <Calendar className='h-3.5 w-3.5' />
+          Applications close {formatDate(bounty.applicationWindowCloseAt)}
+        </p>
+      )}
+
+      <div className='mt-4 flex items-center justify-between gap-2 border-t border-zinc-800 pt-4'>
+        <div className='flex items-center gap-2'>
+          <div className='bg-primary/10 flex h-9 w-9 items-center justify-center rounded-lg'>
+            <Target className='text-primary h-4 w-4' />
+          </div>
+          <div>
+            <p className='text-primary text-base leading-tight font-bold'>
+              {reward
+                ? `${bounty.rewardAmount.toLocaleString()} ${bounty.rewardCurrency}`
+                : 'No reward set'}
+            </p>
+            <p className='text-[11px] text-zinc-500'>reward</p>
+          </div>
+        </div>
+        <span className='max-w-[45%] truncate text-right text-xs text-zinc-400'>
+          {bounty.organization.name}
+        </span>
+      </div>
+    </Link>
+  );
+}

--- a/components/bounties/marketplace/use-bounties-marketplace.ts
+++ b/components/bounties/marketplace/use-bounties-marketplace.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { listBounties, bountyKeys } from '@/features/bounties';
+
+const PAGE_SIZE = 12;
+
+export interface MarketplaceFilters {
+  /** Server-side: bounty lifecycle status (e.g. 'open'). */
+  status?: string;
+  /** Server-side: free-text title/description search. */
+  search?: string;
+}
+
+/**
+ * Infinite (page-accumulating) public bounty list for the marketplace. Wraps the
+ * `listBounties` client; status + search are applied server-side, pagination via
+ * `getNextPageParam` off the response total. Mode/category narrowing is done
+ * client-side in the page (the public list endpoint doesn't filter on them).
+ */
+export function useInfiniteBounties(filters: MarketplaceFilters) {
+  const query = useInfiniteQuery({
+    queryKey: bountyKeys.list({ ...filters, infinite: true }),
+    queryFn: ({ pageParam }) =>
+      listBounties({ ...filters, page: pageParam, limit: PAGE_SIZE }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) => {
+      const loaded = allPages.reduce((n, p) => n + p.bounties.length, 0);
+      return loaded < lastPage.total ? allPages.length + 1 : undefined;
+    },
+  });
+
+  const bounties = query.data?.pages.flatMap(p => p.bounties) ?? [];
+  const totalCount = query.data?.pages[0]?.total ?? 0;
+
+  return {
+    bounties,
+    totalCount,
+    loading: query.isLoading,
+    loadingMore: query.isFetchingNextPage,
+    error: query.error ? (query.error as Error).message : null,
+    hasMore: query.hasNextPage,
+    loadMore: query.fetchNextPage,
+  };
+}

--- a/features/bounties/api/keys.ts
+++ b/features/bounties/api/keys.ts
@@ -10,4 +10,13 @@ export const bountyKeys = {
     [...bountyKeys.all, 'draft', organizationId, id] as const,
   escrowOp: (scope: string, opRowId: string) =>
     [...bountyKeys.all, 'escrow-op', scope, opRowId] as const,
+
+  // Builder / participant reads.
+  list: (params: Record<string, unknown> = {}) =>
+    [...bountyKeys.all, 'list', params] as const,
+  detail: (bountyId: string) =>
+    [...bountyKeys.all, 'detail', bountyId] as const,
+  myApplication: (bountyId: string) =>
+    [...bountyKeys.all, 'my-application', bountyId] as const,
+  myActivity: () => [...bountyKeys.all, 'my-activity'] as const,
 };

--- a/features/bounties/api/participant-client.ts
+++ b/features/bounties/api/participant-client.ts
@@ -1,0 +1,120 @@
+/**
+ * Builder/participant bounty REST client: the public marketplace reads and the
+ * v2 application-record surface (off-chain proposal carrier for the application
+ * entry types), plus open-competition join/leave.
+ *
+ * Several backend handlers still return the raw entity without an `@ApiOkResponse`
+ * (so the generated schema types them as `never`). Those are cast to the
+ * hand-typed `MyBountyApplication` until boundless-nestjs #331 lands and codegen
+ * picks up the real DTO.
+ */
+import { apiClient, unwrapData } from '@/lib/api';
+
+import type {
+  BountyPublic,
+  BountyPublicList,
+  CreateBountyApplicationRequest,
+  EditBountyApplicationRequest,
+  JoinCompetitionRequest,
+  MyBountyApplication,
+} from '../types';
+
+export interface BountiesListParams {
+  organizationId?: string;
+  status?: string;
+  search?: string;
+  page?: number;
+  limit?: number;
+}
+
+// ── Public marketplace ────────────────────────────────────────────────────────
+
+/** Paginated public bounty list (the marketplace). */
+export const listBounties = async (
+  params: BountiesListParams = {}
+): Promise<BountyPublicList> =>
+  unwrapData(
+    await apiClient.GET('/api/bounties', { params: { query: params } })
+  );
+
+/** A single public bounty (the detail page). */
+export const getBounty = async (bountyId: string): Promise<BountyPublic> =>
+  unwrapData(
+    await apiClient.GET('/api/bounties/{id}', {
+      params: { path: { id: bountyId } },
+    })
+  );
+
+// ── v2 application records (application entry types) ──────────────────────────
+
+/** The caller's own application for a bounty, or null when they have not applied. */
+export const getMyBountyApplication = async (
+  bountyId: string
+): Promise<MyBountyApplication | null> =>
+  (unwrapData(
+    await apiClient.GET('/api/bounties/{bountyId}/v2/applications/me', {
+      params: { path: { bountyId } },
+    })
+  ) as unknown as MyBountyApplication | null) ?? null;
+
+/** Submit an application (light / full proposal) for an application-mode bounty. */
+export const applyToBounty = async (
+  bountyId: string,
+  body: CreateBountyApplicationRequest
+): Promise<MyBountyApplication> =>
+  unwrapData(
+    await apiClient.POST('/api/bounties/{bountyId}/v2/applications', {
+      params: { path: { bountyId } },
+      body,
+    })
+  ) as unknown as MyBountyApplication;
+
+/** Edit a SUBMITTED application (before shortlist). */
+export const editBountyApplication = async (
+  bountyId: string,
+  appId: string,
+  body: EditBountyApplicationRequest
+): Promise<MyBountyApplication> =>
+  unwrapData(
+    await apiClient.PATCH('/api/bounties/{bountyId}/v2/applications/{appId}', {
+      params: { path: { bountyId, appId } },
+      body,
+    })
+  ) as unknown as MyBountyApplication;
+
+/** Withdraw a SUBMITTED application (the application record; status -> WITHDRAWN). */
+export const withdrawBountyApplication = async (
+  bountyId: string,
+  appId: string
+): Promise<MyBountyApplication> =>
+  unwrapData(
+    await apiClient.DELETE('/api/bounties/{bountyId}/v2/applications/{appId}', {
+      params: { path: { bountyId, appId } },
+    })
+  ) as unknown as MyBountyApplication;
+
+// ── Open competition join / leave ─────────────────────────────────────────────
+
+/** Join an open competition directly (no application step). */
+export const joinCompetition = async (
+  bountyId: string,
+  body: JoinCompetitionRequest
+): Promise<MyBountyApplication> =>
+  unwrapData(
+    await apiClient.POST('/api/bounties/{bountyId}/v2/competition/join', {
+      params: { path: { bountyId } },
+      body,
+    })
+  ) as unknown as MyBountyApplication;
+
+/** Leave an open competition the caller joined. */
+export const leaveCompetition = async (
+  bountyId: string,
+  body: JoinCompetitionRequest
+): Promise<MyBountyApplication> =>
+  unwrapData(
+    await apiClient.DELETE('/api/bounties/{bountyId}/v2/competition/join', {
+      params: { path: { bountyId } },
+      body,
+    })
+  ) as unknown as MyBountyApplication;

--- a/features/bounties/api/participant-escrow-client.ts
+++ b/features/bounties/api/participant-escrow-client.ts
@@ -1,0 +1,107 @@
+/**
+ * Builder/participant bounty escrow client (boundless-events contract), on the
+ * typed openapi-fetch client. Counterpart to the organizer `escrow-client.ts`:
+ * these are the participant-scoped, no-org-prefix routes (`/api/bounties/{id}/
+ * escrow/...`) the builder lifecycle drives through the shared escrow runner.
+ *
+ * Like the organizer ops, each builds an EscrowOp:
+ *   MANAGED  : backend signs with the caller's platform-held wallet + submits;
+ *              the op returns in PENDING_CONFIRM (the webapp only polls).
+ *   EXTERNAL : backend returns `unsignedXdr`; the webapp signs with a connected
+ *              wallet and POSTs to submit-signed, then polls.
+ */
+import { apiClient, unwrapData } from '@/lib/api';
+
+import type {
+  ApplyBountyRequest,
+  BountyEscrowOpResponse,
+  ContributeBountyRequest,
+  SubmitBountyRequest,
+  SubmitSignedXdrRequest,
+  WithdrawApplicationRequest,
+  WithdrawSubmissionRequest,
+} from '../types';
+
+/** Apply to a bounty on-chain (APPLY_TO_BOUNTY; charges application credits). */
+export const applyToBountyEscrow = async (
+  bountyId: string,
+  body: ApplyBountyRequest
+): Promise<BountyEscrowOpResponse> =>
+  unwrapData(
+    await apiClient.POST('/api/bounties/{id}/escrow/apply', {
+      params: { path: { id: bountyId } },
+      body,
+    })
+  );
+
+/** Withdraw a bounty application (refunds half the application credits). */
+export const withdrawBountyApplicationEscrow = async (
+  bountyId: string,
+  body: WithdrawApplicationRequest
+): Promise<BountyEscrowOpResponse> =>
+  unwrapData(
+    await apiClient.POST('/api/bounties/{id}/escrow/withdraw-application', {
+      params: { path: { id: bountyId } },
+      body,
+    })
+  );
+
+/** Anchor a work submission on-chain (SUBMIT; requires an active application). */
+export const submitBountyWorkEscrow = async (
+  bountyId: string,
+  body: SubmitBountyRequest
+): Promise<BountyEscrowOpResponse> =>
+  unwrapData(
+    await apiClient.POST('/api/bounties/{id}/escrow/submit', {
+      params: { path: { id: bountyId } },
+      body,
+    })
+  );
+
+/** Withdraw a submission anchor. */
+export const withdrawBountySubmissionEscrow = async (
+  bountyId: string,
+  body: WithdrawSubmissionRequest
+): Promise<BountyEscrowOpResponse> =>
+  unwrapData(
+    await apiClient.POST('/api/bounties/{id}/escrow/withdraw-submission', {
+      params: { path: { id: bountyId } },
+      body,
+    })
+  );
+
+/** Contribute funds to a bounty's escrow pool (ADD_FUNDS; 10 USDC minimum). */
+export const contributeToBountyEscrow = async (
+  bountyId: string,
+  body: ContributeBountyRequest
+): Promise<BountyEscrowOpResponse> =>
+  unwrapData(
+    await apiClient.POST('/api/bounties/{id}/escrow/contribute', {
+      params: { path: { id: bountyId } },
+      body,
+    })
+  );
+
+/** Submit a wallet-signed XDR for a participant op (EXTERNAL path). */
+export const submitSignedParticipantBounty = async (
+  bountyId: string,
+  opRowId: string,
+  body: SubmitSignedXdrRequest
+): Promise<BountyEscrowOpResponse> =>
+  unwrapData(
+    await apiClient.POST(
+      '/api/bounties/{id}/escrow/ops/{opRowId}/submit-signed',
+      { params: { path: { id: bountyId, opRowId } }, body }
+    )
+  );
+
+/** Poll the current state of a participant escrow op. */
+export const getParticipantBountyOp = async (
+  bountyId: string,
+  opRowId: string
+): Promise<BountyEscrowOpResponse> =>
+  unwrapData(
+    await apiClient.GET('/api/bounties/{id}/escrow/ops/{opRowId}', {
+      params: { path: { id: bountyId, opRowId } },
+    })
+  );

--- a/features/bounties/api/use-escrow.ts
+++ b/features/bounties/api/use-escrow.ts
@@ -33,6 +33,10 @@ import {
   submitSignedBountyEscrow,
 } from './escrow-client';
 import {
+  getParticipantBountyOp,
+  submitSignedParticipantBounty,
+} from './participant-escrow-client';
+import {
   isTerminalEscrowStatus,
   type BountyEscrowOpResponse,
   type CancelBountyEscrowRequest,
@@ -41,19 +45,19 @@ import {
   type SelectBountyWinnersRequest,
 } from '../types';
 
-// ─── Scope: organizer (org + bounty) ─────────────────────────────────────────
+// ─── Scope: organizer (org + bounty) or participant (bounty-only) ─────────────
 
-export type EscrowOpScope = {
-  kind: 'organizer';
-  organizationId: string;
-  bountyId: string;
-};
+export type EscrowOpScope =
+  | { kind: 'organizer'; organizationId: string; bountyId: string }
+  | { kind: 'participant'; bountyId: string };
 
 function getOpForScope(
   scope: EscrowOpScope,
   opRowId: string
 ): Promise<BountyEscrowOpResponse> {
-  return getBountyEscrowOp(scope.organizationId, scope.bountyId, opRowId);
+  return scope.kind === 'participant'
+    ? getParticipantBountyOp(scope.bountyId, opRowId)
+    : getBountyEscrowOp(scope.organizationId, scope.bountyId, opRowId);
 }
 
 function submitSignedForScope(
@@ -61,22 +65,23 @@ function submitSignedForScope(
   opRowId: string,
   signedXdr: string
 ): Promise<BountyEscrowOpResponse> {
-  return submitSignedBountyEscrow(
-    scope.organizationId,
-    scope.bountyId,
-    opRowId,
-    { signedXdr }
-  );
+  return scope.kind === 'participant'
+    ? submitSignedParticipantBounty(scope.bountyId, opRowId, { signedXdr })
+    : submitSignedBountyEscrow(scope.organizationId, scope.bountyId, opRowId, {
+        signedXdr,
+      });
 }
 
 function escrowOpKey(scope: EscrowOpScope, opRowId: string): QueryKey {
-  return [
-    'bounty-escrow-op',
-    'organizer',
-    scope.organizationId,
-    scope.bountyId,
-    opRowId,
-  ];
+  return scope.kind === 'participant'
+    ? ['bounty-escrow-op', 'participant', scope.bountyId, opRowId]
+    : [
+        'bounty-escrow-op',
+        'organizer',
+        scope.organizationId,
+        scope.bountyId,
+        opRowId,
+      ];
 }
 
 // ─── 1. Polling primitive ────────────────────────────────────────────────────

--- a/features/bounties/api/use-participant.ts
+++ b/features/bounties/api/use-participant.ts
@@ -1,0 +1,236 @@
+'use client';
+
+/**
+ * React Query hooks for the bounty builder/participant lifecycle (boundless #621).
+ *
+ *   reads        — useBountiesList / useBounty (public), useMyBountyApplication.
+ *   applications — useApplyToBounty / useEditApplication / useWithdrawApplication
+ *                  / useJoinCompetition / useLeaveCompetition (v2 records).
+ *   escrow ops   — useSubmitBounty / useWithdrawSubmission / useContributeToBounty
+ *                  / useApplyToBountyEscrow / useWithdrawApplicationEscrow, each
+ *                  driven through the shared {@link useEscrowOpRunner} on the
+ *                  participant scope. Funding defaults to MANAGED (the backend
+ *                  signs + submits with the caller's platform-held wallet); pass
+ *                  a `signXdr` to take the EXTERNAL connected-wallet path.
+ *
+ * `useMyBountyActivity` (cross-bounty applications + submissions) waits on the
+ * backend participant dashboard (boundless-nestjs #332); it is intentionally not
+ * implemented here yet.
+ */
+import { useCallback } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { useEscrowOpRunner, type SignXdrFn } from './use-escrow';
+import { bountyKeys } from './keys';
+import {
+  applyToBountyEscrow,
+  contributeToBountyEscrow,
+  submitBountyWorkEscrow,
+  withdrawBountyApplicationEscrow,
+  withdrawBountySubmissionEscrow,
+} from './participant-escrow-client';
+import {
+  applyToBounty,
+  editBountyApplication,
+  getBounty,
+  getMyBountyApplication,
+  joinCompetition,
+  leaveCompetition,
+  listBounties,
+  withdrawBountyApplication,
+  type BountiesListParams,
+} from './participant-client';
+import type {
+  ApplyBountyRequest,
+  ContributeBountyRequest,
+  CreateBountyApplicationRequest,
+  EditBountyApplicationRequest,
+  FundingMode,
+  JoinCompetitionRequest,
+  SubmitBountyRequest,
+  WithdrawApplicationRequest,
+  WithdrawSubmissionRequest,
+} from '../types';
+
+// ── Reads ─────────────────────────────────────────────────────────────────────
+
+/** Paginated public marketplace list. */
+export function useBountiesList(params: BountiesListParams = {}) {
+  return useQuery({
+    queryKey: bountyKeys.list(params as Record<string, unknown>),
+    queryFn: () => listBounties(params),
+  });
+}
+
+/** A single public bounty (detail page). */
+export function useBounty(bountyId: string | undefined) {
+  return useQuery({
+    queryKey: bountyKeys.detail(bountyId ?? ''),
+    queryFn: () => getBounty(bountyId as string),
+    enabled: !!bountyId,
+  });
+}
+
+/** The caller's own application for a bounty (drives the detail CTA). */
+export function useMyBountyApplication(bountyId: string | undefined) {
+  return useQuery({
+    queryKey: bountyKeys.myApplication(bountyId ?? ''),
+    queryFn: () => getMyBountyApplication(bountyId as string),
+    enabled: !!bountyId,
+  });
+}
+
+// ── Application records (v2) ──────────────────────────────────────────────────
+
+/** Submit an application (light/full proposal) for an application-mode bounty. */
+export function useApplyToBounty(bountyId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateBountyApplicationRequest) =>
+      applyToBounty(bountyId, body),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: bountyKeys.myApplication(bountyId) }),
+  });
+}
+
+/** Edit a SUBMITTED application (before shortlist). */
+export function useEditApplication(bountyId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { appId: string; body: EditBountyApplicationRequest }) =>
+      editBountyApplication(bountyId, vars.appId, vars.body),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: bountyKeys.myApplication(bountyId) }),
+  });
+}
+
+/** Withdraw a SUBMITTED application record (status -> WITHDRAWN). */
+export function useWithdrawApplication(bountyId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (appId: string) => withdrawBountyApplication(bountyId, appId),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: bountyKeys.myApplication(bountyId) }),
+  });
+}
+
+/** Join an open competition directly (no application step). */
+export function useJoinCompetition(bountyId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: JoinCompetitionRequest) =>
+      joinCompetition(bountyId, body),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: bountyKeys.myApplication(bountyId) }),
+  });
+}
+
+/** Leave an open competition the caller joined. */
+export function useLeaveCompetition(bountyId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: JoinCompetitionRequest) =>
+      leaveCompetition(bountyId, body),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: bountyKeys.myApplication(bountyId) }),
+  });
+}
+
+// ── Escrow ops (participant scope, default MANAGED) ───────────────────────────
+
+/** A participant op body with funding mode optional (defaults to MANAGED). */
+type WithManagedDefault<T extends { fundingMode: FundingMode }> = Omit<
+  T,
+  'fundingMode'
+> & { fundingMode?: FundingMode };
+
+const withManaged = <T extends { fundingMode: FundingMode }>(
+  body: WithManagedDefault<T>
+): T => ({ fundingMode: 'MANAGED', ...body }) as T;
+
+interface ParticipantOpOptions {
+  /** Sign the unsigned XDR for the EXTERNAL path. Omit for MANAGED. */
+  signXdr?: SignXdrFn;
+}
+
+/**
+ * Build a participant escrow-op hook: a runner on the participant scope plus a
+ * `run(body)` that starts the op (funding defaults to MANAGED). Returns the full
+ * runner surface (phase/status/error/txHash) for the calling UI.
+ */
+function useParticipantOp<T extends { fundingMode: FundingMode }>(
+  bountyId: string,
+  start: (id: string, body: T) => ReturnType<typeof submitBountyWorkEscrow>,
+  options: ParticipantOpOptions = {}
+) {
+  const runner = useEscrowOpRunner(
+    { kind: 'participant', bountyId },
+    options.signXdr ? { signXdr: options.signXdr } : undefined
+  );
+  const run = useCallback(
+    (body: WithManagedDefault<T>) =>
+      runner.run(() => start(bountyId, withManaged<T>(body))),
+    [runner, bountyId, start]
+  );
+  return { ...runner, run };
+}
+
+/** Anchor a work submission on-chain (SUBMIT). */
+export function useSubmitBounty(
+  bountyId: string,
+  options?: ParticipantOpOptions
+) {
+  return useParticipantOp<SubmitBountyRequest>(
+    bountyId,
+    submitBountyWorkEscrow,
+    options
+  );
+}
+
+/** Withdraw a submission anchor. */
+export function useWithdrawSubmission(
+  bountyId: string,
+  options?: ParticipantOpOptions
+) {
+  return useParticipantOp<WithdrawSubmissionRequest>(
+    bountyId,
+    withdrawBountySubmissionEscrow,
+    options
+  );
+}
+
+/** Apply to a bounty on-chain (APPLY_TO_BOUNTY; open modes). */
+export function useApplyToBountyEscrow(
+  bountyId: string,
+  options?: ParticipantOpOptions
+) {
+  return useParticipantOp<ApplyBountyRequest>(
+    bountyId,
+    applyToBountyEscrow,
+    options
+  );
+}
+
+/** Withdraw an on-chain application (open modes). */
+export function useWithdrawApplicationEscrow(
+  bountyId: string,
+  options?: ParticipantOpOptions
+) {
+  return useParticipantOp<WithdrawApplicationRequest>(
+    bountyId,
+    withdrawBountyApplicationEscrow,
+    options
+  );
+}
+
+/** Contribute funds to a bounty's escrow pool (ADD_FUNDS). */
+export function useContributeToBounty(
+  bountyId: string,
+  options?: ParticipantOpOptions
+) {
+  return useParticipantOp<ContributeBountyRequest>(
+    bountyId,
+    contributeToBountyEscrow,
+    options
+  );
+}

--- a/features/bounties/index.ts
+++ b/features/bounties/index.ts
@@ -86,3 +86,63 @@ export type {
   UseEscrowOpRunnerOptions,
   EscrowOpRunner,
 } from './api/use-escrow';
+
+// ── Builder / participant data layer (#621) ──────────────────────────────────
+
+// Participant types (aliased from the generated schema; MyBountyApplication is
+// hand-typed until boundless-nestjs #331 lands and codegen runs).
+export type {
+  BountyPublic,
+  BountyPublicList,
+  MyBountyApplication,
+  BountyApplicationStatus,
+  ApplyBountyRequest,
+  SubmitBountyRequest,
+  WithdrawApplicationRequest,
+  WithdrawSubmissionRequest,
+  ContributeBountyRequest,
+  CreateBountyApplicationRequest,
+  EditBountyApplicationRequest,
+  JoinCompetitionRequest,
+} from './types';
+
+// Participant REST client (public reads + v2 application records + competition).
+export {
+  listBounties,
+  getBounty,
+  getMyBountyApplication,
+  applyToBounty,
+  editBountyApplication,
+  withdrawBountyApplication,
+  joinCompetition,
+  leaveCompetition,
+} from './api/participant-client';
+export type { BountiesListParams } from './api/participant-client';
+
+// Participant escrow client (on-chain apply/submit/withdraw/contribute).
+export {
+  applyToBountyEscrow,
+  withdrawBountyApplicationEscrow,
+  submitBountyWorkEscrow,
+  withdrawBountySubmissionEscrow,
+  contributeToBountyEscrow,
+  getParticipantBountyOp,
+  submitSignedParticipantBounty,
+} from './api/participant-escrow-client';
+
+// Participant hooks (React Query).
+export {
+  useBountiesList,
+  useBounty,
+  useMyBountyApplication,
+  useApplyToBounty,
+  useEditApplication,
+  useWithdrawApplication,
+  useJoinCompetition,
+  useLeaveCompetition,
+  useSubmitBounty,
+  useWithdrawSubmission,
+  useApplyToBountyEscrow,
+  useWithdrawApplicationEscrow,
+  useContributeToBounty,
+} from './api/use-participant';

--- a/features/bounties/types.ts
+++ b/features/bounties/types.ts
@@ -74,3 +74,58 @@ export const TERMINAL_ESCROW_STATUSES: readonly EscrowOpStatus[] = [
 
 export const isTerminalEscrowStatus = (status: EscrowOpStatus): boolean =>
   TERMINAL_ESCROW_STATUSES.includes(status);
+
+// ── Builder / participant ─────────────────────────────────────────────────────
+
+/** Public marketplace bounty (list row + detail share this shape). */
+export type BountyPublic = Schemas['BountyPublicDto'];
+/** Paginated marketplace list response. */
+export type BountyPublicList = Schemas['BountyPublicListDto'];
+
+// Participant escrow op request bodies (on-chain apply/submit/withdraw/contribute).
+export type ApplyBountyRequest = Schemas['ApplyBountyDto'];
+export type SubmitBountyRequest = Schemas['SubmitBountyDto'];
+export type WithdrawApplicationRequest = Schemas['WithdrawApplicationDto'];
+export type WithdrawSubmissionRequest = Schemas['WithdrawSubmissionDto'];
+export type ContributeBountyRequest = Schemas['ContributeBountyDto'];
+
+// v2 application records (off-chain proposal carrier for application modes).
+export type CreateBountyApplicationRequest =
+  Schemas['CreateBountyApplicationDto'];
+export type EditBountyApplicationRequest = Schemas['EditBountyApplicationDto'];
+export type JoinCompetitionRequest = Schemas['JoinCompetitionDto'];
+
+/**
+ * The caller's own application for a bounty (GET …/v2/applications/me).
+ *
+ * The backend `BountyApplicationResponseDto` (boundless-nestjs #331) is not yet
+ * in the generated schema, so this is hand-typed to its shape. Replace with
+ * `Schemas['BountyApplicationResponseDto']` after that lands and codegen runs.
+ */
+export type BountyApplicationStatus =
+  | 'SUBMITTED'
+  | 'SHORTLISTED'
+  | 'SELECTED'
+  | 'DECLINED'
+  | 'WITHDRAWN';
+
+export interface MyBountyApplication {
+  id: string;
+  bountyId: string;
+  applicantAddress: string;
+  status: string;
+  applicationStatus: BountyApplicationStatus | null;
+  proposalShort: string | null;
+  proposalFull: string | null;
+  portfolioLinks: string[];
+  estimatedDays: number | null;
+  qualifications: string | null;
+  videoIntroUrl: string | null;
+  declineReason: string | null;
+  shortlistedAt: string | null;
+  selectedAt: string | null;
+  declinedAt: string | null;
+  withdrawnAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -108,6 +108,14 @@ export const pageMetadata: Record<string, PageMetadata> = {
     ogImage:
       'https://res.cloudinary.com/danuy5rqb/image/upload/v1759143589/bondless-og-image_jufgnu.png',
   },
+  bounties: {
+    title: 'Bounties - Boundless',
+    description:
+      'Discover open bounties on Boundless. Pick up work, ship it, and earn on-chain rewards.',
+    keywords: ['bounties', 'rewards', 'open source', 'earn', 'contribute'],
+    ogImage:
+      'https://res.cloudinary.com/danuy5rqb/image/upload/v1759143589/bondless-og-image_jufgnu.png',
+  },
   hackathons: {
     title: 'Hackathons - Boundless',
     description:


### PR DESCRIPTION
Closes #623.

> **Stacked on #645 (#622) → #643 (#621).** Until those merge into `feat/t-replace`, this PR's diff also shows their commits; it reduces to just the detail page once they land. Merge order: #643 → #645 → this.

## What

The builder **hub** at `/bounties/[id]`: shows the bounty, the caller's current status, and a mode-aware entry CTA. Wired to the participant data layer (#621).

- **Route** `app/(landing)/bounties/[id]/page.tsx` (server → client `BountyDetail`).
- **BountyDetail** — two-column: title + mode/status badges + organization, **markdown** description (same `@uiw/react-md-editor` renderer the wizard uses), prize tiers, and a sticky sidebar with the reward pool + eligibility panel (reputation minimum / application window / max applicants / shortlist). Loading + not-found states.
- **BountyEntryCta** — mode-aware CTA: **Claim** (open + single claim), **Join** (open + competition), **Apply** (application entry types). Gated/explained when the bounty isn't accepting, the application window has closed, or the caller already has an active application; shows the caller's status (Submitted / Shortlisted / Selected / …) via `useMyBountyApplication`.

## Scoping notes
- **Entry execution (forms / on-chain op) ships in #624.** The CTA here is correctly labeled + gated and hands off to that flow (placeholder toast + `// #624` marker).
- **`applicationCreditCost` is not in `BountyPublicDto`**, so it's omitted from the eligibility panel (same public-DTO gap family as category/deadline). `reputationMinimum` *is* exposed and shown.
- `useMyBountyApplication` degrades gracefully for logged-out visitors (401 → null → entry CTA).

## Testing
- Pre-commit type-check / eslint / prettier / **build** all pass.
- Smoke-verified live `GET /api/bounties/:id` returns every field the page renders (description, prizeTiers, entryType/claimType, reputationMinimum, organization, …).