### PR TITLE
fix(bounty): derive shortlist selection from live application list

### DIFF
--- a/components/organization/bounties/manage/BountyApplicationsPanel.tsx
+++ b/components/organization/bounties/manage/BountyApplicationsPanel.tsx
@@ -104,6 +104,14 @@ export default function BountyApplicationsPanel({
     a.applicationStatus === 'SUBMITTED';
   const busy = select.isPending || shortlist.isPending || decline.isPending;
 
+  // `checked` can hold ids that have since left SUBMITTED (e.g. a checked
+  // application was declined, unmounting its checkbox), so derive the
+  // effective selection from the live list: the sticky-bar count and the
+  // shortlist payload must never include a non-actionable application.
+  const selectedIds = [...checked].filter(id =>
+    applications.some(a => a.id === id && actionable(a))
+  );
+
   const toggleCheck = (id: string) =>
     setChecked(prev => {
       const next = new Set(prev);
@@ -122,7 +130,7 @@ export default function BountyApplicationsPanel({
     );
 
   const onShortlist = () => {
-    const applicationIds = [...checked];
+    const applicationIds = selectedIds;
     if (
       overview.shortlistSize != null &&
       applicationIds.length > overview.shortlistSize
@@ -171,19 +179,19 @@ export default function BountyApplicationsPanel({
       {isCompetition && (
         <div className='sticky bottom-4 flex items-center justify-between gap-3 rounded-2xl border border-zinc-800 bg-zinc-950/90 p-4 backdrop-blur'>
           <span className='text-sm text-zinc-400'>
-            {checked.size} selected
+            {selectedIds.length} selected
             {overview.shortlistSize != null
               ? ` (max ${overview.shortlistSize})`
               : ''}
           </span>
           <BoundlessButton
-            disabled={checked.size === 0 || busy}
+            disabled={selectedIds.length === 0 || busy}
             onClick={onShortlist}
           >
             {shortlist.isPending ? (
               <Loader2 className='h-4 w-4 animate-spin' />
             ) : (
-              `Approve shortlist (${checked.size})`
+              `Approve shortlist (${selectedIds.length})`
             )}
           </BoundlessButton>
         </div>


### PR DESCRIPTION
## Summary

Follow-up fix to the applications review tab (#670, since merged into `feat/t-replace`). Originally this branch superseded #670; after that merge it was rebased down to just this one fix commit.

## The bug

Declining a checked application unmounted its checkbox but left its id in the `checked` set, so:
- the sticky-bar count stayed inflated, and
- **Approve shortlist** submitted a `DECLINED` application's id.

## The fix

The selection is derived from the live list (`selectedIds` = checked ids still in `SUBMITTED`) — the count, the button's disabled state, and the shortlist payload only ever include actionable applications.

## Review notes from #670 (non-blocking, not addressed here)

- `useInvalidateApplications` re-derives the `'org-applications'` key literal instead of using a `bountyKeys` helper — drift risk.
- `retry: false` on the list query deviates from the global query defaults without a comment.
- An empty decline reason is sent as `""` instead of omitted.
- `videoIntroUrl` / `portfolioLinks` are applicant-supplied and rendered as `href`s without scheme validation (same pattern as the submissions panel — candidate for a shared helper).

## Verification

`tsc --noEmit` — 0 errors on this head (rebased onto current `feat/t-replace`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)