### PR TITLE
ci: auto-close linked issues on merge to any base branch

### DIFF
--- a/.github/workflows/close-linked-issues.yml
+++ b/.github/workflows/close-linked-issues.yml
@@ -1,0 +1,84 @@
+name: Close Linked Issues
+
+# Auto-close issues referenced with Closes/Fixes/Resolves #N when a PR merges.
+#
+# GitHub's built-in auto-close only fires for PRs merged into the default branch
+# (main). This repo's feature PRs merge into integration branches such as
+# feat/t-replace, so linked issues are otherwise left open. This workflow closes
+# them on any base branch.
+#
+# pull_request_target runs in the base-repo context, so it has an issues:write
+# token even for PRs opened from forks (the normal pull_request event would get
+# a read-only token). It never checks out or runs PR head code, so it is safe.
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  close-linked-issues:
+    name: Close linked issues
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Close issues referenced in the PR body
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+
+            // Match "<keyword> #123" / "<keyword>: #123", keyword case-insensitive.
+            const keyword = '(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)';
+            const re = new RegExp(`${keyword}\\s*:?\\s+#(\\d+)`, 'gi');
+
+            const numbers = new Set();
+            for (const m of body.matchAll(re)) {
+              numbers.add(Number(m[1]));
+            }
+
+            if (numbers.size === 0) {
+              core.info('No "Closes/Fixes/Resolves #N" references found in the PR body.');
+              return;
+            }
+
+            for (const issue_number of numbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                });
+
+                // Skip PRs (the API treats PRs as issues) and already-closed issues.
+                if (issue.pull_request) {
+                  core.info(`#${issue_number} is a pull request, skipping.`);
+                  continue;
+                }
+                if (issue.state === 'closed') {
+                  core.info(`#${issue_number} is already closed, skipping.`);
+                  continue;
+                }
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  body: `Closed by #${pr.number} (merged into \`${pr.base.ref}\`).`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+                core.info(`Closed #${issue_number}.`);
+              } catch (err) {
+                core.warning(`Could not close #${issue_number}: ${err.message}`);
+              }
+            }


### PR DESCRIPTION
## What

Adds `.github/workflows/close-linked-issues.yml` — a workflow that closes issues referenced with `Closes`/`Fixes`/`Resolves #N` in a PR body when that PR merges, **regardless of which base branch it targets**.

## Why

GitHub's built-in auto-close only fires for PRs merged into the repository's **default branch** (`main`). Our feature PRs merge into integration branches like `feat/t-replace`, so linked issues stay open and have to be closed by hand (we just hit this with the entire bounty participant stack, #621 through #626).

## How it works

- Trigger: `pull_request_target` with `types: [closed]`, gated on `merged == true`.
- `pull_request_target` runs in the base-repo context, so it gets an `issues: write` token even for PRs opened from forks (the plain `pull_request` event would only get a read-only token). It never checks out or runs PR head code, so there's no untrusted-code risk.
- Parses the merged PR body for `Closes/Fixes/Resolves #N` (case-insensitive, optional colon), then comments and closes each referenced same-repo issue. Skips anything that's a PR or already closed.

## Notes

- Because `pull_request_target` reads the workflow from the **base branch**, this only takes effect for PRs targeting `feat/t-replace` once merged here. The backend repo (PRs into `v2`) would need the same file added there separately.
- No effect on existing CI; it's an isolated, additive workflow.