### PR TITLE
feat(bounty): apply / join / claim flow + edit/withdraw (mode-aware)

### DIFF
--- a/components/bounties/detail/BountyEntryCta.tsx
+++ b/components/bounties/detail/BountyEntryCta.tsx
@@ -1,32 +1,26 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
-import { CheckCircle2, Lock } from 'lucide-react';
+import { CheckCircle2, Loader2, Lock } from 'lucide-react';
 
 import { BoundlessButton } from '@/components/buttons';
 import { Badge } from '@/components/ui/badge';
-import type { BountyPublic, MyBountyApplication } from '@/features/bounties';
+import { useWalletContext } from '@/components/providers/wallet-provider';
+import {
+  useLeaveCompetition,
+  useWithdrawApplication,
+  useWithdrawApplicationEscrow,
+  type BountyPublic,
+  type MyBountyApplication,
+} from '@/features/bounties';
+import BountyEntryDialog from './entry/BountyEntryDialog';
 
-/** Statuses where a bounty still accepts new entries. */
 const ACCEPTING_STATUSES = new Set([
   'open',
   'open_for_applications',
   'upcoming',
 ]);
-
-type EntryKind = 'claim' | 'join' | 'apply' | 'view';
-
-function entryKind(b: BountyPublic): { kind: EntryKind; label: string } {
-  const open = b.entryType === 'OPEN';
-  const application =
-    b.entryType === 'APPLICATION_LIGHT' || b.entryType === 'APPLICATION_FULL';
-  if (open && b.claimType === 'SINGLE_CLAIM')
-    return { kind: 'claim', label: 'Claim this bounty' };
-  if (open && b.claimType === 'COMPETITION')
-    return { kind: 'join', label: 'Join competition' };
-  if (application) return { kind: 'apply', label: 'Apply' };
-  return { kind: 'view', label: 'View' };
-}
 
 const STATUS_LABEL: Record<string, string> = {
   SUBMITTED: 'Application submitted',
@@ -51,27 +45,78 @@ export function BountyEntryCta({
   bounty: BountyPublic;
   myApplication: MyBountyApplication | null;
 }) {
-  const { label } = entryKind(bounty);
+  const { walletAddress } = useWalletContext();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [confirmWithdraw, setConfirmWithdraw] = useState(false);
+
+  const withdrawApp = useWithdrawApplication(bounty.id);
+  const leave = useLeaveCompetition(bounty.id);
+  const withdrawClaim = useWithdrawApplicationEscrow(bounty.id);
+
+  const isApplication =
+    bounty.entryType === 'APPLICATION_LIGHT' ||
+    bounty.entryType === 'APPLICATION_FULL';
+  const isCompetition =
+    bounty.entryType === 'OPEN' && bounty.claimType === 'COMPETITION';
+
+  const primaryLabel = isApplication
+    ? 'Apply'
+    : isCompetition
+      ? 'Join competition'
+      : 'Claim this bounty';
 
   const deadlinePassed =
     !!bounty.applicationWindowCloseAt &&
     new Date(bounty.applicationWindowCloseAt).getTime() < Date.now();
   const accepting = ACCEPTING_STATUSES.has(bounty.status);
 
-  // An active (non-withdrawn) application means the caller is already in.
-  const activeStatus =
-    myApplication && myApplication.applicationStatus !== 'WITHDRAWN'
-      ? myApplication.applicationStatus
-      : null;
+  const withdrawn =
+    !!myApplication &&
+    (myApplication.applicationStatus === 'WITHDRAWN' ||
+      myApplication.status === 'withdrawn');
+  const isActive = !!myApplication && !withdrawn;
+  // Application records are only mutable while SUBMITTED.
+  const editable =
+    isApplication && myApplication?.applicationStatus === 'SUBMITTED';
 
-  // The real entry flow (forms / on-chain op) ships in #624; the CTA here is
-  // mode-aware and correctly gated, and hands off to that flow.
-  const onEntry = () =>
-    toast.info('The entry flow is coming in the next step (apply/join/claim).');
+  useEffect(() => {
+    if (withdrawClaim.isCompleted) toast.success('Claim withdrawn.');
+    else if (withdrawClaim.isFailed)
+      toast.error(withdrawClaim.error || 'Withdraw failed.');
+  }, [withdrawClaim.isCompleted, withdrawClaim.isFailed, withdrawClaim.error]);
+
+  const handleWithdraw = () => {
+    if (isApplication) {
+      if (!myApplication) return;
+      withdrawApp.mutate(myApplication.id, {
+        onSuccess: () => toast.success('Application withdrawn.'),
+        onError: e =>
+          toast.error((e as Error).message || 'Failed to withdraw.'),
+      });
+    } else if (isCompetition) {
+      if (!walletAddress) return toast.error('Connect a wallet to leave.');
+      leave.mutate(
+        { applicantAddress: walletAddress },
+        {
+          onSuccess: () => toast.success('You left the competition.'),
+          onError: e => toast.error((e as Error).message || 'Failed to leave.'),
+        }
+      );
+    } else {
+      if (!walletAddress) return toast.error('Connect a wallet to withdraw.');
+      void withdrawClaim.run({ applicantAddress: walletAddress });
+    }
+    setConfirmWithdraw(false);
+  };
+
+  const withdrawPending =
+    withdrawApp.isPending || leave.isPending || withdrawClaim.isRunning;
+  const withdrawLabel = isCompetition ? 'Leave competition' : 'Withdraw';
 
   return (
     <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5'>
-      {activeStatus ? (
+      {isActive ? (
         <div className='space-y-3'>
           <div className='flex items-center gap-2'>
             <CheckCircle2 className='text-primary h-4 w-4' />
@@ -79,15 +124,66 @@ export function BountyEntryCta({
               You&apos;re in this bounty
             </span>
           </div>
-          <Badge
-            variant='outline'
-            className={`rounded-full px-3 py-1 text-xs font-medium ${
-              STATUS_CLASS[activeStatus] ??
-              'border-zinc-700 bg-zinc-800/60 text-zinc-300'
-            }`}
-          >
-            {STATUS_LABEL[activeStatus] ?? activeStatus}
-          </Badge>
+          {myApplication?.applicationStatus && (
+            <Badge
+              variant='outline'
+              className={`rounded-full px-3 py-1 text-xs font-medium ${
+                STATUS_CLASS[myApplication.applicationStatus] ??
+                'border-zinc-700 bg-zinc-800/60 text-zinc-300'
+              }`}
+            >
+              {STATUS_LABEL[myApplication.applicationStatus] ??
+                myApplication.applicationStatus}
+            </Badge>
+          )}
+
+          {/* Edit (application, while SUBMITTED) */}
+          {editable && (
+            <BoundlessButton
+              variant='outline'
+              className='w-full'
+              onClick={() => {
+                setEditing(true);
+                setDialogOpen(true);
+              }}
+            >
+              Edit application
+            </BoundlessButton>
+          )}
+
+          {/* Withdraw / leave (two-step confirm) */}
+          {(editable || isCompetition || !isApplication) &&
+            (confirmWithdraw ? (
+              <div className='flex gap-2'>
+                <BoundlessButton
+                  variant='outline'
+                  className='flex-1'
+                  onClick={() => setConfirmWithdraw(false)}
+                  disabled={withdrawPending}
+                >
+                  Cancel
+                </BoundlessButton>
+                <BoundlessButton
+                  className='flex-1 bg-red-500 text-white hover:bg-red-600'
+                  onClick={handleWithdraw}
+                  disabled={withdrawPending}
+                >
+                  {withdrawPending ? (
+                    <Loader2 className='h-4 w-4 animate-spin' />
+                  ) : (
+                    'Confirm'
+                  )}
+                </BoundlessButton>
+              </div>
+            ) : (
+              <BoundlessButton
+                variant='outline'
+                className='w-full text-red-400 hover:bg-red-500/10 hover:text-red-300'
+                onClick={() => setConfirmWithdraw(true)}
+              >
+                {withdrawLabel}
+              </BoundlessButton>
+            ))}
         </div>
       ) : (
         <>
@@ -95,9 +191,12 @@ export function BountyEntryCta({
             size='lg'
             className='w-full'
             disabled={!accepting || deadlinePassed}
-            onClick={onEntry}
+            onClick={() => {
+              setEditing(false);
+              setDialogOpen(true);
+            }}
           >
-            {label}
+            {primaryLabel}
           </BoundlessButton>
           <p className='mt-2 flex items-center justify-center gap-1.5 text-center text-xs text-zinc-500'>
             {!accepting ? (
@@ -110,7 +209,7 @@ export function BountyEntryCta({
                 <Lock className='h-3.5 w-3.5' />
                 Applications have closed.
               </>
-            ) : myApplication?.applicationStatus === 'WITHDRAWN' ? (
+            ) : withdrawn ? (
               'You withdrew earlier — you can enter again.'
             ) : (
               'Funds are held in escrow and paid on-chain to winners.'
@@ -118,6 +217,14 @@ export function BountyEntryCta({
           </p>
         </>
       )}
+
+      <BountyEntryDialog
+        bounty={bounty}
+        existingApplication={myApplication}
+        editing={editing}
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+      />
     </div>
   );
 }

--- a/components/bounties/detail/entry/BountyApplicationForm.tsx
+++ b/components/bounties/detail/entry/BountyApplicationForm.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Loader2 } from 'lucide-react';
+
+import { BoundlessButton } from '@/components/buttons';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  ApplicationEntryType,
+  ApplicationFormData,
+  MAX_LINKS,
+  countWords,
+  emptyApplicationForm,
+  makeApplicationSchema,
+} from './applicationSchema';
+
+interface BountyApplicationFormProps {
+  entryType: ApplicationEntryType;
+  initialData?: Partial<ApplicationFormData>;
+  submitLabel: string;
+  isSubmitting?: boolean;
+  onSubmit: (data: ApplicationFormData) => void;
+  onCancel?: () => void;
+}
+
+export default function BountyApplicationForm({
+  entryType,
+  initialData,
+  submitLabel,
+  isSubmitting = false,
+  onSubmit,
+  onCancel,
+}: BountyApplicationFormProps) {
+  const isFull = entryType === 'APPLICATION_FULL';
+  const form = useForm<ApplicationFormData>({
+    resolver: zodResolver(makeApplicationSchema(entryType)),
+    defaultValues: { ...emptyApplicationForm, ...initialData },
+  });
+
+  const proposalField = isFull ? 'proposalFull' : 'proposalShort';
+  const words = countWords(form.watch(proposalField) ?? '');
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-5'>
+        {/* Proposal */}
+        <FormField
+          control={form.control}
+          name={proposalField}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className='text-sm font-medium text-white'>
+                {isFull ? 'Full proposal' : 'Proposal'}
+                <span className='text-red-500'>*</span>
+              </FormLabel>
+              <FormControl>
+                <Textarea
+                  {...field}
+                  placeholder={
+                    isFull
+                      ? 'Describe your approach, plan, and what done looks like (500–2000 words).'
+                      : 'Outline how you would tackle this (100–300 words).'
+                  }
+                  className='min-h-40 resize-y border-zinc-800 bg-zinc-900/50 text-white placeholder:text-zinc-600'
+                />
+              </FormControl>
+              <p className='text-xs text-zinc-500'>{words} words</p>
+              <FormMessage className='text-xs text-red-500' />
+            </FormItem>
+          )}
+        />
+
+        {/* Light: estimated days */}
+        {!isFull && (
+          <FormField
+            control={form.control}
+            name='estimatedDays'
+            render={({ field }) => (
+              <FormItem className='max-w-40'>
+                <FormLabel className='text-sm font-medium text-white'>
+                  Estimated days<span className='text-red-500'>*</span>
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    type='number'
+                    min={1}
+                    max={365}
+                    placeholder='14'
+                    className='h-10 border-zinc-800 bg-zinc-900/50 text-white'
+                  />
+                </FormControl>
+                <FormMessage className='text-xs text-red-500' />
+              </FormItem>
+            )}
+          />
+        )}
+
+        {/* Full: qualifications */}
+        {isFull && (
+          <FormField
+            control={form.control}
+            name='qualifications'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className='text-sm font-medium text-white'>
+                  Qualifications<span className='text-red-500'>*</span>
+                </FormLabel>
+                <FormControl>
+                  <Textarea
+                    {...field}
+                    placeholder="Relevant experience and why you're a fit."
+                    className='min-h-24 resize-y border-zinc-800 bg-zinc-900/50 text-white placeholder:text-zinc-600'
+                  />
+                </FormControl>
+                <FormMessage className='text-xs text-red-500' />
+              </FormItem>
+            )}
+          />
+        )}
+
+        {/* Portfolio links */}
+        <FormField
+          control={form.control}
+          name='portfolioLinksRaw'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className='text-sm font-medium text-white'>
+                Portfolio links{' '}
+                <span className='text-zinc-500'>
+                  (one per line, up to {MAX_LINKS[entryType]})
+                </span>
+              </FormLabel>
+              <FormControl>
+                <Textarea
+                  {...field}
+                  placeholder={'https://github.com/you/project\nhttps://...'}
+                  className='min-h-20 resize-y border-zinc-800 bg-zinc-900/50 text-white placeholder:text-zinc-600'
+                />
+              </FormControl>
+              <FormMessage className='text-xs text-red-500' />
+            </FormItem>
+          )}
+        />
+
+        {/* Full: video intro */}
+        {isFull && (
+          <FormField
+            control={form.control}
+            name='videoIntroUrl'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className='text-sm font-medium text-white'>
+                  Video intro <span className='text-zinc-500'>(optional)</span>
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    type='url'
+                    placeholder='https://...'
+                    className='h-10 border-zinc-800 bg-zinc-900/50 text-white'
+                  />
+                </FormControl>
+                <FormMessage className='text-xs text-red-500' />
+              </FormItem>
+            )}
+          />
+        )}
+
+        <div className='flex items-center justify-end gap-3 pt-2'>
+          {onCancel && (
+            <BoundlessButton
+              type='button'
+              variant='outline'
+              onClick={onCancel}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </BoundlessButton>
+          )}
+          <BoundlessButton
+            type='submit'
+            disabled={isSubmitting}
+            className='min-w-32'
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                Submitting...
+              </>
+            ) : (
+              submitLabel
+            )}
+          </BoundlessButton>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/components/bounties/detail/entry/BountyEntryDialog.tsx
+++ b/components/bounties/detail/entry/BountyEntryDialog.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { toast } from 'sonner';
+import { AlertTriangle, Loader2, Wallet } from 'lucide-react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { BoundlessButton } from '@/components/buttons';
+import { useWalletContext } from '@/components/providers/wallet-provider';
+import {
+  useApplyToBounty,
+  useApplyToBountyEscrow,
+  useEditApplication,
+  useJoinCompetition,
+  type BountyPublic,
+  type MyBountyApplication,
+} from '@/features/bounties';
+import BountyApplicationForm from './BountyApplicationForm';
+import {
+  type ApplicationEntryType,
+  type ApplicationFormData,
+  toCreateBody,
+  toEditBody,
+} from './applicationSchema';
+
+type Action = 'apply' | 'edit' | 'join' | 'claim';
+
+function actionFor(bounty: BountyPublic, editing: boolean): Action {
+  const application =
+    bounty.entryType === 'APPLICATION_LIGHT' ||
+    bounty.entryType === 'APPLICATION_FULL';
+  if (application) return editing ? 'edit' : 'apply';
+  if (bounty.entryType === 'OPEN' && bounty.claimType === 'COMPETITION')
+    return 'join';
+  return 'claim'; // OPEN + SINGLE_CLAIM
+}
+
+/** Map an existing application to the form's field shape (for editing). */
+function toFormData(app: MyBountyApplication): Partial<ApplicationFormData> {
+  return {
+    proposalShort: app.proposalShort ?? '',
+    proposalFull: app.proposalFull ?? '',
+    qualifications: app.qualifications ?? '',
+    estimatedDays: app.estimatedDays != null ? String(app.estimatedDays) : '',
+    portfolioLinksRaw: (app.portfolioLinks ?? []).join('\n'),
+    videoIntroUrl: app.videoIntroUrl ?? '',
+  };
+}
+
+interface BountyEntryDialogProps {
+  bounty: BountyPublic;
+  existingApplication?: MyBountyApplication | null;
+  editing?: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function BountyEntryDialog({
+  bounty,
+  existingApplication,
+  editing = false,
+  open,
+  onOpenChange,
+}: BountyEntryDialogProps) {
+  const { walletAddress } = useWalletContext();
+  const action = actionFor(bounty, editing);
+
+  const apply = useApplyToBounty(bounty.id);
+  const edit = useEditApplication(bounty.id);
+  const join = useJoinCompetition(bounty.id);
+  const claim = useApplyToBountyEscrow(bounty.id);
+
+  // Close + toast once the on-chain claim reaches a terminal state.
+  useEffect(() => {
+    if (!open) return;
+    if (claim.isCompleted) {
+      toast.success('Bounty claimed. You can start working.');
+      onOpenChange(false);
+    } else if (claim.isFailed) {
+      toast.error(claim.error || 'Claim failed. Please try again.');
+    }
+  }, [open, claim.isCompleted, claim.isFailed, claim.error, onOpenChange]);
+
+  const needsWallet = action !== 'edit' && !walletAddress;
+
+  const entryType = bounty.entryType as ApplicationEntryType;
+
+  const handleApply = (data: ApplicationFormData) => {
+    if (!walletAddress) return;
+    apply.mutate(toCreateBody(entryType, data, walletAddress), {
+      onSuccess: () => {
+        toast.success('Application submitted.');
+        onOpenChange(false);
+      },
+      onError: e => toast.error((e as Error).message || 'Failed to apply.'),
+    });
+  };
+
+  const handleEdit = (data: ApplicationFormData) => {
+    if (!existingApplication) return;
+    edit.mutate(
+      { appId: existingApplication.id, body: toEditBody(entryType, data) },
+      {
+        onSuccess: () => {
+          toast.success('Application updated.');
+          onOpenChange(false);
+        },
+        onError: e => toast.error((e as Error).message || 'Failed to update.'),
+      }
+    );
+  };
+
+  const handleJoin = () => {
+    if (!walletAddress) return;
+    join.mutate(
+      { applicantAddress: walletAddress },
+      {
+        onSuccess: () => {
+          toast.success("You've joined the competition.");
+          onOpenChange(false);
+        },
+        onError: e => toast.error((e as Error).message || 'Failed to join.'),
+      }
+    );
+  };
+
+  const handleClaim = () => {
+    if (!walletAddress) return;
+    void claim.run({ applicantAddress: walletAddress });
+  };
+
+  const title =
+    action === 'edit'
+      ? 'Edit your application'
+      : action === 'apply'
+        ? 'Apply to this bounty'
+        : action === 'join'
+          ? 'Join this competition'
+          : 'Claim this bounty';
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='max-h-[90vh] overflow-y-auto border-zinc-800 bg-zinc-950 sm:max-w-lg'>
+        <DialogHeader>
+          <DialogTitle className='text-white'>{title}</DialogTitle>
+          <DialogDescription className='text-zinc-400'>
+            {action === 'claim'
+              ? 'You will work this bounty exclusively. Funds are held in escrow and paid on-chain on completion.'
+              : action === 'join'
+                ? 'Submit your work before the deadline; winners are paid on-chain.'
+                : 'Tell the organizer why you are a fit. You can edit while your application is still under review.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Reputation pre-check (open + single claim) */}
+        {action === 'claim' && bounty.reputationMinimum != null && (
+          <div className='flex items-start gap-2 rounded-lg border border-zinc-800 bg-zinc-900/50 p-3 text-xs text-zinc-400'>
+            <AlertTriangle className='mt-0.5 h-4 w-4 shrink-0 text-amber-500' />
+            <span>
+              This bounty requires a minimum reputation of{' '}
+              <span className='font-medium text-white'>
+                {bounty.reputationMinimum}
+              </span>{' '}
+              to claim. Your claim is rejected on-chain if you don&apos;t meet
+              it.
+            </span>
+          </div>
+        )}
+
+        {needsWallet ? (
+          <div className='flex flex-col items-center gap-3 py-6 text-center'>
+            <Wallet className='h-8 w-8 text-zinc-500' />
+            <p className='text-sm text-zinc-400'>
+              Connect a wallet to {action === 'join' ? 'join' : action}.
+            </p>
+          </div>
+        ) : action === 'apply' ? (
+          <BountyApplicationForm
+            entryType={entryType}
+            submitLabel='Submit application'
+            isSubmitting={apply.isPending}
+            onSubmit={handleApply}
+            onCancel={() => onOpenChange(false)}
+          />
+        ) : action === 'edit' ? (
+          <BountyApplicationForm
+            entryType={entryType}
+            initialData={
+              existingApplication ? toFormData(existingApplication) : undefined
+            }
+            submitLabel='Save changes'
+            isSubmitting={edit.isPending}
+            onSubmit={handleEdit}
+            onCancel={() => onOpenChange(false)}
+          />
+        ) : action === 'join' ? (
+          <div className='flex items-center justify-end gap-3 pt-2'>
+            <BoundlessButton
+              variant='outline'
+              onClick={() => onOpenChange(false)}
+              disabled={join.isPending}
+            >
+              Cancel
+            </BoundlessButton>
+            <BoundlessButton
+              onClick={handleJoin}
+              disabled={join.isPending}
+              className='min-w-32'
+            >
+              {join.isPending ? (
+                <>
+                  <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                  Joining...
+                </>
+              ) : (
+                'Join competition'
+              )}
+            </BoundlessButton>
+          </div>
+        ) : (
+          // claim (open + single) — on-chain
+          <div className='space-y-4'>
+            {claim.isRunning ? (
+              <div className='flex items-center gap-3 rounded-lg border border-zinc-800 bg-zinc-900/50 p-4 text-sm text-zinc-300'>
+                <Loader2 className='text-primary h-5 w-5 animate-spin' />
+                <span>
+                  Claiming on-chain…{' '}
+                  <span className='text-zinc-500'>({claim.phase})</span>
+                </span>
+              </div>
+            ) : (
+              <div className='flex items-center justify-end gap-3 pt-2'>
+                <BoundlessButton
+                  variant='outline'
+                  onClick={() => onOpenChange(false)}
+                >
+                  Cancel
+                </BoundlessButton>
+                <BoundlessButton onClick={handleClaim} className='min-w-32'>
+                  Claim bounty
+                </BoundlessButton>
+              </div>
+            )}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/bounties/detail/entry/applicationSchema.ts
+++ b/components/bounties/detail/entry/applicationSchema.ts
@@ -1,0 +1,182 @@
+import { z } from 'zod';
+
+import type {
+  CreateBountyApplicationRequest,
+  EditBountyApplicationRequest,
+} from '@/features/bounties';
+
+export type ApplicationEntryType = 'APPLICATION_LIGHT' | 'APPLICATION_FULL';
+
+const WORD_BOUNDS = {
+  APPLICATION_LIGHT: { min: 100, max: 300 },
+  APPLICATION_FULL: { min: 500, max: 2000 },
+} as const;
+
+export const MAX_LINKS = {
+  APPLICATION_LIGHT: 3,
+  APPLICATION_FULL: 6,
+} as const;
+
+export const countWords = (s: string): number =>
+  s.trim() ? s.trim().split(/\s+/).length : 0;
+
+/** Parse a "one link per line" textarea into a trimmed, non-empty list. */
+export const parseLinks = (raw: string): string[] =>
+  raw
+    .split('\n')
+    .map(l => l.trim())
+    .filter(Boolean);
+
+const isUrl = (s: string): boolean => {
+  try {
+    new URL(s);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export interface ApplicationFormData {
+  proposalShort: string;
+  proposalFull: string;
+  qualifications: string;
+  estimatedDays: string;
+  portfolioLinksRaw: string;
+  videoIntroUrl: string;
+}
+
+export const emptyApplicationForm: ApplicationFormData = {
+  proposalShort: '',
+  proposalFull: '',
+  qualifications: '',
+  estimatedDays: '',
+  portfolioLinksRaw: '',
+  videoIntroUrl: '',
+};
+
+/** Mode-aware application validation, mirroring the backend per-entry-type rules. */
+export function makeApplicationSchema(entryType: ApplicationEntryType) {
+  const isFull = entryType === 'APPLICATION_FULL';
+  const maxLinks = MAX_LINKS[entryType];
+
+  return z
+    .object({
+      proposalShort: z.string(),
+      proposalFull: z.string(),
+      qualifications: z.string(),
+      estimatedDays: z.string(),
+      portfolioLinksRaw: z.string(),
+      videoIntroUrl: z.string(),
+    })
+    .superRefine((data, ctx) => {
+      if (isFull) {
+        const words = countWords(data.proposalFull);
+        const { min, max } = WORD_BOUNDS.APPLICATION_FULL;
+        if (words < min || words > max) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['proposalFull'],
+            message: `Full proposal must be ${min}–${max} words (currently ${words}).`,
+          });
+        }
+        if (data.qualifications.trim().length < 50) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['qualifications'],
+            message: 'Qualifications must be at least 50 characters.',
+          });
+        }
+        if (data.videoIntroUrl.trim() && !isUrl(data.videoIntroUrl.trim())) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['videoIntroUrl'],
+            message: 'Enter a valid URL.',
+          });
+        }
+      } else {
+        const words = countWords(data.proposalShort);
+        const { min, max } = WORD_BOUNDS.APPLICATION_LIGHT;
+        if (words < min || words > max) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['proposalShort'],
+            message: `Proposal must be ${min}–${max} words (currently ${words}).`,
+          });
+        }
+        const days = Number(data.estimatedDays);
+        if (
+          !data.estimatedDays.trim() ||
+          Number.isNaN(days) ||
+          days < 1 ||
+          days > 365
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['estimatedDays'],
+            message: 'Enter an estimate between 1 and 365 days.',
+          });
+        }
+      }
+
+      const links = parseLinks(data.portfolioLinksRaw);
+      if (links.length > maxLinks) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['portfolioLinksRaw'],
+          message: `Up to ${maxLinks} links allowed.`,
+        });
+      }
+      if (links.some(l => !isUrl(l))) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['portfolioLinksRaw'],
+          message: 'Each line must be a valid URL.',
+        });
+      }
+    });
+}
+
+/** Build the POST body from the form (applicantAddress added by the caller). */
+export function toCreateBody(
+  entryType: ApplicationEntryType,
+  data: ApplicationFormData,
+  applicantAddress: string
+): CreateBountyApplicationRequest {
+  const links = parseLinks(data.portfolioLinksRaw);
+  if (entryType === 'APPLICATION_FULL') {
+    return {
+      applicantAddress,
+      proposalFull: data.proposalFull.trim(),
+      qualifications: data.qualifications.trim(),
+      portfolioLinks: links,
+      videoIntroUrl: data.videoIntroUrl.trim() || undefined,
+    };
+  }
+  return {
+    applicantAddress,
+    proposalShort: data.proposalShort.trim(),
+    estimatedDays: Number(data.estimatedDays),
+    portfolioLinks: links,
+  };
+}
+
+/** Build the PATCH body (no applicantAddress; edit only mutates proposal fields). */
+export function toEditBody(
+  entryType: ApplicationEntryType,
+  data: ApplicationFormData
+): EditBountyApplicationRequest {
+  const links = parseLinks(data.portfolioLinksRaw);
+  if (entryType === 'APPLICATION_FULL') {
+    return {
+      proposalFull: data.proposalFull.trim(),
+      qualifications: data.qualifications.trim(),
+      portfolioLinks: links,
+      videoIntroUrl: data.videoIntroUrl.trim() || undefined,
+    };
+  }
+  return {
+    proposalShort: data.proposalShort.trim(),
+    estimatedDays: Number(data.estimatedDays),
+    portfolioLinks: links,
+  };
+}


