### PR TITLE
feat(bounty): submission page, marketplace redesign, and organizer requirements

### DIFF
--- a/app/(landing)/bounties/[id]/submit/page.tsx
+++ b/app/(landing)/bounties/[id]/submit/page.tsx
@@ -1,0 +1,22 @@
+import { Metadata } from 'next';
+
+import { generatePageMetadata } from '@/lib/metadata';
+import BountySubmitGate from '@/components/bounties/detail/submit/BountySubmitGate';
+
+export const metadata: Metadata = generatePageMetadata('bounties');
+
+interface BountySubmitPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function BountySubmitPageRoute({
+  params,
+}: BountySubmitPageProps) {
+  const { id } = await params;
+
+  return (
+    <div className='relative mx-auto min-h-screen max-w-[1440px] px-5 py-8 md:px-[50px] lg:px-[100px]'>
+      <BountySubmitGate id={id} />
+    </div>
+  );
+}

--- a/components/bounties/DueCountdown.tsx
+++ b/components/bounties/DueCountdown.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Clock } from 'lucide-react';
+
+/** Format remaining time to a deadline as "Due in 4d:21h:22m" (null once past). */
+export function formatCountdown(
+  deadlineIso: string,
+  now: number
+): string | null {
+  const diff = new Date(deadlineIso).getTime() - now;
+  if (diff <= 0) return null;
+  const d = Math.floor(diff / 86_400_000);
+  const h = Math.floor((diff % 86_400_000) / 3_600_000);
+  const m = Math.floor((diff % 3_600_000) / 60_000);
+  return `Due in ${d}d:${h}h:${m}m`;
+}
+
+/** Live-ticking due-date countdown (minute granularity). */
+export function DueCountdown({
+  deadline,
+  className = 'flex items-center gap-1.5 text-xs text-zinc-500',
+}: {
+  deadline: string;
+  className?: string;
+}) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(id);
+  }, []);
+  const label = formatCountdown(deadline, now);
+  return (
+    <span className={className}>
+      <Clock className='h-3.5 w-3.5' />
+      {label ?? 'Due date passed'}
+    </span>
+  );
+}

--- a/components/bounties/detail/BountyDetail.tsx
+++ b/components/bounties/detail/BountyDetail.tsx
@@ -3,21 +3,33 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
-import {
-  ArrowLeft,
-  Award,
-  Calendar,
-  Loader2,
-  Target,
-  Users,
-} from 'lucide-react';
+import Image from 'next/image';
+import { ArrowLeft, Award, Calendar, Info, Loader2, Users } from 'lucide-react';
 
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import EmptyState from '@/components/EmptyState';
-import { computeBountyModeLabel } from '@/components/organization/bounties/new/tabs/schemas/modeSchema';
-import { useBounty, useMyBountyApplication } from '@/features/bounties';
+import {
+  computeBountyModeLabel,
+  computeBountyModeDescription,
+} from '@/components/organization/bounties/new/tabs/schemas/modeSchema';
+import {
+  CATEGORY_LABELS,
+  type BountyCategory,
+} from '@/components/organization/bounties/new/tabs/schemas/scopeSchema';
+import {
+  useBounty,
+  useMyBountyApplication,
+  useMyBountySubmission,
+} from '@/features/bounties';
 import { BountyEntryCta } from './BountyEntryCta';
 import BountySubmitPanel from './submit/BountySubmitPanel';
