### PR TITLE
feat(bounty): wrap flow — results, announcement, archive (#635)

### DIFF
--- a/components/bounties/detail/BountyDetail.tsx
+++ b/components/bounties/detail/BountyDetail.tsx
@@ -30,6 +30,7 @@ import {
 import { ordinal } from '@/lib/utils';
 import { BountyEntryCta } from './BountyEntryCta';
 import BountySubmitPanel from './submit/BountySubmitPanel';
+import { BountyResults } from './BountyResults';
 import { DueCountdown } from '../DueCountdown';
 
 // Markdown renderer (matches the wizard's editor package).
@@ -200,6 +201,11 @@ export default function BountyDetail({ id }: { id: string }) {
                   ))}
               </div>
             </div>
+          )}
+
+          {/* Results (winners + announcement) once the bounty is completed. */}
+          {bounty.status === 'completed' && (
+            <BountyResults bountyId={bounty.id} currency={currency} />
           )}
         </div>
 

--- a/components/bounties/detail/BountyResults.tsx
+++ b/components/bounties/detail/BountyResults.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { ExternalLink, Megaphone, Trophy } from 'lucide-react';
+
+import {
+  useBountyAnnouncement,
+  useBountyResults,
+  type BountyResultsWinner,
+} from '@/features/bounties';
+import { formatPublicKey, ordinal } from '@/lib/utils';
+import { getTransactionExplorerUrl } from '@/lib/wallet-utils';
+
+function formatAmount(amount: string | number): string {
+  const n = Number(amount);
+  return Number.isFinite(n)
+    ? n.toLocaleString(undefined, { maximumFractionDigits: 7 })
+    : String(amount);
+}
+
+/**
+ * Public results block for a completed bounty: the winner announcement (if the
+ * organizer published one) and winners by tier with their payout transaction.
+ * Renders nothing until there is something to show.
+ */
+export function BountyResults({
+  bountyId,
+  currency,
+}: {
+  bountyId: string;
+  currency: string;
+}) {
+  const { data: results } = useBountyResults(bountyId);
+  const { data: announcement } = useBountyAnnouncement(bountyId);
+
+  const winners = (results?.winners ?? [])
+    .slice()
+    .sort((a, b) => a.tierPosition - b.tierPosition);
+
+  if (winners.length === 0 && !announcement) return null;
+
+  return (
+    <div className='mt-10'>
+      <h2 className='mb-3 flex items-center gap-2 text-lg font-semibold text-white'>
+        <Trophy className='text-primary h-5 w-5' />
+        Results
+      </h2>
+
+      {announcement && (
+        <div className='mb-4 rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4'>
+          <div className='mb-1.5 flex items-center gap-2 text-sm font-medium text-white'>
+            <Megaphone className='h-4 w-4 text-zinc-400' />
+            Announcement
+          </div>
+          <p className='text-sm whitespace-pre-wrap text-zinc-300'>
+            {announcement.message}
+          </p>
+        </div>
+      )}
+
+      {winners.length > 0 && (
+        <div className='space-y-2'>
+          {winners.map(w => (
+            <WinnerRow key={w.submissionId} winner={w} currency={currency} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WinnerRow({
+  winner,
+  currency,
+}: {
+  winner: BountyResultsWinner;
+  currency: string;
+}) {
+  return (
+    <div className='flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-900/30 px-4 py-3'>
+      <div className='min-w-0'>
+        <p className='text-sm font-medium text-zinc-300'>
+          {ordinal(winner.tierPosition)} place
+        </p>
+        {winner.applicantAddress && (
+          <p className='font-mono text-xs text-zinc-500'>
+            {formatPublicKey(winner.applicantAddress)}
+          </p>
+        )}
+      </div>
+      <div className='text-right'>
+        <p className='text-primary text-sm font-semibold'>
+          {formatAmount(winner.tierAmount)} {currency}
+        </p>
+        {winner.rewardTransactionHash && (
+          <a
+            href={getTransactionExplorerUrl(winner.rewardTransactionHash)}
+            target='_blank'
+            rel='noreferrer'
+            className='text-primary inline-flex items-center gap-1 text-xs hover:underline'
+          >
+            Payout tx
+            <ExternalLink className='h-3 w-3' />
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/organization/bounties/manage/BountyManagementDashboard.tsx
+++ b/components/organization/bounties/manage/BountyManagementDashboard.tsx
@@ -28,6 +28,7 @@ import BountySubmissionsPanel from './BountySubmissionsPanel';
 import BountyPayoutPanel from './BountyPayoutPanel';
 import BountyApplicationsPanel from './BountyApplicationsPanel';
 import BountySettingsPanel from './BountySettingsPanel';
+import BountyResultsPanel from './BountyResultsPanel';
 
 export default function BountyManagementDashboard() {
   const params = useParams<{ id: string; bountyId: string }>();
@@ -85,6 +86,7 @@ export default function BountyManagementDashboard() {
   const isApplication =
     overview.entryType === 'APPLICATION_LIGHT' ||
     overview.entryType === 'APPLICATION_FULL';
+  const isCompleted = overview.status === 'completed';
   const modeLabel =
     overview.entryType && overview.claimType
       ? computeBountyModeLabel(overview.entryType, overview.claimType)
@@ -151,6 +153,7 @@ export default function BountyManagementDashboard() {
           )}
           <TabsTrigger value='submissions'>Submissions</TabsTrigger>
           <TabsTrigger value='payout'>Payout &amp; Winners</TabsTrigger>
+          {isCompleted && <TabsTrigger value='results'>Results</TabsTrigger>}
           <TabsTrigger value='settings'>Settings</TabsTrigger>
         </TabsList>
 
@@ -183,6 +186,15 @@ export default function BountyManagementDashboard() {
             staged={stagedWinners}
           />
         </TabsContent>
+        {isCompleted && (
+          <TabsContent value='results'>
+            <BountyResultsPanel
+              organizationId={organizationId}
+              bountyId={bountyId}
+              overview={overview}
+            />
+          </TabsContent>
+        )}
         <TabsContent value='settings'>
           <BountySettingsPanel
             organizationId={organizationId}

--- a/components/organization/bounties/manage/BountyResultsPanel.tsx
+++ b/components/organization/bounties/manage/BountyResultsPanel.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { CheckCircle2, ExternalLink, Loader2, Megaphone } from 'lucide-react';
+
+import { Textarea } from '@/components/ui/textarea';
+import { BoundlessButton } from '@/components/buttons';
+import EmptyState from '@/components/EmptyState';
+import {
+  useBountyAnnouncement,
+  useBountyResults,
+  usePublishBountyResults,
+  type BountyOperateOverview,
+  type BountyResultsWinner,
+} from '@/features/bounties';
+import { formatPublicKey, ordinal } from '@/lib/utils';
+import { getTransactionExplorerUrl } from '@/lib/wallet-utils';
+
+/** Token amounts arrive as decimal strings; show full Stellar precision. */
+function formatAmount(amount: string | number): string {
+  const n = Number(amount);
+  return Number.isFinite(n)
+    ? n.toLocaleString(undefined, { maximumFractionDigits: 7 })
+    : String(amount);
+}
+
+const MAX_MESSAGE = 2000;
+
+export default function BountyResultsPanel({
+  organizationId,
+  bountyId,
+  overview,
+}: {
+  organizationId: string;
+  bountyId: string;
+  overview: BountyOperateOverview;
+}) {
+  const isCompleted = overview.status === 'completed';
+
+  const { data: results, isLoading: resultsLoading } = useBountyResults(
+    bountyId,
+    { enabled: isCompleted }
+  );
+  const { data: announcement, isLoading: announcementLoading } =
+    useBountyAnnouncement(bountyId, { enabled: isCompleted });
+  const publish = usePublishBountyResults(organizationId, bountyId);
+
+  const [message, setMessage] = useState('');
+
+  if (!isCompleted) {
+    return (
+      <EmptyState
+        title='Results not ready'
+        description='Publish the winner announcement once the bounty is completed and paid out.'
+        type='compact'
+      />
+    );
+  }
+
+  if (resultsLoading || announcementLoading) {
+    return (
+      <div className='flex items-center justify-center py-16'>
+        <Loader2 className='h-5 w-5 animate-spin text-zinc-500' />
+      </div>
+    );
+  }
+
+  const winners = (results?.winners ?? [])
+    .slice()
+    .sort((a, b) => a.tierPosition - b.tierPosition);
+
+  const onPublish = () => {
+    const trimmed = message.trim();
+    if (!trimmed) {
+      toast.error('Write an announcement message first.');
+      return;
+    }
+    publish.mutate(
+      { message: trimmed },
+      {
+        onSuccess: () => {
+          toast.success('Winners announced.');
+          setMessage('');
+        },
+        onError: err =>
+          toast.error(
+            err instanceof Error ? err.message : 'Failed to publish results'
+          ),
+      }
+    );
+  };
+
+  return (
+    <div className='space-y-6'>
+      {/* Winners */}
+      <section className='space-y-3'>
+        <h3 className='text-sm font-semibold text-white'>Winners</h3>
+        {winners.length === 0 ? (
+          <EmptyState
+            title='No winners recorded'
+            description='This bounty completed without recorded winners.'
+            type='compact'
+          />
+        ) : (
+          <div className='space-y-2'>
+            {winners.map(w => (
+              <WinnerRow
+                key={w.submissionId}
+                winner={w}
+                currency={results?.rewardCurrency ?? overview.rewardCurrency}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Announcement */}
+      <section className='space-y-3 border-t border-zinc-800 pt-6'>
+        <div className='flex items-center gap-2'>
+          <Megaphone className='h-4 w-4 text-zinc-400' />
+          <h3 className='text-sm font-semibold text-white'>
+            Winner announcement
+          </h3>
+        </div>
+
+        {announcement ? (
+          <div className='space-y-2 rounded-2xl border border-emerald-500/30 bg-emerald-500/[0.06] p-4'>
+            <div className='flex items-center gap-2 text-sm text-white'>
+              <CheckCircle2 className='h-4 w-4 text-emerald-400' />
+              Published
+            </div>
+            <p className='text-sm whitespace-pre-wrap text-zinc-300'>
+              {announcement.message}
+            </p>
+          </div>
+        ) : (
+          <div className='space-y-3'>
+            <p className='text-sm text-zinc-400'>
+              Publish a message to announce the winners. It notifies the winners
+              and the community, and appears on the public results page.
+            </p>
+            <Textarea
+              value={message}
+              onChange={e => setMessage(e.target.value.slice(0, MAX_MESSAGE))}
+              placeholder='Congratulations to our winners…'
+              rows={5}
+              disabled={publish.isPending}
+              className='border-zinc-800 bg-zinc-900/50 text-white placeholder:text-zinc-600'
+            />
+            <div className='flex items-center justify-between'>
+              <span className='text-xs text-zinc-600'>
+                {message.length}/{MAX_MESSAGE}
+              </span>
+              <BoundlessButton
+                onClick={onPublish}
+                disabled={publish.isPending || !message.trim()}
+              >
+                {publish.isPending ? (
+                  <>
+                    <Loader2 className='h-4 w-4 animate-spin' />
+                    Publishing…
+                  </>
+                ) : (
+                  'Publish & announce'
+                )}
+              </BoundlessButton>
+            </div>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function WinnerRow({
+  winner,
+  currency,
+}: {
+  winner: BountyResultsWinner;
+  currency: string;
+}) {
+  return (
+    <div className='flex items-center justify-between rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4'>
+      <div className='min-w-0'>
+        <p className='text-sm font-medium text-white'>
+          {ordinal(winner.tierPosition)} place
+        </p>
+        {winner.applicantAddress && (
+          <p className='font-mono text-xs text-zinc-500'>
+            {formatPublicKey(winner.applicantAddress)}
+          </p>
+        )}
+      </div>
+      <div className='text-right'>
+        <p className='text-primary text-sm font-semibold'>
+          {formatAmount(winner.tierAmount)} {currency}
+        </p>
+        {winner.rewardTransactionHash && (
+          <a
+            href={getTransactionExplorerUrl(winner.rewardTransactionHash)}
+            target='_blank'
+            rel='noreferrer'
+            className='text-primary inline-flex items-center gap-1 text-xs hover:underline'
+          >
+            Payout tx
+            <ExternalLink className='h-3 w-3' />
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/organization/bounties/manage/BountySettingsPanel.tsx
+++ b/components/organization/bounties/manage/BountySettingsPanel.tsx
@@ -1,11 +1,14 @@
 'use client';
 
 import { useState } from 'react';
+import { toast } from 'sonner';
 import {
   AlertTriangle,
+  Archive,
   CheckCircle2,
   ExternalLink,
   Loader2,
+  RotateCcw,
 } from 'lucide-react';
 
 import {
@@ -20,6 +23,8 @@ import { Input } from '@/components/ui/input';
 import { BoundlessButton } from '@/components/buttons';
 import {
   ESCROW_PHASE_LABEL,
+  useArchiveBounty,
+  useRestoreBounty,
   type BountyOperateOverview,
 } from '@/features/bounties';
 import { useBountyCancel } from '@/hooks/use-bounty-cancel';
@@ -49,11 +54,43 @@ export default function BountySettingsPanel({
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [confirmText, setConfirmText] = useState('');
 
+  const archiveMutation = useArchiveBounty(organizationId, bountyId);
+  const restoreMutation = useRestoreBounty(organizationId, bountyId);
+  // The overview read doesn't carry an archived flag, so we track the last
+  // action locally for immediate feedback; it resets to active on reload.
+  const [archived, setArchived] = useState(false);
+
   const isCancelled = overview.status === 'cancelled';
   const isTerminal = TERMINAL_STATUSES.has(overview.status);
   // A draft has no on-chain escrow to refund; cancel only applies once funded.
   const isPublished = !!overview.escrowEventId;
   const running = cancelOp.isRunning;
+
+  const onArchive = () =>
+    archiveMutation.mutate(undefined, {
+      onSuccess: () => {
+        setArchived(true);
+        toast.success('Bounty archived.');
+      },
+      onError: err =>
+        toast.error(
+          err instanceof Error ? err.message : 'Failed to archive the bounty'
+        ),
+    });
+
+  const onRestore = () =>
+    restoreMutation.mutate(undefined, {
+      onSuccess: () => {
+        setArchived(false);
+        toast.success('Bounty restored.');
+      },
+      onError: err =>
+        toast.error(
+          err instanceof Error ? err.message : 'Failed to restore the bounty'
+        ),
+    });
+
+  const archiveBusy = archiveMutation.isPending || restoreMutation.isPending;
 
   return (
     <div className='max-w-2xl space-y-6'>
@@ -118,6 +155,64 @@ export default function BountySettingsPanel({
           </div>
         </div>
       </div>
+
+      {/* Archive / restore — only for closed-out bounties. Never a hard delete. */}
+      {isTerminal && (
+        <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5'>
+          <div className='flex items-start gap-3'>
+            <Archive className='mt-0.5 h-5 w-5 shrink-0 text-zinc-400' />
+            <div className='min-w-0 flex-1'>
+              <h3 className='text-sm font-semibold text-white'>
+                {archived ? 'Bounty archived' : 'Archive this bounty'}
+              </h3>
+              <p className='mt-1 text-sm text-zinc-400'>
+                {archived
+                  ? 'This bounty is hidden from your active list. Restore it to bring it back. Its records are never deleted.'
+                  : 'Move this closed-out bounty out of your active list. It stays fully recoverable and is never deleted.'}
+              </p>
+              {archived ? (
+                <BoundlessButton
+                  variant='outline'
+                  className='mt-4'
+                  disabled={archiveBusy}
+                  onClick={onRestore}
+                >
+                  {restoreMutation.isPending ? (
+                    <>
+                      <Loader2 className='h-4 w-4 animate-spin' />
+                      Restoring…
+                    </>
+                  ) : (
+                    <>
+                      <RotateCcw className='h-4 w-4' />
+                      Restore bounty
+                    </>
+                  )}
+                </BoundlessButton>
+              ) : (
+                <BoundlessButton
+                  variant='outline'
+                  className='mt-4'
+                  disabled={archiveBusy}
+                  onClick={onArchive}
+                >
+                  {archiveMutation.isPending ? (
+                    <>
+                      <Loader2 className='h-4 w-4 animate-spin' />
+                      Archiving…
+                    </>
+                  ) : (
+                    <>
+                      <Archive className='h-4 w-4' />
+                      Archive bounty
+                    </>
+                  )}
+                </BoundlessButton>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Explicit-confirm gate before the irreversible on-chain refund. */}
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>

--- a/features/bounties/api/keys.ts
+++ b/features/bounties/api/keys.ts
@@ -56,4 +56,10 @@ export const bountyKeys = {
       bountyId,
       params,
     ] as const,
+
+  // Wrap: public results + winner announcement (#635).
+  results: (bountyId: string) =>
+    [...bountyKeys.all, 'results', bountyId] as const,
+  announcement: (bountyId: string) =>
+    [...bountyKeys.all, 'announcement', bountyId] as const,
 };

--- a/features/bounties/api/organizer-wrap-client.ts
+++ b/features/bounties/api/organizer-wrap-client.ts
@@ -1,0 +1,78 @@
+/**
+ * Bounty Wrap API client (#635): the organizer close-out actions and the public
+ * results/announcement reads. Request/response shapes come from the backend
+ * generated schema, so they never drift from boundless-nestjs.
+ *
+ *   - publish-results : organizer publishes the winner announcement (message),
+ *                       which fans out winner + community notifications.
+ *   - archive/restore : soft-close a completed/cancelled bounty (never a hard
+ *                       delete); restore brings it back.
+ *   - results / announcement : public reads consumed by the completed-bounty
+ *                       results view.
+ */
+import { apiClient, unwrapData, type Schemas } from '@/lib/api';
+
+// ── Types (aliased from the generated schema) ────────────────────────────────
+export type BountyResults = Schemas['BountyResultsDto'];
+export type BountyResultsWinner = Schemas['BountyWinnerDto'];
+export type BountyAnnouncement = Schemas['BountyAnnouncementDto'];
+export type PublishBountyResultsBody = Schemas['PublishBountyResultsDto'];
+
+// ── Organizer close-out actions ──────────────────────────────────────────────
+
+/** Publish the winner announcement; triggers winner + community notifications. */
+export const publishBountyResults = async (
+  organizationId: string,
+  bountyId: string,
+  body: PublishBountyResultsBody
+): Promise<BountyAnnouncement> =>
+  unwrapData(
+    await apiClient.POST(
+      '/api/organizations/{organizationId}/bounties/{bountyId}/publish-results',
+      { params: { path: { organizationId, bountyId } }, body }
+    )
+  );
+
+/** Archive a completed/cancelled bounty (soft close; never a hard delete). */
+export const archiveBounty = async (
+  organizationId: string,
+  bountyId: string
+): Promise<void> => {
+  await apiClient.POST(
+    '/api/organizations/{organizationId}/bounties/{bountyId}/archive',
+    { params: { path: { organizationId, bountyId } } }
+  );
+};
+
+/** Restore an archived bounty. */
+export const restoreBounty = async (
+  organizationId: string,
+  bountyId: string
+): Promise<void> => {
+  await apiClient.POST(
+    '/api/organizations/{organizationId}/bounties/{bountyId}/restore',
+    { params: { path: { organizationId, bountyId } } }
+  );
+};
+
+// ── Public reads (results view) ──────────────────────────────────────────────
+
+/** Public results / leaderboard: winners by tier + payout tx. */
+export const getBountyResults = async (
+  bountyId: string
+): Promise<BountyResults> =>
+  unwrapData(
+    await apiClient.GET('/api/bounties/{id}/results', {
+      params: { path: { id: bountyId } },
+    })
+  );
+
+/** Public winner announcement (null when none published yet). */
+export const getBountyAnnouncement = async (
+  bountyId: string
+): Promise<BountyAnnouncement | null> => {
+  const { data } = await apiClient.GET('/api/bounties/{bountyId}/announcement', {
+    params: { path: { bountyId } },
+  });
+  return data ?? null;
+};

--- a/features/bounties/api/use-organizer-wrap.ts
+++ b/features/bounties/api/use-organizer-wrap.ts
@@ -1,0 +1,98 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { bountyKeys } from './keys';
+import {
+  archiveBounty,
+  getBountyAnnouncement,
+  getBountyResults,
+  publishBountyResults,
+  restoreBounty,
+  type BountyAnnouncement,
+  type BountyResults,
+  type PublishBountyResultsBody,
+} from './organizer-wrap-client';
+
+/**
+ * Public results (winners by tier + payout tx) for a completed bounty. Consumed
+ * by the results view on both the organizer dashboard and the public detail.
+ */
+export function useBountyResults(
+  bountyId: string | undefined,
+  options: { enabled?: boolean } = {}
+) {
+  return useQuery<BountyResults>({
+    queryKey: bountyKeys.results(bountyId ?? ''),
+    queryFn: () => getBountyResults(bountyId as string),
+    enabled: !!bountyId && (options.enabled ?? true),
+  });
+}
+
+/** Published winner announcement (null until the organizer publishes one). */
+export function useBountyAnnouncement(
+  bountyId: string | undefined,
+  options: { enabled?: boolean } = {}
+) {
+  return useQuery<BountyAnnouncement | null>({
+    queryKey: bountyKeys.announcement(bountyId ?? ''),
+    queryFn: () => getBountyAnnouncement(bountyId as string),
+    enabled: !!bountyId && (options.enabled ?? true),
+  });
+}
+
+/**
+ * Publish the winner announcement. On success the backend fans out winner +
+ * community notifications; we refresh the announcement and the overview so the
+ * dashboard reflects the published state.
+ */
+export function usePublishBountyResults(
+  organizationId: string,
+  bountyId: string
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: PublishBountyResultsBody) =>
+      publishBountyResults(organizationId, bountyId, body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: bountyKeys.announcement(bountyId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: bountyKeys.overview(organizationId, bountyId),
+      });
+    },
+  });
+}
+
+/** Archive a completed/cancelled bounty; refresh the overview + drafts list. */
+export function useArchiveBounty(organizationId: string, bountyId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => archiveBounty(organizationId, bountyId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: bountyKeys.overview(organizationId, bountyId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: bountyKeys.drafts(organizationId),
+      });
+    },
+  });
+}
+
+/** Restore an archived bounty; refresh the overview + drafts list. */
+export function useRestoreBounty(organizationId: string, bountyId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => restoreBounty(organizationId, bountyId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: bountyKeys.overview(organizationId, bountyId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: bountyKeys.drafts(organizationId),
+      });
+    },
+  });
+}

--- a/features/bounties/index.ts
+++ b/features/bounties/index.ts
@@ -228,6 +228,28 @@ export {
   useDeclineApplication,
 } from './api/use-organizer-applications';
 
+// ── Wrap: results, announcement, archive (#635) ──────────────────────────────
+export {
+  publishBountyResults,
+  archiveBounty,
+  restoreBounty,
+  getBountyResults,
+  getBountyAnnouncement,
+} from './api/organizer-wrap-client';
+export type {
+  BountyResults,
+  BountyResultsWinner,
+  BountyAnnouncement,
+  PublishBountyResultsBody,
+} from './api/organizer-wrap-client';
+export {
+  useBountyResults,
+  useBountyAnnouncement,
+  usePublishBountyResults,
+  useArchiveBounty,
+  useRestoreBounty,
+} from './api/use-organizer-wrap';
+
 // Participant hooks (React Query).
 export {
   useBountiesList,


### PR DESCRIPTION
## What

Implements the FE **Wrap** step (#635) of the Bounty Operate to Payout milestone: after payout, publish results, announce winners, and close out.

> Stacked on #674 (#634 cancel/refund). GitHub can't target a fork branch, so until #674 merges this PR shows its commit too; review the top commit `feat(bounty): wrap flow …`. It rebases cleanly once #674 lands.

## Changes

**Data layer**
- `features/bounties/api/organizer-wrap-client.ts` (new) — typed `apiClient` calls: `publishBountyResults`, `archiveBounty`, `restoreBounty`, plus public reads `getBountyResults` and `getBountyAnnouncement` (nullable). Shapes aliased from the generated schema (backend #339).
- `features/bounties/api/use-organizer-wrap.ts` (new) — `useBountyResults`, `useBountyAnnouncement`, `usePublishBountyResults`, `useArchiveBounty`, `useRestoreBounty`. Mutations invalidate the announcement / overview / drafts keys.

**Organizer dashboard**
- `BountyResultsPanel.tsx` (new) — a **Results** tab (visible once completed): winners by tier with payout-tx links, plus a publish-announcement form (or the published message once sent).
- `BountySettingsPanel.tsx` — added an **Archive / Restore** card for completed/cancelled bounties (soft close, never a hard delete).
- `BountyManagementDashboard.tsx` — Results tab wired in.

**Public**
- `BountyResults.tsx` (new) + `BountyDetail.tsx` — a public results block on a completed bounty: announcement message + winners by tier with payout tx.

## Acceptance criteria

- [x] Results/winners view on the completed bounty (public + dashboard), consuming the results read.
- [x] Publish a winners announcement (message) -> triggers winner + community notifications.
- [x] Archive / restore a completed or cancelled bounty (never a hard delete).

## Known gap (backend follow-up filed)

The operate `overview` DTO has no `archivedAt`, so the Settings archive card tracks archived/restored state locally for immediate feedback; it resets to "active" on reload. Reflecting true archive state across reloads needs a backend field — tracked in a boundless-nestjs follow-up issue.

## Verification

- `tsc --noEmit` — 0 errors.
- `eslint .` — clean.