### PR DESCRIPTION
Closes #624.

> **Stacked on #646 (#623) → #645 (#622) → #643 (#621).** Until those merge into `feat/t-replace`, this PR's diff also shows their commits; it reduces to just the entry flow once they land. Merge order: #643 → #645 → #646 → this.

## What

Fills the entry execution the detail-page CTA hands off to (#623), wired to the participant data layer (#621). Covers all six modes.

- **applicationSchema.ts** — mode-aware Zod validation + request-body builders. Light: `proposalShort` 100–300 words + `estimatedDays` (1–365) + ≤3 portfolio links. Full: `proposalFull` 500–2000 words + `qualifications` ≥50 chars + ≤6 links + optional `videoIntroUrl`. (Bounds match the backend.)
- **BountyApplicationForm.tsx** — conditional fields per entry type, live word count; reused for **create** and **edit**.
- **BountyEntryDialog.tsx** — the mode-aware modal:
  - **Apply** (application modes) → `useApplyToBounty` (POST `v2/applications`); **Edit** prefilled → `useEditApplication` (PATCH).
  - **Join** (open + competition) → `useJoinCompetition` (POST `v2/competition/join`).
  - **Claim** (open + single claim) → on-chain `useApplyToBountyEscrow` (MANAGED) with live progress (`phase`) + the reputation pre-check surfaced.
  - Wallet-gated (uses `useWalletContext().walletAddress` as `applicantAddress`).
- **BountyEntryCta.tsx** (rewired) — opens the dialog (replaces the #623 placeholder), and for an active application exposes **Edit** + **Withdraw** (application, while SUBMITTED), **Leave** (competition → `useLeaveCompetition`), or on-chain **Withdraw** (single claim → `useWithdrawApplicationEscrow`), each behind a two-step confirm.

## Testing / boundary
- Pre-commit type-check / eslint / prettier / **build** all pass; mode→endpoint mappings match the issue; word bounds match the backend service.
- **The POST + on-chain flows need auth + a connected wallet to exercise end-to-end** (REST mutations are auth-gated; claim/withdraw are escrow ops), so they want a manual in-browser pass with a logged-in user + wallet.
- `applicationCreditCost` pre-check isn't shown (not in `BountyPublicDto` — known public-DTO gap); the **reputation** pre-check is surfaced.