### PR TITLE
feat(bounty): manage-dashboard nav + deep-linkable tabs (#637)

### DIFF
--- a/app/(landing)/organizations/[id]/bounties/[bountyId]/page.tsx
+++ b/app/(landing)/organizations/[id]/bounties/[bountyId]/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import { Metadata } from 'next';
 
 import { AuthGuard } from '@/components/auth';
@@ -11,7 +12,10 @@ export default function BountyManagePageRoute() {
   return (
     <AuthGuard redirectTo='/auth?mode=signin' fallback={<Loading />}>
       <div className='mx-auto max-w-6xl px-6 py-8'>
-        <BountyManagementDashboard />
+        {/* Dashboard reads ?tab= via useSearchParams; needs a suspense boundary. */}
+        <Suspense fallback={<Loading />}>
+          <BountyManagementDashboard />
+        </Suspense>
       </div>
     </AuthGuard>
   );

--- a/app/(landing)/organizations/[id]/bounties/page.tsx
+++ b/app/(landing)/organizations/[id]/bounties/page.tsx
@@ -3,7 +3,15 @@
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
-import { Calendar, FileText, Plus, Search, Target, Trash2 } from 'lucide-react';
+import {
+  ArrowRight,
+  Calendar,
+  FileText,
+  Plus,
+  Search,
+  Target,
+  Trash2,
+} from 'lucide-react';
 
 import { BoundlessButton } from '@/components/buttons';
 import { Badge } from '@/components/ui/badge';
@@ -66,6 +74,26 @@ function statusDisplay(status: string) {
       className: 'border-zinc-700 bg-zinc-800/60 text-zinc-300',
     }
   );
+}
+
+/**
+ * Status-aware manage CTA: deep-links into the dashboard tab that matches where
+ * the organizer's attention is needed next.
+ */
+function manageCta(status: string): { label: string; tab: string } {
+  switch (status) {
+    case 'submitted':
+    case 'under_review':
+      return { label: 'Review submissions', tab: 'submissions' };
+    case 'in_progress':
+      return { label: 'Review & pay', tab: 'payout' };
+    case 'completed':
+      return { label: 'View results', tab: 'results' };
+    case 'cancelled':
+      return { label: 'View bounty', tab: 'overview' };
+    default:
+      return { label: 'Manage', tab: 'overview' };
+  }
 }
 
 const draftPrizePool = (draft: BountyDraft): number =>
@@ -279,6 +307,25 @@ export default function OrganizationBountiesPage() {
                           {bounty._count?.submissions ?? 0}
                         </span>
                       </div>
+                      {(() => {
+                        const cta = manageCta(bounty.status);
+                        return (
+                          <BoundlessButton
+                            variant='outline'
+                            size='sm'
+                            className='mt-4 w-full gap-1.5'
+                            onClick={e => {
+                              e.stopPropagation();
+                              router.push(
+                                `/organizations/${organizationId}/bounties/${bounty.id}?tab=${cta.tab}`
+                              );
+                            }}
+                          >
+                            {cta.label}
+                            <ArrowRight className='h-3.5 w-3.5' />
+                          </BoundlessButton>
+                        );
+                      })()}
                     </div>
                   );
                 })}

--- a/components/organization/bounties/manage/BountyManagementDashboard.tsx
+++ b/components/organization/bounties/manage/BountyManagementDashboard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { ArrowLeft, Info, Loader2 } from 'lucide-react';
 
@@ -30,10 +30,22 @@ import BountyApplicationsPanel from './BountyApplicationsPanel';
 import BountySettingsPanel from './BountySettingsPanel';
 import BountyResultsPanel from './BountyResultsPanel';
 
+/** Tabs the org bounty list can deep-link into via `?tab=`. */
+const LINKABLE_TABS = new Set([
+  'overview',
+  'applications',
+  'submissions',
+  'payout',
+  'results',
+  'settings',
+]);
+
 export default function BountyManagementDashboard() {
   const params = useParams<{ id: string; bountyId: string }>();
+  const searchParams = useSearchParams();
   const organizationId = params?.id ?? '';
   const bountyId = params?.bountyId ?? '';
+  const requestedTab = searchParams?.get('tab') ?? '';
 
   // Winner staging lives here (above the tab boundary) so it survives tab
   // switches and is reachable by the Payout tab (#633).
@@ -87,6 +99,14 @@ export default function BountyManagementDashboard() {
     overview.entryType === 'APPLICATION_LIGHT' ||
     overview.entryType === 'APPLICATION_FULL';
   const isCompleted = overview.status === 'completed';
+
+  // Honor a deep-linked ?tab= only when that tab is actually available for this
+  // bounty (applications need an application mode; results need completion).
+  const tabAvailable =
+    LINKABLE_TABS.has(requestedTab) &&
+    (requestedTab !== 'applications' || isApplication) &&
+    (requestedTab !== 'results' || isCompleted);
+  const initialTab = tabAvailable ? requestedTab : 'overview';
   const modeLabel =
     overview.entryType && overview.claimType
       ? computeBountyModeLabel(overview.entryType, overview.claimType)
@@ -145,7 +165,7 @@ export default function BountyManagementDashboard() {
         </h1>
       </div>
 
-      <Tabs defaultValue='overview'>
+      <Tabs defaultValue={initialTab}>
         <TabsList className='mb-6 flex flex-wrap'>
           <TabsTrigger value='overview'>Overview</TabsTrigger>
           {isApplication && (


### PR DESCRIPTION
## What

Implements the nav wiring for #637 (Bounty Operate to Payout — entry points + e2e verification): connects the org bounty list to the operate dashboard and makes the dashboard tabs deep-linkable.

> Stacked on #675 (#635) → #674 (#634). GitHub can't target a fork branch, so until those merge this PR shows their commits too; review the top commit `feat(bounty): manage-dashboard nav …`. It rebases cleanly as the base PRs land.

## Changes

- **`BountyManagementDashboard.tsx`** — tabs are URL-addressable via `?tab=`, validated against what's actually available for the bounty (`applications` only in application modes, `results` only once completed; otherwise falls back to Overview).
- **`organizations/[id]/bounties/page.tsx`** — each published card gets an explicit, status-aware CTA that deep-links to the relevant tab: *Review submissions* (submitted / under review), *Review & pay* (in progress), *View results* (completed), *View bounty* (cancelled), *Manage* otherwise.
- **`[bountyId]/page.tsx`** — wrapped the dashboard in a `<Suspense>` boundary (required now that it reads `useSearchParams`), matching the existing `verify/page.tsx` precedent.

## Task status

- [x] Link the management dashboard from the org bounty list + manage CTAs.
- [x] `npm run codegen` — already current; the generated schema carries every merged epic endpoint (submissions review, operate reads, publish-results, archive/restore, public results/announcement). Disputes are intentionally absent (#340/#636 deferred).
- [ ] End-to-end testnet verification across the six modes — manual QA (organizer host → run → pay → wrap loop; cancel/refund; single- and multi-winner payouts). Dispute path out of scope.

## Verification

- `tsc --noEmit` — 0 errors.
- `eslint .` — clean.