+import { DueCountdown } from '../DueCountdown';
 
 // Markdown renderer (matches the wizard's editor package).
 const Markdown = dynamic(
@@ -42,6 +54,10 @@ const ordinal = (n: number): string => {
 export default function BountyDetail({ id }: { id: string }) {
   const { data: bounty, isLoading, error } = useBounty(id);
   const { data: myApplication } = useMyBountyApplication(id);
+  const { data: mySubmission } = useMyBountySubmission(id);
+  // An anchored (non-withdrawn) submission must be withdrawn before the
+  // application/claim can be withdrawn (the contract enforces this order).
+  const hasActiveSubmission = mySubmission?.escrowAnchorStatus === 'active';
 
   if (isLoading) {
     return (
@@ -75,7 +91,15 @@ export default function BountyDetail({ id }: { id: string }) {
     bounty.entryType && bounty.claimType
       ? computeBountyModeLabel(bounty.entryType, bounty.claimType)
       : 'Bounty';
+  const modeDescription =
+    bounty.entryType && bounty.claimType
+      ? computeBountyModeDescription(bounty.entryType, bounty.claimType)
+      : null;
   const currency = bounty.rewardCurrency;
+  const isUsdc = currency?.toUpperCase() === 'USDC';
+  const categoryLabel = bounty.category
+    ? (CATEGORY_LABELS[bounty.category as BountyCategory] ?? bounty.category)
+    : null;
 
   return (
     <div>
@@ -91,26 +115,61 @@ export default function BountyDetail({ id }: { id: string }) {
         {/* Main */}
         <div className='min-w-0'>
           <div className='mb-4 flex flex-wrap items-center gap-2'>
-            <Badge
-              variant='outline'
-              className='rounded-full border-zinc-700 bg-zinc-800/60 px-3 py-1 text-xs font-medium text-zinc-200'
-            >
-              {modeLabel}
-            </Badge>
+            {modeDescription ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Badge
+                    variant='outline'
+                    className='flex cursor-help items-center gap-1 rounded-full border-zinc-700 bg-zinc-800/60 px-3 py-1 text-xs font-medium text-zinc-200'
+                  >
+                    {modeLabel}
+                    <Info className='h-3 w-3 text-zinc-400' />
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent className='max-w-xs text-xs leading-relaxed'>
+                  {modeDescription}
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <Badge
+                variant='outline'
+                className='rounded-full border-zinc-700 bg-zinc-800/60 px-3 py-1 text-xs font-medium text-zinc-200'
+              >
+                {modeLabel}
+              </Badge>
+            )}
             <Badge
               variant='outline'
               className='rounded-full border-zinc-700 bg-zinc-800/60 px-3 py-1 text-xs font-medium text-zinc-300 capitalize'
             >
               {bounty.status.replace(/_/g, ' ')}
             </Badge>
+            {categoryLabel && (
+              <Badge
+                variant='outline'
+                className='rounded-full border-zinc-700 bg-zinc-800/40 px-3 py-1 text-xs font-medium text-zinc-300'
+              >
+                {categoryLabel}
+              </Badge>
+            )}
           </div>
 
           <h1 className='text-2xl font-bold tracking-tight text-white sm:text-3xl'>
             {bounty.title}
           </h1>
-          <p className='mt-2 text-sm text-zinc-400'>
-            by <span className='text-zinc-200'>{bounty.organization.name}</span>
-          </p>
+          <div className='mt-2 flex items-center gap-2 text-sm text-zinc-400'>
+            <span>by</span>
+            <Avatar className='h-5 w-5'>
+              <AvatarImage
+                src={bounty.organization.logo ?? undefined}
+                alt={bounty.organization.name}
+              />
+              <AvatarFallback className='text-[10px]'>
+                {bounty.organization.name.charAt(0).toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
+            <span className='text-zinc-200'>{bounty.organization.name}</span>
+          </div>
 
           {/* Description (markdown) */}
           <div className='boundless-markdown mt-8' data-color-mode='dark'>
@@ -154,9 +213,20 @@ export default function BountyDetail({ id }: { id: string }) {
           {/* Reward */}
           <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5'>
             <div className='flex items-center gap-3'>
-              <div className='bg-primary/10 flex h-11 w-11 items-center justify-center rounded-xl'>
-                <Target className='text-primary h-5 w-5' />
-              </div>
+              {isUsdc ? (
+                <Image
+                  src='/assets/usdc.svg'
+                  alt='USDC'
+                  width={44}
+                  height={44}
+                  unoptimized
+                  className='h-11 w-11'
+                />
+              ) : (
+                <div className='bg-primary/10 flex h-11 w-11 items-center justify-center rounded-xl'>
+                  <Award className='text-primary h-5 w-5' />
+                </div>
+              )}
               <div>
                 <p className='text-primary text-xl font-bold'>
                   {bounty.rewardAmount > 0
@@ -169,6 +239,17 @@ export default function BountyDetail({ id }: { id: string }) {
 
             {/* Eligibility / mode facts */}
             <dl className='mt-4 space-y-2 border-t border-zinc-800 pt-4 text-sm'>
+              {bounty.submissionDeadline && (
+                <div className='flex items-center justify-between gap-3'>
+                  <dt className='text-zinc-400'>Deadline</dt>
+                  <dd className='text-right'>
+                    <DueCountdown
+                      deadline={bounty.submissionDeadline}
+                      className='flex items-center gap-1.5 text-xs font-medium text-zinc-200'
+                    />
+                  </dd>
+                </div>
+              )}
               {bounty.entryType === 'OPEN' &&
                 bounty.claimType === 'SINGLE_CLAIM' &&
                 bounty.reputationMinimum != null && (
@@ -204,12 +285,14 @@ export default function BountyDetail({ id }: { id: string }) {
           <BountyEntryCta
             bounty={bounty}
             myApplication={myApplication ?? null}
+            hasActiveSubmission={hasActiveSubmission}
           />
 
           {/* Submit work (shown when the builder is eligible) */}
           <BountySubmitPanel
             bounty={bounty}
             myApplication={myApplication ?? null}
+            hasActiveSubmission={hasActiveSubmission}
           />
         </aside>
       </div>

--- a/components/bounties/detail/BountyEntryCta.tsx
+++ b/components/bounties/detail/BountyEntryCta.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { toast } from 'sonner';
-import { CheckCircle2, Loader2, Lock } from 'lucide-react';
+import { CheckCircle2, ChevronRight, Loader2, Lock } from 'lucide-react';
 
 import { BoundlessButton } from '@/components/buttons';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { useWalletContext } from '@/components/providers/wallet-provider';
 import {
@@ -41,9 +43,12 @@ const STATUS_CLASS: Record<string, string> = {
 export function BountyEntryCta({
   bounty,
   myApplication,
+  hasActiveSubmission = false,
 }: {
   bounty: BountyPublic;
   myApplication: MyBountyApplication | null;
+  /** An anchored submission blocks application/claim withdrawal until pulled. */
+  hasActiveSubmission?: boolean;
 }) {
   const { walletAddress } = useWalletContext();
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -76,6 +81,10 @@ export function BountyEntryCta({
     (myApplication.applicationStatus === 'WITHDRAWN' ||
       myApplication.status === 'withdrawn');
   const isActive = !!myApplication && !withdrawn;
+  // A single-claim bounty taken by someone else. The claimant themselves sees
+  // the "you're in this bounty" branch, so this is the locked view for others.
+  const claimant = bounty.claimedBy ?? null;
+  const claimedByOther = !isActive && !!claimant;
   // Application records are only mutable while SUBMITTED.
   const editable =
     isApplication && myApplication?.applicationStatus === 'SUBMITTED';
@@ -175,6 +184,20 @@ export function BountyEntryCta({
                   )}
                 </BoundlessButton>
               </div>
+            ) : hasActiveSubmission ? (
+              <div className='space-y-1.5'>
+                <BoundlessButton
+                  variant='outline'
+                  className='w-full text-zinc-500'
+                  disabled
+                >
+                  {withdrawLabel}
+                </BoundlessButton>
+                <p className='flex items-center gap-1.5 text-xs text-zinc-500'>
+                  <Lock className='h-3.5 w-3.5' />
+                  Withdraw your submission first.
+                </p>
+              </div>
             ) : (
               <BoundlessButton
                 variant='outline'
@@ -184,6 +207,35 @@ export function BountyEntryCta({
                 {withdrawLabel}
               </BoundlessButton>
             ))}
+        </div>
+      ) : claimedByOther ? (
+        <div className='space-y-3'>
+          <div className='flex items-center gap-2'>
+            <Lock className='h-4 w-4 text-zinc-400' />
+            <span className='text-sm font-medium text-white'>Claimed</span>
+          </div>
+          <Link
+            href={`/profile/${claimant!.username}`}
+            target='_blank'
+            className='group flex items-center gap-3 rounded-xl border border-zinc-800 bg-zinc-900/60 p-3 transition-colors hover:border-zinc-700 hover:bg-zinc-800/60'
+          >
+            <Avatar className='h-9 w-9'>
+              <AvatarImage
+                src={claimant!.avatarUrl ?? undefined}
+                alt={claimant!.username}
+              />
+              <AvatarFallback className='text-xs'>
+                {claimant!.username.charAt(0).toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
+            <div className='min-w-0 flex-1'>
+              <p className='truncate text-sm font-medium text-white group-hover:underline'>
+                @{claimant!.username}
+              </p>
+              <p className='text-xs text-zinc-500'>View profile</p>
+            </div>
+            <ChevronRight className='h-4 w-4 shrink-0 text-zinc-500 transition-transform group-hover:translate-x-0.5 group-hover:text-zinc-300' />
+          </Link>
         </div>
       ) : (
         <>

--- a/components/bounties/detail/submit/BountySubmitForm.tsx
+++ b/components/bounties/detail/submit/BountySubmitForm.tsx
@@ -1,0 +1,348 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Image from 'next/image';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import {
+  FileText,
+  Github,
+  Loader2,
+  PlaySquare,
+  Twitter,
+  UploadCloud,
+  Wallet,
+  X,
+} from 'lucide-react';
+
+import { BoundlessButton } from '@/components/buttons';
+import { Input } from '@/components/ui/input';
+import { uploadService } from '@/lib/api/upload';
+import { useWalletContext } from '@/components/providers/wallet-provider';
+import {
+  useSubmitBounty,
+  type BountyPublic,
+  type EscrowRunPhase,
+} from '@/features/bounties';
+
+const PHASE_LABEL: Record<EscrowRunPhase, string> = {
+  idle: '',
+  starting: 'Preparing submission…',
+  signing: 'Signing…',
+  submitting: 'Submitting…',
+  polling: 'Anchoring on-chain…',
+  completed: 'Confirmed',
+  failed: 'Failed',
+};
+
+type Requirements = BountyPublic['submissionRequirements'];
+
+function makeSchema(req: Requirements) {
+  const url = z.string().trim().url('Enter a valid URL');
+  // Optional fields accept a valid URL or an empty string (never undefined, so
+  // the resolver output stays a uniform `string` for every field).
+  const optionalUrl = z.union([url, z.literal('')]);
+  return z.object({
+    contentUri: url,
+    documentationUrl: req.documentation ? url : optionalUrl,
+    tweetUrl: req.tweet ? url : optionalUrl,
+    demoVideoUrl: req.demoVideo ? url : optionalUrl,
+  });
+}
+
+type FormValues = {
+  contentUri: string;
+  documentationUrl: string;
+  tweetUrl: string;
+  demoVideoUrl: string;
+};
+
+/** Icon-led URL field matching the entry form layout. */
+function LinkField({
+  icon,
+  error,
+  required,
+  ...props
+}: {
+  icon: React.ReactNode;
+  error?: string;
+  required?: boolean;
+} & React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <div>
+      <div className='flex items-center gap-3'>
+        <div className='flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border border-zinc-800 bg-zinc-900/60 text-zinc-400'>
+          {icon}
+        </div>
+        <Input
+          type='url'
+          className='h-12 flex-1 border-zinc-800 bg-zinc-900/40 text-white placeholder:text-zinc-600'
+          {...props}
+        />
+      </div>
+      {required && <span className='sr-only'>required</span>}
+      {error && <p className='mt-1.5 text-xs text-red-500'>{error}</p>}
+    </div>
+  );
+}
+
+export default function BountySubmitForm({ bounty }: { bounty: BountyPublic }) {
+  const router = useRouter();
+  const { walletAddress } = useWalletContext();
+  const submit = useSubmitBounty(bounty.id);
+  const req = bounty.submissionRequirements;
+
+  const [mediaUrls, setMediaUrls] = useState<string[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const [mediaError, setMediaError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(makeSchema(req)),
+    mode: 'onBlur',
+    defaultValues: {
+      contentUri: '',
+      documentationUrl: '',
+      tweetUrl: '',
+      demoVideoUrl: '',
+    },
+  });
+
+  useEffect(() => {
+    if (submit.isCompleted) {
+      toast.success('Work submitted and anchored on-chain.');
+      router.push(`/bounties/${bounty.id}`);
+    } else if (submit.isFailed) {
+      toast.error(submit.error || 'Submission failed.');
+    }
+  }, [submit.isCompleted, submit.isFailed, submit.error, bounty.id, router]);
+
+  const handleFiles = async (files: FileList | null) => {
+    if (!files?.length) return;
+    setMediaError(null);
+    setUploading(true);
+    try {
+      for (const file of Array.from(files)) {
+        if (!file.type.match(/^image\/(jpeg|jpg|png|gif|webp|svg\+xml)$/)) {
+          toast.error('Images only (SVG, PNG, JPG, GIF).');
+          continue;
+        }
+        if (file.size > 5 * 1024 * 1024) {
+          toast.error('Each image must be under 5MB.');
+          continue;
+        }
+        const res = await uploadService.uploadSingle(file, {
+          folder: 'boundless/bounties/submissions/media',
+          tags: ['bounty', 'submission', 'media'],
+        });
+        const url = res?.data?.secure_url;
+        if (res?.success && url) setMediaUrls(prev => [...prev, url]);
+        else toast.error('Upload failed.');
+      }
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const onSubmit = (data: FormValues) => {
+    if (!walletAddress) {
+      toast.error('Connect a wallet to submit.');
+      return;
+    }
+    if (req.media && mediaUrls.length === 0) {
+      setMediaError('At least one image is required.');
+      return;
+    }
+    void submit.run({
+      applicantAddress: walletAddress,
+      contentUri: data.contentUri.trim(),
+      documentationUrl: data.documentationUrl.trim() || undefined,
+      tweetUrl: data.tweetUrl.trim() || undefined,
+      demoVideoUrl: data.demoVideoUrl.trim() || undefined,
+      mediaUrls: mediaUrls.length ? mediaUrls : undefined,
+    });
+  };
+
+  const running = submit.isRunning;
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className='w-full space-y-10'>
+      <header>
+        <h1 className='text-2xl font-bold text-white sm:text-3xl'>
+          Submit Your Entry
+        </h1>
+        <p className='mt-2 text-sm text-zinc-400'>
+          <span className='font-semibold text-zinc-300'>Tip:</span> If your
+          submission includes multiple assets, organize them in a single public
+          folder (e.g. Google Drive or Dropbox) and share that link as your
+          primary submission.
+        </p>
+      </header>
+
+      {/* Primary submission */}
+      <section className='space-y-2'>
+        <label className='text-sm font-medium text-zinc-200'>
+          Link to Your Submission <span className='text-red-400'>*</span>
+        </label>
+        <LinkField
+          icon={<Github className='h-5 w-5' />}
+          placeholder='https://'
+          error={errors.contentUri?.message}
+          {...register('contentUri')}
+        />
+        <p className='text-sm text-zinc-500'>
+          Share documentation, setup instructions, or API references to help
+          reviewers understand your implementation.
+        </p>
+        <LinkField
+          icon={<FileText className='h-5 w-5' />}
+          placeholder='https://'
+          required={req.documentation}
+          error={errors.documentationUrl?.message}
+          {...register('documentationUrl')}
+        />
+      </section>
+
+      {/* Other links */}
+      <section className='space-y-4'>
+        <div>
+          <h2 className='text-lg font-bold text-white'>Other Links</h2>
+          <p className='text-sm text-zinc-500'>
+            Make sure these links are accessible by everyone.
+          </p>
+        </div>
+
+        <div className='space-y-1.5'>
+          <label className='text-sm text-zinc-300'>
+            Tweet Link{req.tweet && <span className='text-red-400'> *</span>}
+          </label>
+          <LinkField
+            icon={<Twitter className='h-5 w-5' />}
+            placeholder='https://'
+            required={req.tweet}
+            error={errors.tweetUrl?.message}
+            {...register('tweetUrl')}
+          />
+        </div>
+
+        <div className='space-y-1.5'>
+          <label className='text-sm text-zinc-300'>
+            Demo Video
+            {req.demoVideo && <span className='text-red-400'> *</span>}
+          </label>
+          <LinkField
+            icon={<PlaySquare className='h-5 w-5' />}
+            placeholder='https://'
+            required={req.demoVideo}
+            error={errors.demoVideoUrl?.message}
+            {...register('demoVideoUrl')}
+          />
+        </div>
+      </section>
+
+      {/* Media */}
+      <section className='space-y-3'>
+        <div>
+          <h2 className='text-lg font-bold text-white'>
+            Media{req.media && <span className='text-red-400'> *</span>}
+          </h2>
+          <p className='text-sm text-zinc-500'>
+            Add images to help others understand your project better.
+          </p>
+        </div>
+
+        {mediaUrls.length > 0 && (
+          <div className='flex flex-wrap gap-3'>
+            {mediaUrls.map(url => (
+              <div
+                key={url}
+                className='group relative h-24 w-32 overflow-hidden rounded-lg border border-zinc-800'
+              >
+                <Image
+                  src={url}
+                  alt='Submission media'
+                  fill
+                  unoptimized
+                  className='object-cover'
+                />
+                <button
+                  type='button'
+                  onClick={() =>
+                    setMediaUrls(prev => prev.filter(u => u !== url))
+                  }
+                  className='absolute top-1 right-1 rounded-full bg-black/70 p-1 text-white opacity-0 transition-opacity group-hover:opacity-100'
+                  aria-label='Remove image'
+                >
+                  <X className='h-3.5 w-3.5' />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <label
+          onDragOver={e => e.preventDefault()}
+          onDrop={e => {
+            e.preventDefault();
+            void handleFiles(e.dataTransfer.files);
+          }}
+          className='flex cursor-pointer flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-zinc-700 bg-zinc-900/30 px-6 py-10 text-center transition-colors hover:border-zinc-600 hover:bg-zinc-900/50'
+        >
+          <input
+            type='file'
+            accept='image/svg+xml,image/png,image/jpeg,image/gif'
+            multiple
+            className='hidden'
+            onChange={e => void handleFiles(e.target.files)}
+          />
+          {uploading ? (
+            <Loader2 className='h-6 w-6 animate-spin text-zinc-400' />
+          ) : (
+            <UploadCloud className='h-6 w-6 text-zinc-500' />
+          )}
+          <p className='text-sm'>
+            <span className='text-primary font-medium'>Click to upload</span>
+            <span className='text-zinc-500'> or drag and drop</span>
+          </p>
+          <p className='text-xs text-zinc-600'>SVG, PNG, JPG or GIF</p>
+        </label>
+        {mediaError && <p className='text-xs text-red-500'>{mediaError}</p>}
+      </section>
+
+      {/* Submit */}
+      <div className='border-t border-zinc-800 pt-6'>
+        {!walletAddress ? (
+          <p className='flex items-center gap-2 text-sm text-zinc-400'>
+            <Wallet className='h-4 w-4' />
+            Connect a wallet to submit.
+          </p>
+        ) : running ? (
+          <div className='flex items-center gap-2 rounded-lg border border-zinc-800 bg-zinc-900/50 p-3 text-sm text-zinc-300'>
+            <Loader2 className='text-primary h-4 w-4 animate-spin' />
+            {PHASE_LABEL[submit.phase] || 'Working…'}
+          </div>
+        ) : (
+          <div className='flex items-center gap-3'>
+            <BoundlessButton type='submit' size='lg' disabled={uploading}>
+              Submit entry
+            </BoundlessButton>
+            <BoundlessButton
+              type='button'
+              variant='outline'
+              size='lg'
+              onClick={() => router.push(`/bounties/${bounty.id}`)}
+            >
+              Cancel
+            </BoundlessButton>
+          </div>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/components/bounties/detail/submit/BountySubmitGate.tsx
+++ b/components/bounties/detail/submit/BountySubmitGate.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowLeft, Loader2 } from 'lucide-react';
+
+import EmptyState from '@/components/EmptyState';
+import {
+  useBounty,
+  useMyBountyApplication,
+  type BountyPublic,
+  type MyBountyApplication,
+} from '@/features/bounties';
+import BountySubmitForm from './BountySubmitForm';
+
+/** Statuses where a builder is entitled to submit work (mirrors the panel). */
+function canSubmit(
+  bounty: BountyPublic,
+  app: MyBountyApplication | null
+): boolean {
+  if (!app) return false;
+  const withdrawn =
+    app.applicationStatus === 'WITHDRAWN' || app.status === 'withdrawn';
+  if (withdrawn) return false;
+  const isApplication =
+    bounty.entryType === 'APPLICATION_LIGHT' ||
+    bounty.entryType === 'APPLICATION_FULL';
+  if (isApplication) {
+    return (
+      app.applicationStatus === 'SELECTED' ||
+      app.applicationStatus === 'SHORTLISTED'
+    );
+  }
+  return app.status === 'active' || app.applicationStatus === 'SELECTED';
+}
+
+export default function BountySubmitGate({ id }: { id: string }) {
+  const { data: bounty, isLoading, error } = useBounty(id);
+  const { data: myApplication } = useMyBountyApplication(id);
+
+  if (isLoading) {
+    return (
+      <div className='flex min-h-[50vh] items-center justify-center'>
+        <Loader2 className='h-6 w-6 animate-spin text-zinc-500' />
+      </div>
+    );
+  }
+
+  if (error || !bounty) {
+    return (
+      <div className='py-20'>
+        <EmptyState
+          title='Bounty not found'
+          description='This bounty may have been removed or is not public.'
+          type='compact'
+        />
+      </div>
+    );
+  }
+
+  const backLink = (
+    <Link
+      href={`/bounties/${id}`}
+      className='mb-6 inline-flex items-center gap-1.5 text-sm text-zinc-400 transition-colors hover:text-white'
+    >
+      <ArrowLeft className='h-4 w-4' />
+      Back to bounty
+    </Link>
+  );
+
+  if (!canSubmit(bounty, myApplication ?? null)) {
+    return (
+      <div>
+        {backLink}
+        <div className='py-16'>
+          <EmptyState
+            title="You can't submit to this bounty yet"
+            description='You need an active claim or a selected/shortlisted application before submitting work.'
+            type='compact'
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='mx-auto max-w-3xl'>
+      {backLink}
+      <BountySubmitForm bounty={bounty} />
+    </div>
+  );
+}

--- a/components/bounties/detail/submit/BountySubmitPanel.tsx
+++ b/components/bounties/detail/submit/BountySubmitPanel.tsx
@@ -1,24 +1,16 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { toast } from 'sonner';
-import {
-  CheckCircle2,
-  ExternalLink,
-  Loader2,
-  Send,
-  Wallet,
-} from 'lucide-react';
+import { CheckCircle2, Loader2, Send } from 'lucide-react';
 
 import { BoundlessButton } from '@/components/buttons';
-import { Input } from '@/components/ui/input';
 import { useWalletContext } from '@/components/providers/wallet-provider';
 import {
-  useSubmitBounty,
   useWithdrawSubmission,
   type BountyPublic,
   type MyBountyApplication,
-  type EscrowRunPhase,
 } from '@/features/bounties';
 
 /** Statuses where a builder is entitled to submit work. */
@@ -43,56 +35,23 @@ function canSubmit(
   return app.status === 'active' || app.applicationStatus === 'SELECTED';
 }
 
-const PHASE_LABEL: Record<EscrowRunPhase, string> = {
-  idle: '',
-  starting: 'Preparing submission…',
-  signing: 'Signing…',
-  submitting: 'Submitting…',
-  polling: 'Anchoring on-chain…',
-  completed: 'Confirmed',
-  failed: 'Failed',
-};
-
-const isUrl = (s: string): boolean => {
-  try {
-    new URL(s);
-    return true;
-  } catch {
-    return false;
-  }
-};
-
 export default function BountySubmitPanel({
   bounty,
   myApplication,
+  hasActiveSubmission = false,
 }: {
   bounty: BountyPublic;
   myApplication: MyBountyApplication | null;
+  /** True once the caller has an anchored (non-withdrawn) submission. */
+  hasActiveSubmission?: boolean;
 }) {
   const { walletAddress } = useWalletContext();
-  const submit = useSubmitBounty(bounty.id);
   const withdraw = useWithdrawSubmission(bounty.id);
-
-  const [contentUri, setContentUri] = useState('');
-  const [touched, setTouched] = useState(false);
-  // Session-local: persistent submission state needs the #332 my-submission
-  // read (deferred until that backend endpoint is in the schema).
-  const [submitted, setSubmitted] = useState(false);
   const [confirmWithdraw, setConfirmWithdraw] = useState(false);
-
-  useEffect(() => {
-    if (submit.isCompleted) {
-      toast.success('Work submitted and anchored on-chain.');
-      setSubmitted(true);
-    } else if (submit.isFailed) {
-      toast.error(submit.error || 'Submission failed.');
-    }
-  }, [submit.isCompleted, submit.isFailed, submit.error]);
 
   useEffect(() => {
     if (withdraw.isCompleted) {
       toast.success('Submission withdrawn.');
-      setSubmitted(false);
       setConfirmWithdraw(false);
     } else if (withdraw.isFailed) {
       toast.error(withdraw.error || 'Withdraw failed.');
@@ -100,20 +59,6 @@ export default function BountySubmitPanel({
   }, [withdraw.isCompleted, withdraw.isFailed, withdraw.error]);
 
   if (!canSubmit(bounty, myApplication)) return null;
-
-  const urlValid = isUrl(contentUri.trim());
-
-  const handleSubmit = () => {
-    if (!walletAddress) return toast.error('Connect a wallet to submit.');
-    if (!urlValid) {
-      setTouched(true);
-      return;
-    }
-    void submit.run({
-      applicantAddress: walletAddress,
-      contentUri: contentUri.trim(),
-    });
-  };
 
   const handleWithdraw = () => {
     if (!walletAddress) return toast.error('Connect a wallet to withdraw.');
@@ -127,29 +72,22 @@ export default function BountySubmitPanel({
         Submit your work
       </h3>
 
-      {!walletAddress ? (
-        <p className='mt-2 flex items-center gap-2 text-xs text-zinc-400'>
-          <Wallet className='h-3.5 w-3.5' />
-          Connect a wallet to submit.
-        </p>
-      ) : submitted ? (
-        // Submitted — show confirmation + withdraw.
+      {hasActiveSubmission ? (
         <div className='mt-3 space-y-3'>
           <div className='flex items-center gap-2 text-sm text-zinc-200'>
             <CheckCircle2 className='text-primary h-4 w-4' />
             Work submitted
           </div>
-          {submit.txHash && (
-            <a
-              href={`https://stellar.expert/explorer/testnet/tx/${submit.txHash}`}
-              target='_blank'
-              rel='noreferrer'
-              className='text-primary inline-flex items-center gap-1 text-xs hover:underline'
-            >
-              View transaction
-              <ExternalLink className='h-3 w-3' />
-            </a>
-          )}
+          <Link
+            href={`/bounties/${bounty.id}/submit`}
+            target='_blank'
+            rel='noopener noreferrer'
+            className='block'
+          >
+            <BoundlessButton variant='outline' className='w-full'>
+              Edit submission
+            </BoundlessButton>
+          </Link>
           {confirmWithdraw ? (
             <div className='flex gap-2'>
               <BoundlessButton
@@ -183,37 +121,20 @@ export default function BountySubmitPanel({
           )}
         </div>
       ) : (
-        // Submit form.
-        <div className='mt-3 space-y-3'>
+        <div className='mt-3 space-y-2'>
           <p className='text-xs text-zinc-500'>
-            Link your deliverable — a pull request, repo, writeup, or demo.
+            Link your deliverable and any supporting docs, demo, or media.
           </p>
-          <Input
-            type='url'
-            placeholder='https://github.com/org/repo/pull/123'
-            value={contentUri}
-            onChange={e => setContentUri(e.target.value)}
-            disabled={submit.isRunning}
-            className='h-10 border-zinc-800 bg-zinc-900/50 text-white placeholder:text-zinc-600'
-          />
-          {touched && !urlValid && (
-            <p className='text-xs text-red-500'>Enter a valid URL.</p>
-          )}
-
-          {submit.isRunning ? (
-            <div className='flex items-center gap-2 rounded-lg border border-zinc-800 bg-zinc-900/50 p-3 text-xs text-zinc-300'>
-              <Loader2 className='text-primary h-4 w-4 animate-spin' />
-              {PHASE_LABEL[submit.phase] || 'Working…'}
-            </div>
-          ) : (
-            <BoundlessButton
-              className='w-full'
-              onClick={handleSubmit}
-              disabled={!contentUri.trim()}
-            >
-              Submit work
+          <Link
+            href={`/bounties/${bounty.id}/submit`}
+            target='_blank'
+            rel='noopener noreferrer'
+            className='block'
+          >
+            <BoundlessButton className='w-full'>
+              Submit your work
             </BoundlessButton>
-          )}
+          </Link>
         </div>
       )}
     </div>

--- a/components/bounties/marketplace/BountiesPage.tsx
+++ b/components/bounties/marketplace/BountiesPage.tsx
@@ -11,6 +11,7 @@ import { BountyCard } from './BountyCard';
 import BountiesFiltersHeader, {
   type ModeFilter,
 } from './BountiesFiltersHeader';
+import { CategoryTabs, type CategoryFilter } from './CategoryTabs';
 import { useInfiniteBounties } from './use-bounties-marketplace';
 
 /** Client-side mode narrowing (the public list endpoint doesn't filter on mode). */
@@ -34,6 +35,7 @@ export default function BountiesPage() {
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [status, setStatus] = useState('all');
+  const [category, setCategory] = useState<CategoryFilter>('all');
   const [mode, setMode] = useState<ModeFilter>('all');
 
   // Debounce the search so we don't refetch on every keystroke.
@@ -52,6 +54,7 @@ export default function BountiesPage() {
     loadMore,
   } = useInfiniteBounties({
     status: status === 'all' ? undefined : status,
+    category: category === 'all' ? undefined : category,
     search: debouncedSearch || undefined,
   });
 
@@ -68,10 +71,15 @@ export default function BountiesPage() {
     rootMargin: '0px 0px 1200px 0px',
   });
 
-  const hasFilters = !!debouncedSearch || status !== 'all' || mode !== 'all';
+  const hasFilters =
+    !!debouncedSearch ||
+    status !== 'all' ||
+    category !== 'all' ||
+    mode !== 'all';
   const clearFilters = () => {
     setSearch('');
     setStatus('all');
+    setCategory('all');
     setMode('all');
   };
 
@@ -86,6 +94,8 @@ export default function BountiesPage() {
         onStatus={setStatus}
         onMode={setMode}
       />
+
+      <CategoryTabs value={category} onChange={setCategory} />
 
       {loading && (
         <div className='flex items-center justify-center py-24'>

--- a/components/bounties/marketplace/BountyCard.tsx
+++ b/components/bounties/marketplace/BountyCard.tsx
@@ -1,11 +1,18 @@
 'use client';
 
 import Link from 'next/link';
-import { Calendar, Target } from 'lucide-react';
+import Image from 'next/image';
+import { Target } from 'lucide-react';
 
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { computeBountyModeLabel } from '@/components/organization/bounties/new/tabs/schemas/modeSchema';
+import {
+  CATEGORY_LABELS,
+  type BountyCategory,
+} from '@/components/organization/bounties/new/tabs/schemas/scopeSchema';
 import type { BountyPublic } from '@/features/bounties';
+import { DueCountdown } from '../DueCountdown';
 
 /** Plain-language mode label (single claim / competition / application). */
 function modeLabel(b: BountyPublic): string {
@@ -22,16 +29,12 @@ const STATUS_CLASS: Record<string, string> = {
   cancelled: 'border-zinc-700 bg-zinc-800/60 text-zinc-300',
 };
 
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
-}
-
 export function BountyCard({ bounty }: { bounty: BountyPublic }) {
   const reward = bounty.rewardAmount > 0;
+  const isUsdc = bounty.rewardCurrency?.toUpperCase() === 'USDC';
+  const categoryLabel = bounty.category
+    ? (CATEGORY_LABELS[bounty.category as BountyCategory] ?? bounty.category)
+    : null;
   const statusClass =
     STATUS_CLASS[bounty.status] ??
     'border-zinc-700 bg-zinc-800/60 text-zinc-300';
@@ -60,24 +63,37 @@ export function BountyCard({ bounty }: { bounty: BountyPublic }) {
       <h3 className='group-hover:text-primary line-clamp-2 min-h-12 text-lg font-bold text-white transition-colors'>
         {bounty.title}
       </h3>
-      {bounty.description && (
-        <p className='mt-1 line-clamp-2 text-sm text-zinc-400'>
-          {bounty.description}
-        </p>
-      )}
 
-      {bounty.applicationWindowCloseAt && (
-        <p className='mt-3 flex items-center gap-1.5 text-xs text-zinc-500'>
-          <Calendar className='h-3.5 w-3.5' />
-          Applications close {formatDate(bounty.applicationWindowCloseAt)}
-        </p>
-      )}
+      <div className='mt-3 flex flex-wrap items-center gap-x-3 gap-y-1.5'>
+        {categoryLabel && (
+          <Badge
+            variant='outline'
+            className='rounded-full border-zinc-700 bg-zinc-800/40 px-2.5 py-0.5 text-[11px] font-medium text-zinc-300'
+          >
+            {categoryLabel}
+          </Badge>
+        )}
+        {bounty.submissionDeadline && (
+          <DueCountdown deadline={bounty.submissionDeadline} />
+        )}
+      </div>
 
       <div className='mt-4 flex items-center justify-between gap-2 border-t border-zinc-800 pt-4'>
         <div className='flex items-center gap-2'>
-          <div className='bg-primary/10 flex h-9 w-9 items-center justify-center rounded-lg'>
-            <Target className='text-primary h-4 w-4' />
-          </div>
+          {isUsdc ? (
+            <Image
+              src='/assets/usdc.svg'
+              alt='USDC'
+              width={28}
+              height={28}
+              unoptimized
+              className='h-7 w-7'
+            />
+          ) : (
+            <div className='bg-primary/10 flex h-9 w-9 items-center justify-center rounded-lg'>
+              <Target className='text-primary h-4 w-4' />
+            </div>
+          )}
           <div>
             <p className='text-primary text-base leading-tight font-bold'>
               {reward
@@ -87,9 +103,21 @@ export function BountyCard({ bounty }: { bounty: BountyPublic }) {
             <p className='text-[11px] text-zinc-500'>reward</p>
           </div>
         </div>
-        <span className='max-w-[45%] truncate text-right text-xs text-zinc-400'>
-          {bounty.organization.name}
-        </span>
+
+        <div className='flex max-w-[45%] items-center gap-2'>
+          <Avatar className='h-6 w-6'>
+            <AvatarImage
+              src={bounty.organization.logo ?? undefined}
+              alt={bounty.organization.name}
+            />
+            <AvatarFallback className='text-[10px]'>
+              {bounty.organization.name.charAt(0).toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+          <span className='truncate text-xs text-zinc-400'>
+            {bounty.organization.name}
+          </span>
+        </div>
       </div>
     </Link>
   );

--- a/components/bounties/marketplace/CategoryTabs.tsx
+++ b/components/bounties/marketplace/CategoryTabs.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import {
+  BOUNTY_CATEGORIES,
+  CATEGORY_LABELS,
+  type BountyCategory,
+} from '@/components/organization/bounties/new/tabs/schemas/scopeSchema';
+
+export type CategoryFilter = 'all' | BountyCategory;
+
+const TABS: { value: CategoryFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  ...BOUNTY_CATEGORIES.map(c => ({ value: c, label: CATEGORY_LABELS[c] })),
+];
+
+/** Category switcher for the bounty marketplace. "All" first, then disciplines. */
+export function CategoryTabs({
+  value,
+  onChange,
+}: {
+  value: CategoryFilter;
+  onChange: (v: CategoryFilter) => void;
+}) {
+  return (
+    <div
+      role='tablist'
+      aria-label='Filter bounties by category'
+      className='mb-6 flex flex-wrap gap-1 border-b border-zinc-800'
+    >
+      {TABS.map(tab => {
+        const active = tab.value === value;
+        return (
+          <button
+            key={tab.value}
+            role='tab'
+            aria-selected={active}
+            type='button'
+            onClick={() => onChange(tab.value)}
+            className={`relative px-4 py-2 text-sm font-medium transition-colors ${
+              active ? 'text-white' : 'text-zinc-400 hover:text-zinc-200'
+            }`}
+          >
+            {tab.label}
+            {active && (
+              <span className='bg-primary absolute inset-x-2 -bottom-px h-0.5 rounded-full' />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/bounties/marketplace/use-bounties-marketplace.ts
+++ b/components/bounties/marketplace/use-bounties-marketplace.ts
@@ -9,15 +9,17 @@ const PAGE_SIZE = 12;
 export interface MarketplaceFilters {
   /** Server-side: bounty lifecycle status (e.g. 'open'). */
   status?: string;
+  /** Server-side: discipline (DESIGN, DEVELOPMENT, CONTENT, GROWTH, COMMUNITY). */
+  category?: string;
   /** Server-side: free-text title/description search. */
   search?: string;
 }
 
 /**
  * Infinite (page-accumulating) public bounty list for the marketplace. Wraps the
- * `listBounties` client; status + search are applied server-side, pagination via
- * `getNextPageParam` off the response total. Mode/category narrowing is done
- * client-side in the page (the public list endpoint doesn't filter on them).
+ * `listBounties` client; status + category + search are applied server-side,
+ * pagination via `getNextPageParam` off the response total. Mode narrowing is
+ * still client-side in the page (the list endpoint doesn't filter on mode).
  */
 export function useInfiniteBounties(filters: MarketplaceFilters) {
   const query = useInfiniteQuery({

--- a/components/organization/bounties/new/tabs/SubmissionModelTab.tsx
+++ b/components/organization/bounties/new/tabs/SubmissionModelTab.tsx
@@ -14,6 +14,7 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
 import {
   getModeFields,
   ModeSelection,
@@ -89,11 +90,15 @@ export default function SubmissionModelTab({
     defaultValues: {
       submissionDeadline: '',
       reputationMinimum:
-        fields.reputationMinimum === 'hidden' ? null : reputationFloor || null,
+        fields.reputationMinimum === 'hidden' ? null : reputationFloor,
       applicationWindowCloseAt: null,
       maxApplicants: null,
       shortlistSize: null,
       applicationCreditCost: null,
+      requireDocumentation: false,
+      requireTweet: false,
+      requireDemoVideo: false,
+      requireMedia: false,
       ...initialData,
       // The mode forces submission visibility, regardless of any saved value.
       submissionVisibility: fields.submissionVisibility,
@@ -112,7 +117,7 @@ export default function SubmissionModelTab({
     if (fields.reputationMinimum === 'hidden') return;
     const current = form.getValues('reputationMinimum');
     if (current == null || current < reputationFloor) {
-      form.setValue('reputationMinimum', reputationFloor || null);
+      form.setValue('reputationMinimum', reputationFloor);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reputationFloor, fields.reputationMinimum]);
@@ -342,6 +347,46 @@ export default function SubmissionModelTab({
               (set by the selected mode)
             </span>
           </p>
+        </div>
+
+        {/* Required submission fields — the primary link is always required. */}
+        <div className='space-y-3 rounded-xl border border-zinc-800 bg-zinc-900/30 p-4'>
+          <div>
+            <p className='text-sm font-medium text-white'>
+              Required submission fields
+            </p>
+            <p className='mt-0.5 text-xs text-zinc-500'>
+              The submission link is always required. Toggle any extra fields
+              builders must provide when they submit work.
+            </p>
+          </div>
+          {(
+            [
+              ['requireDocumentation', 'Documentation link'],
+              ['requireDemoVideo', 'Demo video link'],
+              ['requireTweet', 'Tweet link'],
+              ['requireMedia', 'Media image'],
+            ] as const
+          ).map(([name, label]) => (
+            <FormField
+              key={name}
+              control={form.control}
+              name={name}
+              render={({ field }) => (
+                <FormItem className='flex items-center justify-between gap-3 space-y-0'>
+                  <FormLabel className='text-sm font-normal text-zinc-300'>
+                    {label}
+                  </FormLabel>
+                  <FormControl>
+                    <Switch
+                      checked={!!field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          ))}
         </div>
 
         <div className='flex items-center justify-between pt-4'>

--- a/components/organization/bounties/new/tabs/schemas/modeSchema.ts
+++ b/components/organization/bounties/new/tabs/schemas/modeSchema.ts
@@ -61,6 +61,29 @@ export function computeBountyModeLabel(
   return base;
 }
 
+/**
+ * Plain-language explanation of a bounty mode, shown in the detail-page tooltip
+ * so participants understand how entry and payout work before engaging.
+ */
+export function computeBountyModeDescription(
+  entryType: BountyEntryType,
+  claimType: BountyClaimType
+): string {
+  const single = claimType === 'SINGLE_CLAIM';
+  if (entryType === 'OPEN') {
+    return single
+      ? 'Anyone eligible can claim this bounty directly. The first to claim locks it, does the work, and gets paid. One worker, one reward.'
+      : 'Anyone can join and work in parallel. Submissions stay hidden until the deadline, then the organizer picks the winner(s).';
+  }
+  const depth =
+    entryType === 'APPLICATION_LIGHT'
+      ? 'a short application'
+      : 'a full application (proposal, portfolio, and more)';
+  return single
+    ? `Submit ${depth}. The organizer selects one applicant to do the work and get paid.`
+    : `Submit ${depth}. The organizer shortlists several applicants who then compete, and picks the winner(s) at the deadline.`;
+}
+
 export type FieldRule = 'required' | 'optional' | 'hidden';
 
 export interface ModeFields {

--- a/components/organization/bounties/new/tabs/schemas/scopeSchema.ts
+++ b/components/organization/bounties/new/tabs/schemas/scopeSchema.ts
@@ -23,15 +23,19 @@ export const CATEGORY_LABELS: Record<BountyCategory, string> = {
 
 /**
  * Baseline minimum reputation a claimant needs, per category. The organizer can
- * raise this in the Submission step but not drop below it. Development is the
- * highest bar (it carries the most risk of low-quality / AI-generated work).
+ * raise this in the Submission step but not drop below it.
+ *
+ * Temporarily flattened to 0 across all categories while the builder lifecycle
+ * is in testing, so the open-claim reputation gate (completedBountyCount >=
+ * reputationMinimum) doesn't block testers with no completed bounties yet.
+ * Restore the tiered values (Development highest) before launch.
  */
 export const CATEGORY_REPUTATION_BASELINE: Record<BountyCategory, number> = {
-  DEVELOPMENT: 50,
-  DESIGN: 25,
-  GROWTH: 20,
-  CONTENT: 15,
-  COMMUNITY: 10,
+  DEVELOPMENT: 0,
+  DESIGN: 0,
+  GROWTH: 0,
+  CONTENT: 0,
+  COMMUNITY: 0,
 };
 
 /**

--- a/components/organization/bounties/new/tabs/schemas/submissionModelSchema.ts
+++ b/components/organization/bounties/new/tabs/schemas/submissionModelSchema.ts
@@ -18,6 +18,11 @@ const submissionModelBase = z.object({
   submissionDeadline: z.string().min(1, 'Submission deadline is required'),
   submissionVisibility: z.enum(SUBMISSION_VISIBILITIES),
   reputationMinimum: z.union([z.number().int().min(0), z.null()]).optional(),
+  // Organizer-required submission fields (the primary link is always required).
+  requireDocumentation: z.boolean().optional(),
+  requireTweet: z.boolean().optional(),
+  requireDemoVideo: z.boolean().optional(),
+  requireMedia: z.boolean().optional(),
   applicationWindowCloseAt: z.union([z.string().min(1), z.null()]).optional(),
   maxApplicants: z.union([z.number().int().min(1), z.null()]).optional(),
   shortlistSize: z.union([z.number().int().min(1), z.null()]).optional(),

--- a/features/bounties/api/keys.ts
+++ b/features/bounties/api/keys.ts
@@ -18,5 +18,7 @@ export const bountyKeys = {
     [...bountyKeys.all, 'detail', bountyId] as const,
   myApplication: (bountyId: string) =>
     [...bountyKeys.all, 'my-application', bountyId] as const,
+  mySubmission: (bountyId: string) =>
+    [...bountyKeys.all, 'my-submission', bountyId] as const,
   myActivity: () => [...bountyKeys.all, 'my-activity'] as const,
 };

--- a/features/bounties/api/participant-client.ts
+++ b/features/bounties/api/participant-client.ts
@@ -22,6 +22,7 @@ import type {
 export interface BountiesListParams {
   organizationId?: string;
   status?: string;
+  category?: string;
   search?: string;
   page?: number;
   limit?: number;

--- a/features/bounties/api/participant-dashboard-client.ts
+++ b/features/bounties/api/participant-dashboard-client.ts
@@ -50,3 +50,11 @@ export const listMyBountySubmissions = async (
   params: MyActivityParams = {}
 ): Promise<BountyActivityPage<MyBountySubmissionRow>> =>
   unwrap(await api.get(withQuery('/bounties/me/submissions', params)));
+
+/** The caller's own submission for a single bounty, or null if none. */
+export const getMyBountySubmission = async (
+  bountyId: string
+): Promise<MyBountySubmissionRow | null> =>
+  unwrap<MyBountySubmissionRow | null>(
+    await api.get(`/bounties/me/submissions/${bountyId}`)
+  ) ?? null;

--- a/features/bounties/api/use-participant-dashboard.ts
+++ b/features/bounties/api/use-participant-dashboard.ts
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { bountyKeys } from './keys';
 import {
+  getMyBountySubmission,
   listMyBountyApplications,
   listMyBountySubmissions,
   type MyActivityParams,
@@ -27,6 +28,16 @@ export function useMyBountySubmissions(params: MyActivityParams = {}) {
   return useQuery({
     queryKey: [...bountyKeys.myActivity(), 'submissions', params],
     queryFn: () => listMyBountySubmissions(params),
+    retry: false,
+  });
+}
+
+/** The caller's submission for one bounty (drives submit/withdraw gating). */
+export function useMyBountySubmission(bountyId: string | undefined) {
+  return useQuery({
+    queryKey: bountyKeys.mySubmission(bountyId ?? ''),
+    queryFn: () => getMyBountySubmission(bountyId as string),
+    enabled: !!bountyId,
     retry: false,
   });
 }

--- a/features/bounties/index.ts
+++ b/features/bounties/index.ts
@@ -139,11 +139,13 @@ export type {
 export {
   listMyBountyApplications,
   listMyBountySubmissions,
+  getMyBountySubmission,
 } from './api/participant-dashboard-client';
 export type { MyActivityParams } from './api/participant-dashboard-client';
 export {
   useMyBountyApplications,
   useMyBountySubmissions,
+  useMyBountySubmission,
 } from './api/use-participant-dashboard';
 
 // Participant hooks (React Query).

--- a/lib/api/generated/schema.d.ts
+++ b/lib/api/generated/schema.d.ts
@@ -20437,6 +20437,14 @@ export interface components {
       reputationMinimum?: number | null;
       /** @enum {string} */
       submissionVisibility?: 'ORGANIZER_ONLY' | 'HIDDEN_UNTIL_DEADLINE';
+      /** @description Require a documentation link when submitting work. */
+      requireDocumentation?: boolean;
+      /** @description Require a tweet link when submitting work. */
+      requireTweet?: boolean;
+      /** @description Require a demo video link when submitting work. */
+      requireDemoVideo?: boolean;
+      /** @description Require at least one media image when submitting work. */
+      requireMedia?: boolean;
       /** @description Credits required to apply (anti-spam). Supplied to the contract at publish via PublishBountyEscrowDto; not a Bounty column. */
       applicationCreditCost?: number | null;
     };
@@ -20689,6 +20697,14 @@ export interface components {
        * @example https://github.com/me/boundless-fix/pull/1
        */
       contentUri: string;
+      /** @description Documentation / setup / API reference URL. */
+      documentationUrl?: string;
+      /** @description Tweet / X post URL. */
+      tweetUrl?: string;
+      /** @description Demo video URL. */
+      demoVideoUrl?: string;
+      /** @description Media image URLs (uploaded screenshots / assets). */
+      mediaUrls?: string[];
     };
     WithdrawSubmissionDto: {
       /**
@@ -20935,6 +20951,19 @@ export interface components {
       slug?: string | null;
       logo?: string | null;
     };
+    BountySubmissionRequirementsDto: {
+      documentation: boolean;
+      tweet: boolean;
+      demoVideo: boolean;
+      media: boolean;
+    };
+    BountyClaimantPublicDto: {
+      /** @description Display handle (username, falling back to name). */
+      username: string;
+      /** @description Claimant wallet address. */
+      address: string;
+      avatarUrl?: string | null;
+    };
     BountyPublicDto: {
       id: string;
       title: string;
@@ -20960,8 +20989,19 @@ export interface components {
       /** @description On-chain event id once published; null while in draft. */
       escrowEventId?: string | null;
       escrowTxHash?: string | null;
+      /** @description Bounty discipline (DESIGN, DEVELOPMENT, CONTENT, GROWTH, COMMUNITY). */
+      category?: string | null;
+      /**
+       * Format: date-time
+       * @description Work/submission deadline (set at publish); null while in draft.
+       */
+      submissionDeadline?: string | null;
+      /** @description Which submission metadata fields the organizer requires. */
+      submissionRequirements: components['schemas']['BountySubmissionRequirementsDto'];
       /** Format: date-time */
       createdAt: string;
+      /** @description Active claimant of a single-claim bounty once claimed; null otherwise. */
+      claimedBy?: components['schemas']['BountyClaimantPublicDto'] | null;
     };
     BountyPublicListDto: {
       bounties: components['schemas']['BountyPublicDto'][];
@@ -37761,6 +37801,7 @@ export interface operations {
         page?: number;
         limit?: number;
         search?: unknown;
+        category?: unknown;
         status?: unknown;
         organizationId?: unknown;
       };

--- a/openapi.snapshot.json
+++ b/openapi.snapshot.json
@@ -24644,6 +24644,12 @@
             "schema": {}
           },
           {
+            "name": "category",
+            "required": false,
+            "in": "query",
+            "schema": {}
+          },
+          {
             "name": "status",
             "required": false,
             "in": "query",
@@ -49972,6 +49978,22 @@
             "type": "string",
             "enum": ["ORGANIZER_ONLY", "HIDDEN_UNTIL_DEADLINE"]
           },
+          "requireDocumentation": {
+            "type": "boolean",
+            "description": "Require a documentation link when submitting work."
+          },
+          "requireTweet": {
+            "type": "boolean",
+            "description": "Require a tweet link when submitting work."
+          },
+          "requireDemoVideo": {
+            "type": "boolean",
+            "description": "Require a demo video link when submitting work."
+          },
+          "requireMedia": {
+            "type": "boolean",
+            "description": "Require at least one media image when submitting work."
+          },
           "applicationCreditCost": {
             "type": "number",
             "nullable": true,
@@ -50472,6 +50494,28 @@
             "example": "https://github.com/me/boundless-fix/pull/1",
             "minLength": 1,
             "maxLength": 1024
+          },
+          "documentationUrl": {
+            "type": "string",
+            "description": "Documentation / setup / API reference URL.",
+            "maxLength": 1024
+          },
+          "tweetUrl": {
+            "type": "string",
+            "description": "Tweet / X post URL.",
+            "maxLength": 1024
+          },
+          "demoVideoUrl": {
+            "type": "string",
+            "description": "Demo video URL.",
+            "maxLength": 1024
+          },
+          "mediaUrls": {
+            "description": "Media image URLs (uploaded screenshots / assets).",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": ["applicantAddress", "contentUri"]
@@ -51071,6 +51115,42 @@
         },
         "required": ["id", "name"]
       },
+      "BountySubmissionRequirementsDto": {
+        "type": "object",
+        "properties": {
+          "documentation": {
+            "type": "boolean"
+          },
+          "tweet": {
+            "type": "boolean"
+          },
+          "demoVideo": {
+            "type": "boolean"
+          },
+          "media": {
+            "type": "boolean"
+          }
+        },
+        "required": ["documentation", "tweet", "demoVideo", "media"]
+      },
+      "BountyClaimantPublicDto": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string",
+            "description": "Display handle (username, falling back to name)."
+          },
+          "address": {
+            "type": "string",
+            "description": "Claimant wallet address."
+          },
+          "avatarUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": ["username", "address"]
+      },
       "BountyPublicDto": {
         "type": "object",
         "properties": {
@@ -51143,9 +51223,37 @@
             "type": "string",
             "nullable": true
           },
+          "category": {
+            "type": "string",
+            "nullable": true,
+            "description": "Bounty discipline (DESIGN, DEVELOPMENT, CONTENT, GROWTH, COMMUNITY)."
+          },
+          "submissionDeadline": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Work/submission deadline (set at publish); null while in draft."
+          },
+          "submissionRequirements": {
+            "description": "Which submission metadata fields the organizer requires.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BountySubmissionRequirementsDto"
+              }
+            ]
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time"
+          },
+          "claimedBy": {
+            "nullable": true,
+            "description": "Active claimant of a single-claim bounty once claimed; null otherwise.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BountyClaimantPublicDto"
+              }
+            ]
           }
         },
         "required": [
@@ -51159,6 +51267,7 @@
           "submissionVisibility",
           "prizeTiers",
           "organization",
+          "submissionRequirements",
           "createdAt"
         ]
       },


### PR DESCRIPTION
Builder-side bounty UX: a dedicated submission page, marketplace/detail redesign, and organizer-configurable submission requirements. Pairs with the backend PR on `v2` (submission metadata, single-claim exclusivity, claimedBy/category/deadline on the public DTO).

## Commits

1. **Submission metadata types, category filter, wizard requirement toggles** — regenerate the OpenAPI schema for the new public-bounty fields (`claimedBy`, `category`, `submissionDeadline`, `submissionRequirements`) and submit-op metadata; add the category list query param, the per-bounty my-submission read + hook, and the organizer requirement toggles in the Configure wizard. Reputation baseline flattened to 0 for testing (wizard accepts a 0 floor).
2. **Marketplace card redesign, category tabs, detail display** — cards show org logo, category, a live due-date countdown, and the USDC logo (title only, no markdown bleed); marketplace category tab bar (All first); detail page mirrors the same details + a mode-explainer tooltip; single-claim 'Claimed by' card linking to the claimant profile; application-withdraw gated while a submission is anchored.
3. **Dedicated submit page** — `/bounties/[id]/submit` with the primary submission link plus optional documentation/tweet/demo-video links and a drag-and-drop media uploader; required fields follow the organizer config; returns to the detail page on success.

## Verification

`tsc`, `eslint .`, and `next build` all green. Submit flow validated end to end on a freshly claimed testnet bounty.

## Notes

- Requires the `v2` backend PR for the new fields (codegen was run against it).
- Reputation baseline is intentionally 0 while in testing; restore the tiered values before launch.