### PR TITLE
feat(bounty): submissions review tab (#632)

### DIFF
--- a/components/bounties/statusClass.ts
+++ b/components/bounties/statusClass.ts
@@ -17,3 +17,23 @@ const STATUS_CLASS: Record<string, string> = {
 export function bountyStatusClass(status: string): string {
   return STATUS_CLASS[status] ?? 'border-zinc-700 bg-zinc-800/60 text-zinc-300';
 }
+
+/**
+ * Badge styling for the submission review status (pending/accepted/rejected/
+ * disputed). Kept next to bountyStatusClass so the two vocabularies stay
+ * deliberately aligned; disputed is amber here (not the bounty-level red) so
+ * a disputed submission reads differently from a rejected one in the list.
+ */
+const SUBMISSION_STATUS_CLASS: Record<string, string> = {
+  pending: 'border-blue-500/30 bg-blue-500/10 text-blue-400',
+  accepted: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400',
+  rejected: 'border-red-500/30 bg-red-500/10 text-red-400',
+  disputed: 'border-amber-500/30 bg-amber-500/10 text-amber-400',
+};
+
+export function submissionStatusClass(status: string): string {
+  return (
+    SUBMISSION_STATUS_CLASS[status] ??
+    'border-zinc-700 bg-zinc-800/60 text-zinc-300'
+  );
+}

--- a/components/organization/bounties/manage/BountyManagementDashboard.tsx
+++ b/components/organization/bounties/manage/BountyManagementDashboard.tsx
@@ -23,6 +23,7 @@ import {
   type BountyOperateOverview,
 } from '@/features/bounties';
 import { ordinal } from '@/lib/utils';
+import BountySubmissionsPanel from './BountySubmissionsPanel';
 
 export default function BountyManagementDashboard() {
   const params = useParams<{ id: string; bountyId: string }>();
@@ -144,7 +145,12 @@ export default function BountyManagementDashboard() {
           </TabsContent>
         )}
         <TabsContent value='submissions'>
-          <TabPlaceholder title='Submissions review' issue='#632' />
+          <BountySubmissionsPanel
+            organizationId={organizationId}
+            bountyId={bountyId}
+            submissionVisibility={overview.submissionVisibility ?? ''}
+            submissionDeadline={overview.submissionDeadline ?? null}
+          />
         </TabsContent>
         <TabsContent value='payout'>
           <TabPlaceholder title='Winner selection & payout' issue='#633' />

--- a/components/organization/bounties/manage/BountyManagementDashboard.tsx
+++ b/components/organization/bounties/manage/BountyManagementDashboard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { ArrowLeft, Info, Loader2, Lock } from 'lucide-react';
@@ -29,6 +30,20 @@ export default function BountyManagementDashboard() {
   const params = useParams<{ id: string; bountyId: string }>();
   const organizationId = params?.id ?? '';
   const bountyId = params?.bountyId ?? '';
+
+  // Winner staging lives here (above the tab boundary) so it survives tab
+  // switches and is reachable by the Payout tab (#633).
+  const [stagedWinners, setStagedWinners] = useState<Set<string>>(new Set());
+  const toggleStagedWinner = (id: string) =>
+    setStagedWinners(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
 
   const {
     data: overview,
@@ -148,8 +163,11 @@ export default function BountyManagementDashboard() {
           <BountySubmissionsPanel
             organizationId={organizationId}
             bountyId={bountyId}
-            submissionVisibility={overview.submissionVisibility ?? ''}
+            submissionVisibility={overview.submissionVisibility}
             submissionDeadline={overview.submissionDeadline ?? null}
+            rewardCurrency={overview.rewardCurrency}
+            staged={stagedWinners}
+            onToggleStage={toggleStagedWinner}
           />
         </TabsContent>
         <TabsContent value='payout'>

--- a/components/organization/bounties/manage/BountySubmissionsPanel.tsx
+++ b/components/organization/bounties/manage/BountySubmissionsPanel.tsx
@@ -1,0 +1,349 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import {
+  CheckCircle2,
+  ExternalLink,
+  EyeOff,
+  FileText,
+  Github,
+  Loader2,
+  PlaySquare,
+  Star,
+  Trophy,
+  Twitter,
+} from 'lucide-react';
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { BoundlessButton } from '@/components/buttons';
+import EmptyState from '@/components/EmptyState';
+import { DueCountdown } from '@/components/bounties/DueCountdown';
+import {
+  useBountySubmissions,
+  type OrganizerBountySubmission,
+} from '@/features/bounties';
+
+const STATUS_CLASS: Record<string, string> = {
+  pending: 'border-blue-500/30 bg-blue-500/10 text-blue-400',
+  accepted: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400',
+  rejected: 'border-red-500/30 bg-red-500/10 text-red-400',
+  disputed: 'border-amber-500/30 bg-amber-500/10 text-amber-400',
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+export default function BountySubmissionsPanel({
+  organizationId,
+  bountyId,
+  submissionVisibility,
+  submissionDeadline,
+}: {
+  organizationId: string;
+  bountyId: string;
+  submissionVisibility: string;
+  submissionDeadline: string | null;
+}) {
+  const [staged, setStaged] = useState<Set<string>>(new Set());
+
+  const deadlinePassed = submissionDeadline
+    ? new Date(submissionDeadline).getTime() <= Date.now()
+    : false;
+  // Competition submissions stay hidden until the deadline so the organizer
+  // cannot play favorites mid-flight.
+  const gated =
+    submissionVisibility === 'HIDDEN_UNTIL_DEADLINE' && !deadlinePassed;
+
+  // Don't even fetch sealed competition work until the deadline.
+  const { data, isLoading, error } = useBountySubmissions(
+    organizationId,
+    bountyId,
+    {},
+    { enabled: !gated }
+  );
+
+  if (gated) {
+    return (
+      <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 py-16 text-center'>
+        <EyeOff className='mx-auto mb-3 h-6 w-6 text-zinc-500' />
+        <p className='text-sm font-medium text-zinc-200'>
+          Submissions are hidden until the deadline
+        </p>
+        <p className='mt-1 text-xs text-zinc-500'>
+          This is a competition. Work stays sealed so review stays fair.
+        </p>
+        {submissionDeadline && (
+          <div className='mt-3 flex justify-center'>
+            <DueCountdown
+              deadline={submissionDeadline}
+              className='flex items-center gap-1.5 text-xs font-medium text-zinc-300'
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className='flex items-center justify-center py-16'>
+        <Loader2 className='h-5 w-5 animate-spin text-zinc-500' />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className='py-12'>
+        <EmptyState
+          title="Couldn't load submissions"
+          description='Try again in a moment.'
+          type='compact'
+        />
+      </div>
+    );
+  }
+
+  const submissions = data?.items ?? [];
+
+  if (submissions.length === 0) {
+    return (
+      <div className='py-12'>
+        <EmptyState
+          title='No submissions yet'
+          description='Submitted work will appear here for review.'
+          type='compact'
+        />
+      </div>
+    );
+  }
+
+  const toggleStage = (id: string) =>
+    setStaged(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  return (
+    <div className='space-y-4'>
+      {staged.size > 0 && (
+        <div className='border-primary/30 bg-primary/10 flex items-center gap-2 rounded-xl border px-4 py-2.5 text-sm'>
+          <Trophy className='text-primary h-4 w-4' />
+          <span className='text-zinc-200'>{staged.size} staged for payout</span>
+          <span className='text-xs text-zinc-500'>
+            (winner selection + signing lands in #633)
+          </span>
+        </div>
+      )}
+
+      {submissions.map(s => (
+        <SubmissionCard
+          key={s.id}
+          submission={s}
+          staged={staged.has(s.id)}
+          onToggleStage={() => toggleStage(s.id)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function SubmissionCard({
+  submission: s,
+  staged,
+  onToggleStage,
+}: {
+  submission: OrganizerBountySubmission;
+  staged: boolean;
+  onToggleStage: () => void;
+}) {
+  const user = s.submittedBy;
+  const statusClass =
+    STATUS_CLASS[s.status] ?? 'border-zinc-700 bg-zinc-800/60 text-zinc-300';
+  const awarded = s.tierPosition != null;
+
+  return (
+    <div
+      className={`rounded-2xl border bg-zinc-900/40 p-5 transition-colors ${
+        staged
+          ? 'border-primary/40 bg-primary/5'
+          : 'border-zinc-800 hover:border-zinc-700'
+      }`}
+    >
+      <div className='flex items-start justify-between gap-3'>
+        {/* Submitter */}
+        <Link
+          href={user.username ? `/profile/${user.username}` : '#'}
+          className='group flex items-center gap-2.5'
+        >
+          <Avatar className='h-8 w-8'>
+            <AvatarImage src={user.avatarUrl ?? undefined} alt={user.name} />
+            <AvatarFallback className='text-xs'>
+              {user.name.charAt(0).toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+          <div>
+            <p className='group-hover:text-primary text-sm font-medium text-white'>
+              {user.name}
+            </p>
+            {user.username && (
+              <p className='text-xs text-zinc-500'>@{user.username}</p>
+            )}
+          </div>
+        </Link>
+
+        <div className='flex items-center gap-2'>
+          {awarded && (
+            <Badge
+              variant='outline'
+              className='border-primary/30 bg-primary/10 text-primary flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium'
+            >
+              <Trophy className='h-3 w-3' />
+              {ordinal(s.tierPosition as number)}
+              {s.tierAmount
+                ? ` · ${Number(s.tierAmount).toLocaleString()}`
+                : ''}
+            </Badge>
+          )}
+          <Badge
+            variant='outline'
+            className={`rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${statusClass}`}
+          >
+            {s.status}
+          </Badge>
+        </div>
+      </div>
+
+      {/* Work links */}
+      <div className='mt-4 flex flex-wrap gap-2'>
+        {s.contentUri && (
+          <LinkChip
+            href={s.contentUri}
+            icon={<Github className='h-3.5 w-3.5' />}
+            label='Submission'
+            primary
+          />
+        )}
+        {s.documentationUrl && (
+          <LinkChip
+            href={s.documentationUrl}
+            icon={<FileText className='h-3.5 w-3.5' />}
+            label='Docs'
+          />
+        )}
+        {s.tweetUrl && (
+          <LinkChip
+            href={s.tweetUrl}
+            icon={<Twitter className='h-3.5 w-3.5' />}
+            label='Tweet'
+          />
+        )}
+        {s.demoVideoUrl && (
+          <LinkChip
+            href={s.demoVideoUrl}
+            icon={<PlaySquare className='h-3.5 w-3.5' />}
+            label='Demo'
+          />
+        )}
+      </div>
+
+      {/* Media */}
+      {s.mediaUrls.length > 0 && (
+        <div className='mt-3 flex flex-wrap gap-2'>
+          {s.mediaUrls.map(url => (
+            <a
+              key={url}
+              href={url}
+              target='_blank'
+              rel='noreferrer'
+              className='relative h-16 w-24 overflow-hidden rounded-lg border border-zinc-800'
+            >
+              <Image
+                src={url}
+                alt='Submission media'
+                fill
+                unoptimized
+                className='object-cover'
+              />
+            </a>
+          ))}
+        </div>
+      )}
+
+      {/* Footer */}
+      <div className='mt-4 flex items-center justify-between border-t border-zinc-800 pt-3'>
+        <span className='text-xs text-zinc-500'>
+          Submitted {formatDate(s.createdAt)}
+          {s.escrowAnchorStatus && s.escrowAnchorStatus !== 'active' && (
+            <span className='ml-2 text-amber-400'>
+              ({s.escrowAnchorStatus.replace(/_/g, ' ')})
+            </span>
+          )}
+        </span>
+        <BoundlessButton
+          variant='outline'
+          size='sm'
+          onClick={onToggleStage}
+          className={staged ? 'border-primary text-primary' : 'text-zinc-300'}
+        >
+          {staged ? (
+            <>
+              <CheckCircle2 className='mr-1.5 h-3.5 w-3.5' />
+              Staged
+            </>
+          ) : (
+            <>
+              <Star className='mr-1.5 h-3.5 w-3.5' />
+              Stage for payout
+            </>
+          )}
+        </BoundlessButton>
+      </div>
+    </div>
+  );
+}
+
+function LinkChip({
+  href,
+  icon,
+  label,
+  primary,
+}: {
+  href: string;
+  icon: React.ReactNode;
+  label: string;
+  primary?: boolean;
+}) {
+  return (
+    <a
+      href={href}
+      target='_blank'
+      rel='noreferrer'
+      className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
+        primary
+          ? 'border-primary/30 bg-primary/10 text-primary hover:bg-primary/20'
+          : 'border-zinc-800 bg-zinc-900/50 text-zinc-300 hover:border-zinc-700'
+      }`}
+    >
+      {icon}
+      {label}
+      <ExternalLink className='h-3 w-3 opacity-60' />
+    </a>
+  );
+}
+
+const ordinal = (n: number): string => {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  return `${n}${s[(v - 20) % 10] ?? s[v] ?? s[0]}`;
+};

--- a/components/organization/bounties/manage/BountySubmissionsPanel.tsx
+++ b/components/organization/bounties/manage/BountySubmissionsPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import {
@@ -21,17 +21,16 @@ import { Badge } from '@/components/ui/badge';
 import { BoundlessButton } from '@/components/buttons';
 import EmptyState from '@/components/EmptyState';
 import { DueCountdown } from '@/components/bounties/DueCountdown';
+import { submissionStatusClass } from '@/components/bounties/statusClass';
 import {
   useBountySubmissions,
+  type BountyOperateOverview,
   type OrganizerBountySubmission,
 } from '@/features/bounties';
+import { ordinal } from '@/lib/utils';
 
-const STATUS_CLASS: Record<string, string> = {
-  pending: 'border-blue-500/30 bg-blue-500/10 text-blue-400',
-  accepted: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400',
-  rejected: 'border-red-500/30 bg-red-500/10 text-red-400',
-  disputed: 'border-amber-500/30 bg-amber-500/10 text-amber-400',
-};
+/** Matches the backend's default page size (organizer submissions endpoint). */
+const PAGE_SIZE = 20;
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString(undefined, {
@@ -41,33 +40,63 @@ function formatDate(iso: string): string {
   });
 }
 
+/** Token amounts arrive as decimal strings; show full Stellar precision. */
+function formatTierAmount(amount: string): string {
+  const n = Number(amount);
+  return Number.isFinite(n)
+    ? n.toLocaleString(undefined, { maximumFractionDigits: 7 })
+    : amount;
+}
+
 export default function BountySubmissionsPanel({
   organizationId,
   bountyId,
   submissionVisibility,
   submissionDeadline,
+  rewardCurrency,
+  staged,
+  onToggleStage,
 }: {
   organizationId: string;
   bountyId: string;
-  submissionVisibility: string;
+  submissionVisibility: BountyOperateOverview['submissionVisibility'];
   submissionDeadline: string | null;
+  rewardCurrency: string;
+  staged: Set<string>;
+  onToggleStage: (id: string) => void;
 }) {
-  const [staged, setStaged] = useState<Set<string>>(new Set());
+  const [page, setPage] = useState(1);
+  const [deadlinePassed, setDeadlinePassed] = useState(() =>
+    submissionDeadline
+      ? new Date(submissionDeadline).getTime() <= Date.now()
+      : false
+  );
 
-  const deadlinePassed = submissionDeadline
-    ? new Date(submissionDeadline).getTime() <= Date.now()
-    : false;
-  // Competition submissions stay hidden until the deadline so the organizer
-  // cannot play favorites mid-flight.
+  // Re-check on the same cadence as DueCountdown so the gate opens while the
+  // organizer is sitting on the tab, instead of only on remount.
+  useEffect(() => {
+    if (!submissionDeadline || deadlinePassed) return;
+    const target = new Date(submissionDeadline).getTime();
+    const interval = setInterval(() => {
+      if (Date.now() >= target) setDeadlinePassed(true);
+    }, 30_000);
+    return () => clearInterval(interval);
+  }, [submissionDeadline, deadlinePassed]);
+
+  // Keep competition work out of the UI until the deadline. Publish validation
+  // guarantees a deadline for live competitions; without one there is nothing
+  // to count down to, so we do not gate. NOTE: this is a UX gate only, the
+  // organizer endpoint itself returns submissions regardless of visibility.
   const gated =
-    submissionVisibility === 'HIDDEN_UNTIL_DEADLINE' && !deadlinePassed;
+    submissionVisibility === 'HIDDEN_UNTIL_DEADLINE' &&
+    submissionDeadline != null &&
+    !deadlinePassed;
 
-  // Don't even fetch sealed competition work until the deadline.
+  // Don't fetch sealed competition work until the deadline.
   const { data, isLoading, error } = useBountySubmissions(
     organizationId,
     bountyId,
-    {},
-    { enabled: !gated }
+    { params: { page, limit: PAGE_SIZE }, enabled: !gated }
   );
 
   if (gated) {
@@ -80,14 +109,12 @@ export default function BountySubmissionsPanel({
         <p className='mt-1 text-xs text-zinc-500'>
           This is a competition. Work stays sealed so review stays fair.
         </p>
-        {submissionDeadline && (
-          <div className='mt-3 flex justify-center'>
-            <DueCountdown
-              deadline={submissionDeadline}
-              className='flex items-center gap-1.5 text-xs font-medium text-zinc-300'
-            />
-          </div>
-        )}
+        <div className='mt-3 flex justify-center'>
+          <DueCountdown
+            deadline={submissionDeadline}
+            className='flex items-center gap-1.5 text-xs font-medium text-zinc-300'
+          />
+        </div>
       </div>
     );
   }
@@ -113,6 +140,8 @@ export default function BountySubmissionsPanel({
   }
 
   const submissions = data?.items ?? [];
+  const total = data?.total ?? submissions.length;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   if (submissions.length === 0) {
     return (
@@ -126,13 +155,8 @@ export default function BountySubmissionsPanel({
     );
   }
 
-  const toggleStage = (id: string) =>
-    setStaged(prev => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
+  const rangeStart = (page - 1) * PAGE_SIZE + 1;
+  const rangeEnd = rangeStart + submissions.length - 1;
 
   return (
     <div className='space-y-4'>
@@ -150,27 +174,76 @@ export default function BountySubmissionsPanel({
         <SubmissionCard
           key={s.id}
           submission={s}
+          rewardCurrency={rewardCurrency}
           staged={staged.has(s.id)}
-          onToggleStage={() => toggleStage(s.id)}
+          onToggleStage={() => onToggleStage(s.id)}
         />
       ))}
+
+      {totalPages > 1 && (
+        <div className='flex items-center justify-between border-t border-zinc-800 pt-4'>
+          <span className='text-xs text-zinc-500'>
+            Showing {rangeStart}-{rangeEnd} of {total} submissions
+          </span>
+          <div className='flex items-center gap-2'>
+            <BoundlessButton
+              variant='outline'
+              size='sm'
+              disabled={page <= 1}
+              onClick={() => setPage(p => Math.max(1, p - 1))}
+            >
+              Previous
+            </BoundlessButton>
+            <span className='text-xs text-zinc-400'>
+              Page {page} of {totalPages}
+            </span>
+            <BoundlessButton
+              variant='outline'
+              size='sm'
+              disabled={page >= totalPages}
+              onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+            >
+              Next
+            </BoundlessButton>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
 
 function SubmissionCard({
   submission: s,
+  rewardCurrency,
   staged,
   onToggleStage,
 }: {
   submission: OrganizerBountySubmission;
+  rewardCurrency: string;
   staged: boolean;
   onToggleStage: () => void;
 }) {
   const user = s.submittedBy;
-  const statusClass =
-    STATUS_CLASS[s.status] ?? 'border-zinc-700 bg-zinc-800/60 text-zinc-300';
   const awarded = s.tierPosition != null;
+
+  const submitter = (
+    <>
+      <Avatar className='h-8 w-8'>
+        <AvatarImage src={user.avatarUrl ?? undefined} alt={user.name} />
+        <AvatarFallback className='text-xs'>
+          {user.name.charAt(0).toUpperCase()}
+        </AvatarFallback>
+      </Avatar>
+      <div>
+        <p className='group-hover:text-primary text-sm font-medium text-white'>
+          {user.name}
+        </p>
+        {user.username && (
+          <p className='text-xs text-zinc-500'>@{user.username}</p>
+        )}
+      </div>
+    </>
+  );
 
   return (
     <div
@@ -182,25 +255,16 @@ function SubmissionCard({
     >
       <div className='flex items-start justify-between gap-3'>
         {/* Submitter */}
-        <Link
-          href={user.username ? `/profile/${user.username}` : '#'}
-          className='group flex items-center gap-2.5'
-        >
-          <Avatar className='h-8 w-8'>
-            <AvatarImage src={user.avatarUrl ?? undefined} alt={user.name} />
-            <AvatarFallback className='text-xs'>
-              {user.name.charAt(0).toUpperCase()}
-            </AvatarFallback>
-          </Avatar>
-          <div>
-            <p className='group-hover:text-primary text-sm font-medium text-white'>
-              {user.name}
-            </p>
-            {user.username && (
-              <p className='text-xs text-zinc-500'>@{user.username}</p>
-            )}
-          </div>
-        </Link>
+        {user.username ? (
+          <Link
+            href={`/profile/${user.username}`}
+            className='group flex items-center gap-2.5'
+          >
+            {submitter}
+          </Link>
+        ) : (
+          <div className='flex items-center gap-2.5'>{submitter}</div>
+        )}
 
         <div className='flex items-center gap-2'>
           {awarded && (
@@ -211,13 +275,13 @@ function SubmissionCard({
               <Trophy className='h-3 w-3' />
               {ordinal(s.tierPosition as number)}
               {s.tierAmount
-                ? ` · ${Number(s.tierAmount).toLocaleString()}`
+                ? ` · ${formatTierAmount(s.tierAmount)} ${rewardCurrency}`
                 : ''}
             </Badge>
           )}
           <Badge
             variant='outline'
-            className={`rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${statusClass}`}
+            className={`rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${submissionStatusClass(s.status)}`}
           >
             {s.status}
           </Badge>
@@ -260,9 +324,9 @@ function SubmissionCard({
       {/* Media */}
       {s.mediaUrls.length > 0 && (
         <div className='mt-3 flex flex-wrap gap-2'>
-          {s.mediaUrls.map(url => (
+          {s.mediaUrls.map((url, i) => (
             <a
-              key={url}
+              key={`${url}-${i}`}
               href={url}
               target='_blank'
               rel='noreferrer'
@@ -272,7 +336,11 @@ function SubmissionCard({
                 src={url}
                 alt='Submission media'
                 fill
-                unoptimized
+                sizes='96px'
+                // Uploads go to Cloudinary (whitelisted in next.config), where
+                // the optimizer serves resized thumbs; stray hosts bypass the
+                // optimizer instead of throwing on an unconfigured hostname.
+                unoptimized={!url.startsWith('https://res.cloudinary.com/')}
                 className='object-cover'
               />
             </a>
@@ -341,9 +409,3 @@ function LinkChip({
     </a>
   );
 }
-
-const ordinal = (n: number): string => {
-  const s = ['th', 'st', 'nd', 'rd'];
-  const v = n % 100;
-  return `${n}${s[(v - 20) % 10] ?? s[v] ?? s[0]}`;
-};

--- a/features/bounties/api/keys.ts
+++ b/features/bounties/api/keys.ts
@@ -1,3 +1,5 @@
+import type { OrganizerSubmissionsParams } from './organizer-dashboard-client';
+
 /**
  * React Query key factory for the bounties feature. Co-locating the keys keeps
  * the hooks and any imperative `queryClient.invalidateQueries` calls in sync.
@@ -26,7 +28,7 @@ export const bountyKeys = {
   orgSubmissions: (
     organizationId: string,
     bountyId: string,
-    params: Record<string, unknown> = {}
+    params: OrganizerSubmissionsParams = {}
   ) =>
     [
       ...bountyKeys.all,

--- a/features/bounties/api/keys.ts
+++ b/features/bounties/api/keys.ts
@@ -23,4 +23,16 @@ export const bountyKeys = {
   myActivity: () => [...bountyKeys.all, 'my-activity'] as const,
   overview: (organizationId: string, bountyId: string) =>
     [...bountyKeys.all, 'overview', organizationId, bountyId] as const,
+  orgSubmissions: (
+    organizationId: string,
+    bountyId: string,
+    params: Record<string, unknown> = {}
+  ) =>
+    [
+      ...bountyKeys.all,
+      'org-submissions',
+      organizationId,
+      bountyId,
+      params,
+    ] as const,
 };

--- a/features/bounties/api/organizer-dashboard-client.ts
+++ b/features/bounties/api/organizer-dashboard-client.ts
@@ -28,3 +28,29 @@ export const getBountyOverview = async (
       { params: { path: { organizationId, bountyId } } }
     )
   );
+
+// ── Organizer submissions review (#337 / #632) ────────────────────────────────
+
+export type OrganizerBountySubmission = Schemas['OrganizerBountySubmissionDto'];
+export type OrganizerBountySubmissionList =
+  Schemas['OrganizerBountySubmissionListDto'];
+export type OrganizerSubmissionUser = Schemas['OrganizerSubmissionUserDto'];
+
+export interface OrganizerSubmissionsParams {
+  status?: string;
+  page?: number;
+  limit?: number;
+}
+
+/** List the submitted work on a bounty for the reviewing organizer. */
+export const listBountySubmissions = async (
+  organizationId: string,
+  bountyId: string,
+  params: OrganizerSubmissionsParams = {}
+): Promise<OrganizerBountySubmissionList> =>
+  unwrapData(
+    await apiClient.GET(
+      '/api/organizations/{organizationId}/bounties/{bountyId}/submissions',
+      { params: { path: { organizationId, bountyId }, query: params } }
+    )
+  );

--- a/features/bounties/api/use-organizer-dashboard.ts
+++ b/features/bounties/api/use-organizer-dashboard.ts
@@ -30,20 +30,22 @@ export function useBountyOverview(
 
 /**
  * Submitted work on a bounty, for the reviewing organizer (#337 / #632).
- * Pass `enabled: false` to keep sealed competition work unfetched until the
- * deadline (the FE gate) so it never reaches the browser early.
+ * Pass `enabled: false` to keep the Submissions tab from fetching sealed
+ * competition work before the deadline. This is a UX gate only: the API
+ * returns the organizer's submissions regardless of visibility, so the
+ * actual seal (if required) must be enforced server-side.
  */
 export function useBountySubmissions(
   organizationId: string | undefined,
   bountyId: string | undefined,
-  params: OrganizerSubmissionsParams = {},
-  options: { enabled?: boolean } = {}
+  options: { params?: OrganizerSubmissionsParams; enabled?: boolean } = {}
 ) {
+  const params = options.params ?? {};
   return useQuery<OrganizerBountySubmissionList>({
     queryKey: bountyKeys.orgSubmissions(
       organizationId ?? '',
       bountyId ?? '',
-      params as Record<string, unknown>
+      params
     ),
     queryFn: () =>
       listBountySubmissions(
@@ -52,6 +54,5 @@ export function useBountySubmissions(
         params
       ),
     enabled: !!organizationId && !!bountyId && (options.enabled ?? true),
-    retry: false,
   });
 }

--- a/features/bounties/api/use-organizer-dashboard.ts
+++ b/features/bounties/api/use-organizer-dashboard.ts
@@ -5,7 +5,10 @@ import { useQuery } from '@tanstack/react-query';
 import { bountyKeys } from './keys';
 import {
   getBountyOverview,
+  listBountySubmissions,
   type BountyOperateOverview,
+  type OrganizerBountySubmissionList,
+  type OrganizerSubmissionsParams,
 } from './organizer-dashboard-client';
 
 /**
@@ -22,5 +25,33 @@ export function useBountyOverview(
     queryFn: () =>
       getBountyOverview(organizationId as string, bountyId as string),
     enabled: !!organizationId && !!bountyId,
+  });
+}
+
+/**
+ * Submitted work on a bounty, for the reviewing organizer (#337 / #632).
+ * Pass `enabled: false` to keep sealed competition work unfetched until the
+ * deadline (the FE gate) so it never reaches the browser early.
+ */
+export function useBountySubmissions(
+  organizationId: string | undefined,
+  bountyId: string | undefined,
+  params: OrganizerSubmissionsParams = {},
+  options: { enabled?: boolean } = {}
+) {
+  return useQuery<OrganizerBountySubmissionList>({
+    queryKey: bountyKeys.orgSubmissions(
+      organizationId ?? '',
+      bountyId ?? '',
+      params as Record<string, unknown>
+    ),
+    queryFn: () =>
+      listBountySubmissions(
+        organizationId as string,
+        bountyId as string,
+        params
+      ),
+    enabled: !!organizationId && !!bountyId && (options.enabled ?? true),
+    retry: false,
   });
 }

--- a/features/bounties/index.ts
+++ b/features/bounties/index.ts
@@ -184,7 +184,10 @@ export {
 } from './api/use-participant-dashboard';
 
 // ── Organizer operate dashboard (#338 / #630) ─────────────────────────────────
-export { getBountyOverview } from './api/organizer-dashboard-client';
+export {
+  getBountyOverview,
+  listBountySubmissions,
+} from './api/organizer-dashboard-client';
 export type {
   BountyOperateOverview,
   BountyOperateIntake,
@@ -192,8 +195,15 @@ export type {
   BountyOperateSubmissionStats,
   BountyOperateContributionStats,
   BountyOverviewPrizeTier,
+  OrganizerBountySubmission,
+  OrganizerBountySubmissionList,
+  OrganizerSubmissionUser,
+  OrganizerSubmissionsParams,
 } from './api/organizer-dashboard-client';
-export { useBountyOverview } from './api/use-organizer-dashboard';
+export {
+  useBountyOverview,
+  useBountySubmissions,
+} from './api/use-organizer-dashboard';
 
 // Participant hooks (React Query).
 export {


### PR DESCRIPTION
Closes #632. Part of the **Bounty Operate to Payout** milestone (#638). **Stacked on #667 (#630)** — merge #667 first; until then the diff shows #630's commits too. The only new file/logic here is the submissions tab.

## What

Fills the management dashboard's **Submissions** tab (the #630 shell), consuming the merged backend organizer submissions endpoint (#337):

- **Submissions list** — per submission: submitter (avatar + name/username, links to profile), review status badge, awarded tier + amount once winners are picked, the primary submission link + documentation/tweet/demo chips, media thumbnails, and submitted-at + anchor status.
- **Visibility gate** — competition `HIDDEN_UNTIL_DEADLINE` work stays sealed behind a countdown and is **not even fetched** until the deadline, so it never reaches the browser early.
- **Winner staging** — a client-side 'stage for payout' toggle (with a summary bar) that highlights staged submissions and feeds winner selection (#633).
- **Data layer** — `listBountySubmissions` client + `useBountySubmissions` hook (with an `enabled` gate option), typed against the generated `OrganizerBountySubmissionDto`.

## Verification

tsc 0 errors, eslint clean. Endpoint verified live against the running v2 backend.

## Notes

- Winner staging is client-side only; the tier assignment + on-chain `select-winners` signing is #633.
- Includes the #630 commits (codegen + dashboard shell) until #667 merges.