### PR TITLE
feat(bounty): mirror hackathon organizer shell for bounties

### DIFF
--- a/app/(landing)/organizations/[id]/bounties/[bountyId]/settings/page.tsx
+++ b/app/(landing)/organizations/[id]/bounties/[bountyId]/settings/page.tsx
@@ -1,0 +1,288 @@
+'use client';
+
+import { Suspense } from 'react';
+import { useParams, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import {
+  ArrowLeft,
+  CalendarClock,
+  Info,
+  Loader2,
+  Lock,
+  Settings,
+  ShieldAlert,
+  Trophy,
+} from 'lucide-react';
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { AuthGuard } from '@/components/auth';
+import Loading from '@/components/Loading';
+import EmptyState from '@/components/EmptyState';
+import { DueCountdown } from '@/components/bounties/DueCountdown';
+import BountyGeneralSettingsTab from '@/components/organization/bounties/settings/BountyGeneralSettingsTab';
+import BountySettingsPanel from '@/components/organization/bounties/manage/BountySettingsPanel';
+import {
+  useBountyOverview,
+  type BountyOperateOverview,
+} from '@/features/bounties';
+import { ordinal } from '@/lib/utils';
+
+const tabTriggerClassName =
+  'data-[state=active]:border-b-primary rounded-none border-b-2 border-transparent bg-transparent px-0 pt-4 pb-3 text-sm font-medium text-zinc-400 transition-all data-[state=active]:text-white data-[state=active]:shadow-none flex items-center gap-2';
+
+const SETTINGS_SECTIONS = new Set([
+  'general',
+  'rewards',
+  'timeline',
+  'closeout',
+]);
+
+export default function BountySettingsPage() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <BountySettingsView />
+    </Suspense>
+  );
+}
+
+function BountySettingsView() {
+  const params = useParams<{ id: string; bountyId: string }>();
+  const searchParams = useSearchParams();
+  const organizationId = params?.id ?? '';
+  const bountyId = params?.bountyId ?? '';
+  const requestedSection = searchParams?.get('section') ?? '';
+  const initialSection = SETTINGS_SECTIONS.has(requestedSection)
+    ? requestedSection
+    : 'general';
+
+  const {
+    data: overview,
+    isLoading,
+    error,
+  } = useBountyOverview(organizationId, bountyId);
+
+  return (
+    <AuthGuard redirectTo='/auth?mode=signin' fallback={<Loading />}>
+      <div className='bg-background min-h-screen'>
+        <div className='mx-auto max-w-7xl px-6 py-8'>
+          <Link
+            href={`/organizations/${organizationId}/bounties/${bountyId}`}
+            className='mb-6 inline-flex items-center gap-1.5 text-sm text-zinc-400 transition-colors hover:text-white'
+          >
+            <ArrowLeft className='h-4 w-4' />
+            Back to dashboard
+          </Link>
+
+          <div className='mb-6 flex items-center gap-3'>
+            <Settings className='text-primary h-6 w-6' />
+            <div>
+              <h1 className='text-2xl font-bold text-white sm:text-3xl'>
+                Bounty Settings
+              </h1>
+              <p className='text-sm text-zinc-400'>
+                Configuration, rewards, timeline, and close-out.
+              </p>
+            </div>
+          </div>
+
+          {isLoading ? (
+            <div className='flex min-h-[40vh] items-center justify-center'>
+              <Loader2 className='h-6 w-6 animate-spin text-zinc-500' />
+            </div>
+          ) : error || !overview ? (
+            <EmptyState
+              title="Couldn't load this bounty"
+              description='It may not exist, or you may not have access to manage it.'
+              type='compact'
+            />
+          ) : (
+            <BountySettingsContent
+              organizationId={organizationId}
+              bountyId={bountyId}
+              overview={overview}
+              defaultSection={initialSection}
+            />
+          )}
+        </div>
+      </div>
+    </AuthGuard>
+  );
+}
+
+function BountySettingsContent({
+  organizationId,
+  bountyId,
+  overview,
+  defaultSection,
+}: {
+  organizationId: string;
+  bountyId: string;
+  overview: BountyOperateOverview;
+  defaultSection: string;
+}) {
+  return (
+    <Tabs defaultValue={defaultSection} className='w-full'>
+      <div className='mb-6 border-b border-zinc-900'>
+        <TabsList className='inline-flex h-auto gap-6 bg-transparent p-0'>
+          <TabsTrigger value='general' className={tabTriggerClassName}>
+            <Info className='h-4 w-4' />
+            General
+          </TabsTrigger>
+          <TabsTrigger value='rewards' className={tabTriggerClassName}>
+            <Trophy className='h-4 w-4' />
+            Rewards
+          </TabsTrigger>
+          <TabsTrigger value='timeline' className={tabTriggerClassName}>
+            <CalendarClock className='h-4 w-4' />
+            Timeline
+          </TabsTrigger>
+          <TabsTrigger value='closeout' className={tabTriggerClassName}>
+            <ShieldAlert className='h-4 w-4' />
+            Close-out
+          </TabsTrigger>
+        </TabsList>
+      </div>
+
+      {/* General — editable off-chain details. */}
+      <TabsContent value='general' className='mt-0'>
+        <BountyGeneralSettingsTab
+          organizationId={organizationId}
+          bountyId={bountyId}
+        />
+      </TabsContent>
+
+      {/* Rewards — on-chain, immutable once funded. */}
+      <TabsContent value='rewards' className='mt-0'>
+        <div className='max-w-2xl space-y-4'>
+          <OnChainNotice />
+          <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5'>
+            <h3 className='mb-3 text-sm font-semibold text-white'>
+              Reward pool
+            </h3>
+            <p className='text-primary text-2xl font-bold'>
+              {overview.rewardAmount.toLocaleString()} {overview.rewardCurrency}
+            </p>
+            {overview.prizeTiers.length > 0 && (
+              <div className='mt-4 space-y-2 border-t border-zinc-800 pt-4'>
+                {overview.prizeTiers
+                  .slice()
+                  .sort((a, b) => a.position - b.position)
+                  .map(tier => (
+                    <div
+                      key={tier.position}
+                      className='flex items-center justify-between text-sm'
+                    >
+                      <span className='text-zinc-400'>
+                        {ordinal(tier.position)} place
+                      </span>
+                      <span className='font-medium text-white'>
+                        {Number(tier.amount).toLocaleString()}{' '}
+                        {overview.rewardCurrency}
+                      </span>
+                    </div>
+                  ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </TabsContent>
+
+      {/* Timeline — on-chain deadline, immutable once funded. */}
+      <TabsContent value='timeline' className='mt-0'>
+        <div className='max-w-2xl space-y-4'>
+          <OnChainNotice />
+          <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5'>
+            <h3 className='mb-3 text-sm font-semibold text-white'>Timeline</h3>
+            <dl className='space-y-2.5 text-sm'>
+              {overview.submissionDeadline ? (
+                <div className='flex items-center justify-between gap-3'>
+                  <dt className='text-zinc-400'>Submission deadline</dt>
+                  <dd>
+                    <DueCountdown
+                      deadline={overview.submissionDeadline}
+                      className='flex items-center gap-1.5 text-xs font-medium text-zinc-200'
+                    />
+                  </dd>
+                </div>
+              ) : (
+                <Row label='Submission deadline' value='Not set' />
+              )}
+              {overview.applicationWindowCloseAt && (
+                <div className='flex items-center justify-between gap-3'>
+                  <dt className='text-zinc-400'>Applications close</dt>
+                  <dd>
+                    <DueCountdown
+                      deadline={overview.applicationWindowCloseAt}
+                      className='flex items-center gap-1.5 text-xs font-medium text-zinc-200'
+                    />
+                  </dd>
+                </div>
+              )}
+              {overview.maxApplicants != null && (
+                <Row
+                  label='Max applicants'
+                  value={String(overview.maxApplicants)}
+                />
+              )}
+              {overview.shortlistSize != null && (
+                <Row
+                  label='Shortlist size'
+                  value={String(overview.shortlistSize)}
+                />
+              )}
+            </dl>
+          </div>
+        </div>
+      </TabsContent>
+
+      {/* Close-out — cancel / refund + archive (moved from the dashboard). */}
+      <TabsContent value='closeout' className='mt-0'>
+        <BountySettingsPanel
+          organizationId={organizationId}
+          bountyId={bountyId}
+          overview={overview}
+        />
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+function OnChainNotice() {
+  return (
+    <div className='flex items-start gap-2.5 rounded-xl border border-zinc-800 bg-zinc-900/30 p-3.5 text-sm text-zinc-400'>
+      <Lock className='mt-0.5 h-4 w-4 shrink-0 text-zinc-500' />
+      <span>
+        These values are anchored on-chain in the escrow and cannot be changed
+        after funding.
+      </span>
+    </div>
+  );
+}
+
+function Row({
+  label,
+  value,
+  hint,
+  capitalize,
+}: {
+  label: string;
+  value: string;
+  hint?: string | null;
+  capitalize?: boolean;
+}) {
+  return (
+    <div className='flex items-start justify-between gap-4'>
+      <dt className='text-zinc-400'>{label}</dt>
+      <dd className='max-w-[60%] text-right'>
+        <span
+          className={`font-medium text-white ${capitalize ? 'capitalize' : ''}`}
+        >
+          {value}
+        </span>
+        {hint && (
+          <span className='mt-0.5 block text-xs text-zinc-500'>{hint}</span>
+        )}
+      </dd>
+    </div>
+  );
+}

--- a/app/(landing)/organizations/[id]/bounties/page.tsx
+++ b/app/(landing)/organizations/[id]/bounties/page.tsx
@@ -3,12 +3,14 @@
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import {
-  ArrowRight,
   Calendar,
   FileText,
   Plus,
   Search,
+  Settings,
   Target,
   Trash2,
 } from 'lucide-react';
@@ -26,7 +28,9 @@ import {
 import { AuthGuard } from '@/components/auth';
 import Loading from '@/components/Loading';
 import DeleteBountyDraftDialog from '@/components/organization/bounties/DeleteBountyDraftDialog';
+import RemoveBountyDialog from '@/components/organization/bounties/RemoveBountyDialog';
 import {
+  archiveBounty,
   useDeleteDraft,
   useDraftList,
   useOrganizationBounties,
@@ -76,26 +80,6 @@ function statusDisplay(status: string) {
   );
 }
 
-/**
- * Status-aware manage CTA: deep-links into the dashboard tab that matches where
- * the organizer's attention is needed next.
- */
-function manageCta(status: string): { label: string; tab: string } {
-  switch (status) {
-    case 'submitted':
-    case 'under_review':
-      return { label: 'Review submissions', tab: 'submissions' };
-    case 'in_progress':
-      return { label: 'Review & pay', tab: 'payout' };
-    case 'completed':
-      return { label: 'View results', tab: 'results' };
-    case 'cancelled':
-      return { label: 'View bounty', tab: 'overview' };
-    default:
-      return { label: 'Manage', tab: 'overview' };
-  }
-}
-
 const draftPrizePool = (draft: BountyDraft): number =>
   (draft.data?.reward?.prizeTiers ?? []).reduce(
     (sum, tier) => sum + (Number(tier.amount) || 0),
@@ -118,6 +102,23 @@ export default function OrganizationBountiesPage() {
     id: string;
     title: string;
   } | null>(null);
+
+  // Removing a published bounty: archive it (once closed out) or route to the
+  // cancel/refund flow (while it's still live). Confirmed in RemoveBountyDialog.
+  const [bountyToRemove, setBountyToRemove] =
+    useState<OrganizationBountyListItem | null>(null);
+  const archiveMutation = useMutation({
+    mutationFn: (bountyId: string) => archiveBounty(organizationId, bountyId),
+    onSuccess: () => {
+      toast.success('Bounty archived.');
+      setBountyToRemove(null);
+      void publishedQuery.refetch();
+    },
+    onError: err =>
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to archive the bounty'
+      ),
+  });
 
   const allDrafts: BountyDraft[] = draftsQuery.data ?? [];
 
@@ -302,30 +303,44 @@ export default function OrganizationBountiesPage() {
                             <p className='text-[11px] text-zinc-500'>reward</p>
                           </div>
                         </div>
-                        <span className='flex items-center gap-1 text-xs text-zinc-400'>
+                        <span
+                          className='flex items-center gap-1 text-xs text-zinc-400'
+                          title='Submissions'
+                        >
                           <FileText className='h-4 w-4' />
-                          {bounty._count?.submissions ?? 0}
+                          {bounty._count?.submissions ?? 0} submissions
                         </span>
                       </div>
-                      {(() => {
-                        const cta = manageCta(bounty.status);
-                        return (
-                          <BoundlessButton
-                            variant='outline'
-                            size='sm'
-                            className='mt-4 w-full gap-1.5'
-                            onClick={e => {
-                              e.stopPropagation();
-                              router.push(
-                                `/organizations/${organizationId}/bounties/${bounty.id}?tab=${cta.tab}`
-                              );
-                            }}
-                          >
-                            {cta.label}
-                            <ArrowRight className='h-3.5 w-3.5' />
-                          </BoundlessButton>
-                        );
-                      })()}
+
+                      {/* Hover actions (mirrors the hackathon organizer card). */}
+                      <div className='absolute top-3 right-3 z-10 flex gap-2 opacity-0 transition-opacity group-hover:opacity-100'>
+                        <button
+                          type='button'
+                          onClick={e => {
+                            e.stopPropagation();
+                            router.push(
+                              `/organizations/${organizationId}/bounties/${bounty.id}/settings`
+                            );
+                          }}
+                          className='flex h-9 w-9 items-center justify-center rounded-lg border border-zinc-800 bg-zinc-900/70 text-zinc-400 hover:border-zinc-700 hover:text-white'
+                          title='Settings'
+                          aria-label={`Bounty settings for ${bounty.title || 'Untitled bounty'}`}
+                        >
+                          <Settings className='h-4 w-4' />
+                        </button>
+                        <button
+                          type='button'
+                          onClick={e => {
+                            e.stopPropagation();
+                            setBountyToRemove(bounty);
+                          }}
+                          className='flex h-9 w-9 items-center justify-center rounded-lg border border-zinc-800 bg-zinc-900/70 text-zinc-400 hover:border-red-600 hover:text-red-500'
+                          title='Remove bounty'
+                          aria-label={`Remove ${bounty.title || 'Untitled bounty'}`}
+                        >
+                          <Trash2 className='h-4 w-4' />
+                        </button>
+                      </div>
                     </div>
                   );
                 })}
@@ -427,6 +442,27 @@ export default function OrganizationBountiesPage() {
         isDeleting={deleteDraft.isPending}
         onConfirm={() => {
           if (draftToDelete) deleteDraft.mutate(draftToDelete.id);
+        }}
+      />
+
+      <RemoveBountyDialog
+        open={!!bountyToRemove}
+        onOpenChange={open => {
+          if (!open) setBountyToRemove(null);
+        }}
+        bountyTitle={bountyToRemove?.title ?? ''}
+        status={bountyToRemove?.status ?? ''}
+        isArchiving={archiveMutation.isPending}
+        onArchive={() => {
+          if (bountyToRemove) archiveMutation.mutate(bountyToRemove.id);
+        }}
+        onCancelRefund={() => {
+          if (!bountyToRemove) return;
+          const id = bountyToRemove.id;
+          setBountyToRemove(null);
+          router.push(
+            `/organizations/${organizationId}/bounties/${id}/settings?section=closeout`
+          );
         }}
       />
     </AuthGuard>

--- a/app/(landing)/organizations/layout.tsx
+++ b/app/(landing)/organizations/layout.tsx
@@ -13,6 +13,7 @@ import {
 import { cn } from '@/lib/utils';
 import HackathonSidebar from '@/components/organization/hackathons/details/HackathonSidebar';
 import HackathonNavigationLoader from '@/components/organization/hackathons/details/HackathonNavigationLoader';
+import BountyManageSidebar from '@/components/organization/bounties/manage/BountyManageSidebar';
 
 export default function OrganizationsLayout({
   children,
@@ -29,6 +30,14 @@ export default function OrganizationsLayout({
   // under /hackathons/ except the list page itself.
   const showHackathonSidebar =
     pathname.includes('/hackathons/') && !pathname.endsWith('/hackathons');
+  // Management shell for a published bounty (dashboard + settings). Excludes the
+  // list, the create wizard (/new) and draft editing (/drafts), which keep the
+  // general org sidebar.
+  const showBountySidebar =
+    pathname.includes('/bounties/') &&
+    !pathname.endsWith('/bounties') &&
+    !pathname.includes('/bounties/new') &&
+    !pathname.includes('/bounties/drafts');
   const getOrgIdFromPath = () => {
     if (pathname.startsWith('/organizations/')) {
       const pathParts = pathname.split('/');
@@ -49,6 +58,7 @@ export default function OrganizationsLayout({
           showOrganizationSidebar={showOrganizationSidebar}
           showNewGrantSidebar={showNewGrantSidebar}
           showHackathonSidebar={showHackathonSidebar}
+          showBountySidebar={showBountySidebar}
           initialOrgId={initialOrgId}
         >
           {children}
@@ -63,12 +73,14 @@ function OrganizationsLayoutContent({
   showOrganizationSidebar,
   showNewGrantSidebar,
   showHackathonSidebar,
+  showBountySidebar,
   initialOrgId,
 }: {
   children: React.ReactNode;
   showOrganizationSidebar: boolean;
   showNewGrantSidebar: boolean;
   showHackathonSidebar: boolean;
+  showBountySidebar: boolean;
   initialOrgId: string | null;
 }) {
   const { isNavigating } = useNavigationLoading();
@@ -81,9 +93,13 @@ function OrganizationsLayoutContent({
         <div className='relative border-t border-t-zinc-800'>
           {showOrganizationSidebar &&
             !showNewGrantSidebar &&
-            !showHackathonSidebar && <OrganizationSidebar />}
+            !showHackathonSidebar &&
+            !showBountySidebar && <OrganizationSidebar />}
           {showHackathonSidebar && (
             <HackathonSidebar organizationId={initialOrgId || undefined} />
+          )}
+          {showBountySidebar && (
+            <BountyManageSidebar organizationId={initialOrgId || undefined} />
           )}
           {/* {showNewGrantSidebar && <NewGrantSidebar />} */}
 

--- a/components/organization/bounties/RemoveBountyDialog.tsx
+++ b/components/organization/bounties/RemoveBountyDialog.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { AlertTriangle, Archive } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+/** completed / cancelled bounties can be archived; live ones must be cancelled. */
+const TERMINAL_STATUSES = new Set(['completed', 'cancelled']);
+
+interface RemoveBountyDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  bountyTitle: string;
+  /** Lowercase lifecycle status of the bounty being removed. */
+  status: string;
+  isArchiving?: boolean;
+  /** Archive (soft-delete) a closed-out bounty. */
+  onArchive: () => void;
+  /** Route to the settings close-out (cancel + refund) for a live bounty. */
+  onCancelRefund: () => void;
+}
+
+/**
+ * Confirmation modal for removing a published bounty, mirroring the hackathon
+ * delete dialog. A funded bounty can't be hard-deleted: once completed or
+ * cancelled it is archived (recoverable, never deleted); while still live it
+ * must be cancelled and refunded on-chain, so we route there instead.
+ */
+export default function RemoveBountyDialog({
+  open,
+  onOpenChange,
+  bountyTitle,
+  status,
+  isArchiving = false,
+  onArchive,
+  onCancelRefund,
+}: RemoveBountyDialogProps) {
+  const isTerminal = TERMINAL_STATUSES.has(status);
+  const title = bountyTitle || 'this bounty';
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className='border-zinc-800 bg-zinc-950'>
+        <AlertDialogHeader className='items-center'>
+          <div className='flex size-12 items-center justify-center rounded-full bg-red-500/10'>
+            {isTerminal ? (
+              <Archive className='size-6 text-red-500' />
+            ) : (
+              <AlertTriangle className='size-6 text-red-500' />
+            )}
+          </div>
+          <AlertDialogTitle className='text-xl text-white'>
+            {isTerminal ? 'Archive this bounty?' : 'This bounty is still live'}
+          </AlertDialogTitle>
+          <AlertDialogDescription className='text-center text-zinc-400'>
+            {isTerminal ? (
+              <>
+                <span className='font-semibold text-white'>
+                  &quot;{title}&quot;
+                </span>{' '}
+                will be hidden from your active list. Its records are never
+                deleted, and you can restore it anytime.
+              </>
+            ) : (
+              <>
+                <span className='font-semibold text-white'>
+                  &quot;{title}&quot;
+                </span>{' '}
+                is funded on-chain and can&apos;t be deleted. To remove it,
+                cancel and refund it first.
+              </>
+            )}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel
+            disabled={isArchiving}
+            className='border-zinc-700 bg-zinc-900 text-zinc-300 hover:bg-zinc-800 hover:text-white'
+          >
+            {isTerminal ? 'Cancel' : 'Not now'}
+          </AlertDialogCancel>
+          {isTerminal ? (
+            <AlertDialogAction
+              onClick={onArchive}
+              disabled={isArchiving}
+              className='bg-red-500 text-white hover:bg-red-600 disabled:cursor-not-allowed disabled:opacity-50'
+            >
+              {isArchiving ? 'Archiving...' : 'Archive bounty'}
+            </AlertDialogAction>
+          ) : (
+            <AlertDialogAction
+              onClick={onCancelRefund}
+              className='bg-red-500 text-white hover:bg-red-600'
+            >
+              Cancel &amp; refund
+            </AlertDialogAction>
+          )}
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/components/organization/bounties/manage/BountyManageSidebar.tsx
+++ b/components/organization/bounties/manage/BountyManageSidebar.tsx
@@ -1,0 +1,272 @@
+'use client';
+
+import { useMemo } from 'react';
+import Link from 'next/link';
+import { usePathname, useSearchParams } from 'next/navigation';
+import {
+  BarChartBig,
+  FileText,
+  LayoutDashboard,
+  Menu,
+  Settings,
+  Trophy,
+  Users,
+  type LucideIcon,
+} from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
+import {
+  useBountyOverview,
+  useOrganizationBounties,
+} from '@/features/bounties';
+import BountySelector, { type SidebarBounty } from './BountySelector';
+
+type SectionKey =
+  | 'overview'
+  | 'applications'
+  | 'submissions'
+  | 'payout'
+  | 'results'
+  | 'settings';
+
+interface NavItem {
+  key: SectionKey;
+  icon: LucideIcon;
+  label: string;
+  description: string;
+  href: string;
+}
+
+const DRAFT_STATUSES = new Set(['draft', 'draft_awaiting_funding']);
+
+/**
+ * Persistent management sidebar for a single bounty, mirroring the hackathon
+ * organizer sidebar: a bounty switcher on top and the operational nav below.
+ * Rendered by the organizations layout on bounty management routes (replacing
+ * the general org sidebar), so it is self-contained — it derives the bounty id
+ * from the path and fetches its own data.
+ */
+export default function BountyManageSidebar({
+  organizationId,
+}: {
+  organizationId?: string;
+}) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const orgId = useMemo(() => {
+    if (organizationId) return organizationId;
+    const parts = pathname?.split('/') ?? [];
+    return parts[1] === 'organizations' ? (parts[2] ?? '') : '';
+  }, [organizationId, pathname]);
+
+  const bountyId = useMemo(() => {
+    const parts = pathname?.split('/') ?? [];
+    // /organizations/{org}/bounties/{bountyId}[/settings]
+    if (parts[3] === 'bounties') {
+      const id = parts[4];
+      if (id && id !== 'new' && id !== 'drafts') return id;
+    }
+    return '';
+  }, [pathname]);
+
+  const { data: listData } = useOrganizationBounties(orgId);
+  const { data: overview } = useBountyOverview(orgId, bountyId);
+
+  const bounties: SidebarBounty[] = useMemo(
+    () =>
+      (listData ?? [])
+        .filter(b => !DRAFT_STATUSES.has(b.status))
+        .map(b => ({
+          id: b.id,
+          title: b.title ?? 'Untitled bounty',
+          status: b.status,
+        })),
+    [listData]
+  );
+
+  const onSettings = pathname?.endsWith('/settings') ?? false;
+  const activeKey: SectionKey = onSettings
+    ? 'settings'
+    : ((searchParams?.get('tab') as SectionKey) ?? 'overview');
+
+  const isApplication =
+    overview?.entryType === 'APPLICATION_LIGHT' ||
+    overview?.entryType === 'APPLICATION_FULL';
+  const isCompleted = overview?.status === 'completed';
+
+  const base = `/organizations/${orgId}/bounties/${bountyId}`;
+  const items: NavItem[] = useMemo(() => {
+    const list: NavItem[] = [
+      {
+        key: 'overview',
+        icon: LayoutDashboard,
+        label: 'Overview',
+        description: 'Analytics dashboard',
+        href: `${base}?tab=overview`,
+      },
+    ];
+    if (isApplication) {
+      list.push({
+        key: 'applications',
+        icon: Users,
+        label: 'Applications',
+        description: 'Shortlist and select',
+        href: `${base}?tab=applications`,
+      });
+    }
+    list.push(
+      {
+        key: 'submissions',
+        icon: FileText,
+        label: 'Submissions',
+        description: 'Review submitted work',
+        href: `${base}?tab=submissions`,
+      },
+      {
+        key: 'payout',
+        icon: Trophy,
+        label: 'Payout & Winners',
+        description: 'Select and pay winners',
+        href: `${base}?tab=payout`,
+      }
+    );
+    if (isCompleted) {
+      list.push({
+        key: 'results',
+        icon: BarChartBig,
+        label: 'Results',
+        description: 'Winners and announcement',
+        href: `${base}?tab=results`,
+      });
+    }
+    list.push({
+      key: 'settings',
+      icon: Settings,
+      label: 'Settings',
+      description: 'Configure and close out',
+      href: `${base}/settings`,
+    });
+    return list;
+  }, [base, isApplication, isCompleted]);
+
+  const content = (
+    <BountySidebarContent
+      organizationId={orgId}
+      bountyId={bountyId}
+      bounties={bounties}
+      items={items}
+      activeKey={activeKey}
+    />
+  );
+
+  return (
+    <>
+      {/* Mobile: hamburger + sheet */}
+      <div className='fixed top-20 left-4 z-50 md:hidden'>
+        <Sheet>
+          <SheetTrigger asChild>
+            <button
+              className='flex h-10 w-10 items-center justify-center rounded-lg border border-zinc-800 bg-black/60 shadow-lg backdrop-blur-xl'
+              aria-label='Open bounty menu'
+            >
+              <Menu className='h-5 w-5 text-white' />
+            </button>
+          </SheetTrigger>
+          <SheetContent
+            side='left'
+            className='w-[280px] border-r border-zinc-800 bg-black p-0'
+          >
+            {content}
+          </SheetContent>
+        </Sheet>
+      </div>
+
+      {/* Desktop: fixed sidebar */}
+      <aside
+        className='fixed left-0 hidden h-[calc(100vh-90px)] w-[280px] border-r border-zinc-800/50 bg-black/40 backdrop-blur-xl md:block'
+        style={{ top: '90px' }}
+      >
+        {content}
+      </aside>
+    </>
+  );
+}
+
+function BountySidebarContent({
+  organizationId,
+  bountyId,
+  bounties,
+  items,
+  activeKey,
+}: {
+  organizationId: string;
+  bountyId: string;
+  bounties: SidebarBounty[];
+  items: NavItem[];
+  activeKey: SectionKey;
+}) {
+  return (
+    <nav className='flex h-full flex-col overflow-y-auto px-4 py-6'>
+      <div className='mb-6 rounded-xl bg-zinc-900/50 p-2'>
+        <BountySelector
+          organizationId={organizationId}
+          bounties={bounties}
+          currentId={bountyId}
+        />
+      </div>
+
+      <h3 className='mb-3 px-3 text-[11px] font-semibold tracking-wider text-zinc-500 uppercase'>
+        Navigation
+      </h3>
+
+      <div className='space-y-1'>
+        {items.map(item => {
+          const Icon = item.icon;
+          const isActive = item.key === activeKey;
+          return (
+            <Link
+              key={item.key}
+              href={item.href}
+              aria-current={isActive ? 'page' : undefined}
+              className={cn(
+                'group relative flex items-center gap-3 rounded-xl px-3 py-3 text-sm font-medium transition-all',
+                isActive
+                  ? 'from-primary/10 text-primary shadow-primary/5 bg-linear-to-r to-transparent shadow-lg'
+                  : 'text-zinc-400 hover:bg-zinc-900/50 hover:text-white'
+              )}
+            >
+              {isActive && (
+                <span className='bg-primary absolute top-1/2 left-0 h-8 w-1 -translate-y-1/2 rounded-r-full' />
+              )}
+              <span
+                className={cn(
+                  'flex h-9 w-9 items-center justify-center rounded-lg transition-all',
+                  isActive
+                    ? 'bg-primary/20 shadow-primary/20 shadow-lg'
+                    : 'bg-zinc-900/50 group-hover:bg-zinc-800'
+                )}
+              >
+                <Icon className='h-4 w-4' />
+              </span>
+              <span className='flex flex-col'>
+                <span>{item.label}</span>
+                <span
+                  className={cn(
+                    'text-xs transition-colors',
+                    isActive
+                      ? 'text-primary/60'
+                      : 'text-zinc-600 group-hover:text-zinc-500'
+                  )}
+                >
+                  {item.description}
+                </span>
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/components/organization/bounties/manage/BountyManagementDashboard.tsx
+++ b/components/organization/bounties/manage/BountyManagementDashboard.tsx
@@ -3,31 +3,26 @@
 import { useState } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { ArrowLeft, Info, Loader2 } from 'lucide-react';
+import { Info, Loader2 } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Tabs, TabsContent } from '@/components/ui/tabs';
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import EmptyState from '@/components/EmptyState';
-import { DueCountdown } from '@/components/bounties/DueCountdown';
 import { bountyStatusClass } from '@/components/bounties/statusClass';
 import {
   computeBountyModeLabel,
   computeBountyModeDescription,
 } from '@/components/organization/bounties/new/tabs/schemas/modeSchema';
-import {
-  useBountyOverview,
-  type BountyOperateOverview,
-} from '@/features/bounties';
-import { ordinal } from '@/lib/utils';
+import { useBountyOverview } from '@/features/bounties';
+import BountyOverviewPanel from './BountyOverviewPanel';
 import BountySubmissionsPanel from './BountySubmissionsPanel';
 import BountyPayoutPanel from './BountyPayoutPanel';
 import BountyApplicationsPanel from './BountyApplicationsPanel';
-import BountySettingsPanel from './BountySettingsPanel';
 import BountyResultsPanel from './BountyResultsPanel';
 
 /** Tabs the org bounty list can deep-link into via `?tab=`. */
@@ -37,7 +32,6 @@ const LINKABLE_TABS = new Set([
   'submissions',
   'payout',
   'results',
-  'settings',
 ]);
 
 export default function BountyManagementDashboard() {
@@ -119,14 +113,6 @@ export default function BountyManagementDashboard() {
 
   return (
     <div>
-      <Link
-        href={`/organizations/${organizationId}/bounties`}
-        className='mb-6 inline-flex items-center gap-1.5 text-sm text-zinc-400 transition-colors hover:text-white'
-      >
-        <ArrowLeft className='h-4 w-4' />
-        Back to bounties
-      </Link>
-
       {/* Header */}
       <div className='mb-6'>
         <div className='mb-3 flex flex-wrap items-center gap-2'>
@@ -165,20 +151,10 @@ export default function BountyManagementDashboard() {
         </h1>
       </div>
 
-      <Tabs defaultValue={initialTab}>
-        <TabsList className='mb-6 flex flex-wrap'>
-          <TabsTrigger value='overview'>Overview</TabsTrigger>
-          {isApplication && (
-            <TabsTrigger value='applications'>Applications</TabsTrigger>
-          )}
-          <TabsTrigger value='submissions'>Submissions</TabsTrigger>
-          <TabsTrigger value='payout'>Payout &amp; Winners</TabsTrigger>
-          {isCompleted && <TabsTrigger value='results'>Results</TabsTrigger>}
-          <TabsTrigger value='settings'>Settings</TabsTrigger>
-        </TabsList>
-
+      {/* Sections are driven by the management sidebar via ?tab=. */}
+      <Tabs value={initialTab}>
         <TabsContent value='overview'>
-          <OverviewPanel overview={overview} />
+          <BountyOverviewPanel overview={overview} />
         </TabsContent>
         {isApplication && (
           <TabsContent value='applications'>
@@ -215,179 +191,7 @@ export default function BountyManagementDashboard() {
             />
           </TabsContent>
         )}
-        <TabsContent value='settings'>
-          <BountySettingsPanel
-            organizationId={organizationId}
-            bountyId={bountyId}
-            overview={overview}
-          />
-        </TabsContent>
       </Tabs>
-    </div>
-  );
-}
-
-function OverviewPanel({ overview }: { overview: BountyOperateOverview }) {
-  const { intake } = overview;
-  return (
-    <div className='space-y-6'>
-      {/* Intake stats */}
-      <div className='grid gap-4 sm:grid-cols-3'>
-        <StatCard
-          label='Applications'
-          total={intake.applications.total}
-          breakdown={[
-            ['Submitted', intake.applications.submitted],
-            ['Shortlisted', intake.applications.shortlisted],
-            ['Selected', intake.applications.selected],
-            ['Declined', intake.applications.declined],
-            ['Withdrawn', intake.applications.withdrawn],
-          ]}
-        />
-        <StatCard
-          label='Submissions'
-          total={intake.submissions.total}
-          breakdown={[
-            ['Pending', intake.submissions.pending],
-            ['Accepted', intake.submissions.accepted],
-            ['Rejected', intake.submissions.rejected],
-            ['Disputed', intake.submissions.disputed],
-          ]}
-        />
-        <StatCard
-          label='Contributions'
-          total={intake.contributions.count}
-          breakdown={[
-            [
-              'Total',
-              `${Number(intake.contributions.total).toLocaleString()} ${overview.rewardCurrency}`,
-            ],
-          ]}
-        />
-      </div>
-
-      {/* Facts */}
-      <div className='grid gap-4 lg:grid-cols-2'>
-        <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5'>
-          <h3 className='mb-3 text-sm font-semibold text-white'>Details</h3>
-          <dl className='space-y-2 text-sm'>
-            <Row
-              label='Reward pool'
-              value={`${overview.rewardAmount.toLocaleString()} ${overview.rewardCurrency}`}
-            />
-            {overview.submissionDeadline && (
-              <div className='flex items-center justify-between gap-3'>
-                <dt className='text-zinc-400'>Submission deadline</dt>
-                <dd className='text-right'>
-                  <DueCountdown
-                    deadline={overview.submissionDeadline}
-                    className='flex items-center gap-1.5 text-xs font-medium text-zinc-200'
-                  />
-                </dd>
-              </div>
-            )}
-            {overview.applicationWindowCloseAt && (
-              <div className='flex items-center justify-between gap-3'>
-                <dt className='text-zinc-400'>Applications close</dt>
-                <dd className='text-right'>
-                  <DueCountdown
-                    deadline={overview.applicationWindowCloseAt}
-                    className='flex items-center gap-1.5 text-xs font-medium text-zinc-200'
-                  />
-                </dd>
-              </div>
-            )}
-            {overview.maxApplicants != null && (
-              <Row
-                label='Max applicants'
-                value={String(overview.maxApplicants)}
-              />
-            )}
-            {overview.shortlistSize != null && (
-              <Row
-                label='Shortlist size'
-                value={String(overview.shortlistSize)}
-              />
-            )}
-            {overview.escrowEventId && (
-              <Row label='Escrow event' value={overview.escrowEventId} mono />
-            )}
-          </dl>
-        </div>
-
-        {/* Prize tiers */}
-        <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5'>
-          <h3 className='mb-3 text-sm font-semibold text-white'>Prize tiers</h3>
-          {overview.prizeTiers.length === 0 ? (
-            <p className='text-sm text-zinc-500'>No prize tiers configured.</p>
-          ) : (
-            <div className='space-y-2'>
-              {overview.prizeTiers.map(tier => (
-                <div
-                  key={tier.position}
-                  className='flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-900/30 px-4 py-2.5'
-                >
-                  <span className='text-sm font-medium text-zinc-300'>
-                    {ordinal(tier.position)} place
-                  </span>
-                  <span className='text-primary text-sm font-semibold'>
-                    {Number(tier.amount).toLocaleString()}{' '}
-                    {overview.rewardCurrency}
-                  </span>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function StatCard({
-  label,
-  total,
-  breakdown,
-}: {
-  label: string;
-  total: number;
-  breakdown: Array<[string, string | number]>;
-}) {
-  return (
-    <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5'>
-      <p className='text-xs font-medium text-zinc-500'>{label}</p>
-      <p className='mt-1 text-2xl font-bold text-white'>{total}</p>
-      <dl className='mt-3 space-y-1 border-t border-zinc-800 pt-3'>
-        {breakdown.map(([k, v]) => (
-          <div key={k} className='flex items-center justify-between text-xs'>
-            <dt className='text-zinc-500'>{k}</dt>
-            <dd className='font-medium text-zinc-300'>{v}</dd>
-          </div>
-        ))}
-      </dl>
-    </div>
-  );
-}
-
-function Row({
-  label,
-  value,
-  mono,
-}: {
-  label: string;
-  value: string;
-  mono?: boolean;
-}) {
-  return (
-    <div className='flex items-center justify-between gap-3'>
-      <dt className='text-zinc-400'>{label}</dt>
-      <dd
-        className={`max-w-[60%] truncate text-right font-medium text-white ${
-          mono ? 'font-mono text-xs' : ''
-        }`}
-      >
-        {value}
-      </dd>
     </div>
   );
 }

--- a/components/organization/bounties/manage/BountyOverviewPanel.tsx
+++ b/components/organization/bounties/manage/BountyOverviewPanel.tsx
@@ -1,0 +1,329 @@
+'use client';
+
+import { Calendar, Check, LineChart, TrendingUp } from 'lucide-react';
+
+import { DueCountdown } from '@/components/bounties/DueCountdown';
+import { ordinal } from '@/lib/utils';
+import type { BountyOperateOverview } from '@/features/bounties';
+
+/**
+ * Overview = the bounty analytics dashboard, mirroring the hackathon organizer
+ * overview: an Analytics section (intake stat cards + trend charts) followed by
+ * a Timeline of the bounty lifecycle. Trend charts await a backend analytics
+ * endpoint, so they render the same empty state the hackathon charts use.
+ */
+export default function BountyOverviewPanel({
+  overview,
+}: {
+  overview: BountyOperateOverview;
+}) {
+  const { intake } = overview;
+
+  return (
+    <div className='space-y-12'>
+      {/* ── Analytics ── */}
+      <section>
+        <div className='mb-6 flex items-center gap-2'>
+          <TrendingUp className='h-4 w-4 text-zinc-500' />
+          <h2 className='text-xs font-medium tracking-wider text-zinc-500 uppercase'>
+            Analytics
+          </h2>
+        </div>
+
+        {/* Intake stat cards */}
+        <div className='grid gap-4 sm:grid-cols-3'>
+          <StatCard
+            label='Applications'
+            total={intake.applications.total}
+            breakdown={[
+              ['Submitted', intake.applications.submitted],
+              ['Shortlisted', intake.applications.shortlisted],
+              ['Selected', intake.applications.selected],
+              ['Declined', intake.applications.declined],
+              ['Withdrawn', intake.applications.withdrawn],
+            ]}
+          />
+          <StatCard
+            label='Submissions'
+            total={intake.submissions.total}
+            breakdown={[
+              ['Pending', intake.submissions.pending],
+              ['Accepted', intake.submissions.accepted],
+              ['Rejected', intake.submissions.rejected],
+              ['Disputed', intake.submissions.disputed],
+            ]}
+          />
+          <StatCard
+            label='Contributions'
+            total={intake.contributions.count}
+            breakdown={[
+              [
+                'Total',
+                `${Number(intake.contributions.total).toLocaleString()} ${overview.rewardCurrency}`,
+              ],
+            ]}
+          />
+        </div>
+
+        {/* Trend charts */}
+        <div className='mt-6 grid gap-4 lg:grid-cols-2'>
+          <ChartCard title='Submissions over time' />
+          <ChartCard title='Applications trend' />
+        </div>
+      </section>
+
+      {/* ── Details + prize tiers ── */}
+      <section className='grid gap-4 lg:grid-cols-2'>
+        <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5'>
+          <h3 className='mb-3 text-sm font-semibold text-white'>Details</h3>
+          <dl className='space-y-2 text-sm'>
+            <Row
+              label='Reward pool'
+              value={`${overview.rewardAmount.toLocaleString()} ${overview.rewardCurrency}`}
+            />
+            {overview.submissionDeadline && (
+              <div className='flex items-center justify-between gap-3'>
+                <dt className='text-zinc-400'>Submission deadline</dt>
+                <dd className='text-right'>
+                  <DueCountdown
+                    deadline={overview.submissionDeadline}
+                    className='flex items-center gap-1.5 text-xs font-medium text-zinc-200'
+                  />
+                </dd>
+              </div>
+            )}
+            {overview.applicationWindowCloseAt && (
+              <div className='flex items-center justify-between gap-3'>
+                <dt className='text-zinc-400'>Applications close</dt>
+                <dd className='text-right'>
+                  <DueCountdown
+                    deadline={overview.applicationWindowCloseAt}
+                    className='flex items-center gap-1.5 text-xs font-medium text-zinc-200'
+                  />
+                </dd>
+              </div>
+            )}
+            {overview.maxApplicants != null && (
+              <Row
+                label='Max applicants'
+                value={String(overview.maxApplicants)}
+              />
+            )}
+            {overview.shortlistSize != null && (
+              <Row
+                label='Shortlist size'
+                value={String(overview.shortlistSize)}
+              />
+            )}
+            {overview.escrowEventId && (
+              <Row label='Escrow event' value={overview.escrowEventId} mono />
+            )}
+          </dl>
+        </div>
+
+        <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5'>
+          <h3 className='mb-3 text-sm font-semibold text-white'>Prize tiers</h3>
+          {overview.prizeTiers.length === 0 ? (
+            <p className='text-sm text-zinc-500'>No prize tiers configured.</p>
+          ) : (
+            <div className='space-y-2'>
+              {overview.prizeTiers.map(tier => (
+                <div
+                  key={tier.position}
+                  className='flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-900/30 px-4 py-2.5'
+                >
+                  <span className='text-sm font-medium text-zinc-300'>
+                    {ordinal(tier.position)} place
+                  </span>
+                  <span className='text-primary text-sm font-semibold'>
+                    {Number(tier.amount).toLocaleString()}{' '}
+                    {overview.rewardCurrency}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* ── Timeline ── */}
+      <BountyTimeline overview={overview} />
+    </div>
+  );
+}
+
+function ChartCard({ title }: { title: string }) {
+  return (
+    <div className='flex min-w-0 flex-col gap-3 rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4'>
+      <div className='text-xs font-medium tracking-wide text-white uppercase'>
+        {title}
+      </div>
+      <div className='flex h-[200px] flex-col items-center justify-center gap-2 text-zinc-600 sm:h-[240px]'>
+        <LineChart className='h-6 w-6' />
+        <p className='text-sm text-zinc-500'>No trend data yet</p>
+      </div>
+    </div>
+  );
+}
+
+interface TimelineEvent {
+  label: string;
+  description: string;
+  date?: string | null;
+  state: 'completed' | 'ongoing' | 'upcoming';
+}
+
+function BountyTimeline({ overview }: { overview: BountyOperateOverview }) {
+  const now = Date.now();
+  const isTerminal =
+    overview.status === 'completed' || overview.status === 'cancelled';
+
+  const dated = (date?: string | null): TimelineEvent['state'] =>
+    date && new Date(date).getTime() <= now ? 'completed' : 'upcoming';
+
+  const events: TimelineEvent[] = [
+    {
+      label: 'Published',
+      description: 'Bounty published and funded on-chain.',
+      date: overview.createdAt,
+      state: 'completed',
+    },
+  ];
+
+  if (overview.applicationWindowCloseAt) {
+    events.push({
+      label: 'Applications close',
+      description: 'The application window closes.',
+      date: overview.applicationWindowCloseAt,
+      state: dated(overview.applicationWindowCloseAt),
+    });
+  }
+  if (overview.submissionDeadline) {
+    events.push({
+      label: 'Submission deadline',
+      description: 'Work submissions close for review.',
+      date: overview.submissionDeadline,
+      state: dated(overview.submissionDeadline),
+    });
+  }
+
+  events.push({
+    label: overview.status === 'cancelled' ? 'Cancelled' : 'Completed',
+    description:
+      overview.status === 'cancelled'
+        ? 'Bounty cancelled and escrow refunded.'
+        : 'Winners selected and rewards paid out.',
+    state: isTerminal ? 'completed' : 'upcoming',
+  });
+
+  return (
+    <section>
+      <div className='mb-6 flex items-center gap-2 border-t border-zinc-900 pt-8'>
+        <Calendar className='h-4 w-4 text-zinc-500' />
+        <h2 className='text-xs font-medium tracking-wider text-zinc-500 uppercase'>
+          Timeline
+        </h2>
+      </div>
+
+      <div className='space-y-0'>
+        {events.map((phase, index) => {
+          const isLast = index === events.length - 1;
+          const isCompleted = phase.state === 'completed';
+          const isOngoing = phase.state === 'ongoing';
+          return (
+            <div
+              key={`${phase.label}-${index}`}
+              className={`relative flex items-start gap-3 sm:gap-4 ${!isLast ? 'pb-6' : ''}`}
+            >
+              <div className='relative flex flex-col items-center'>
+                {isCompleted ? (
+                  <div className='z-10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-emerald-500/20 bg-emerald-500/10'>
+                    <Check className='h-3 w-3 text-emerald-500' />
+                  </div>
+                ) : isOngoing ? (
+                  <div className='z-10 flex shrink-0 items-center justify-center rounded-full bg-emerald-500/20 p-1'>
+                    <div className='bg-primary h-4 w-4 shrink-0 rounded-full' />
+                  </div>
+                ) : (
+                  <div className='z-10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-zinc-800 opacity-50' />
+                )}
+                {!isLast && (
+                  <div className='absolute top-6 left-1/2 h-6 w-0.5 -translate-x-1/2'>
+                    <div className='h-full border-l-2 border-dashed border-zinc-700' />
+                  </div>
+                )}
+              </div>
+              <div className='flex min-w-0 flex-1 flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4'>
+                <div className='min-w-0 flex-1'>
+                  <h3 className='mb-1 text-sm font-medium text-white sm:text-base'>
+                    {phase.label}
+                  </h3>
+                  <p
+                    className={`text-xs sm:text-sm ${
+                      isCompleted ? 'text-zinc-400' : 'text-white/40'
+                    }`}
+                  >
+                    {phase.description}
+                  </p>
+                </div>
+                {phase.date && (
+                  <div className='shrink-0 text-xs whitespace-nowrap text-white/60 sm:text-sm'>
+                    {new Date(phase.date).toLocaleDateString()}
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function StatCard({
+  label,
+  total,
+  breakdown,
+}: {
+  label: string;
+  total: number;
+  breakdown: Array<[string, string | number]>;
+}) {
+  return (
+    <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5'>
+      <p className='text-xs font-medium text-zinc-500'>{label}</p>
+      <p className='mt-1 text-2xl font-bold text-white'>{total}</p>
+      <dl className='mt-3 space-y-1 border-t border-zinc-800 pt-3'>
+        {breakdown.map(([k, v]) => (
+          <div key={k} className='flex items-center justify-between text-xs'>
+            <dt className='text-zinc-500'>{k}</dt>
+            <dd className='font-medium text-zinc-300'>{v}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+function Row({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className='flex items-center justify-between gap-3'>
+      <dt className='text-zinc-400'>{label}</dt>
+      <dd
+        className={`max-w-[60%] truncate text-right font-medium text-white ${
+          mono ? 'font-mono text-xs' : ''
+        }`}
+      >
+        {value}
+      </dd>
+    </div>
+  );
+}

--- a/components/organization/bounties/manage/BountySelector.tsx
+++ b/components/organization/bounties/manage/BountySelector.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { Check, ChevronsUpDown, Plus } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Button } from '@/components/ui/button';
+
+export interface SidebarBounty {
+  id: string;
+  title: string;
+  status: string;
+}
+
+/** Lifecycle status -> selector dot color. */
+function statusDot(status: string): string {
+  switch (status) {
+    case 'open':
+    case 'in_progress':
+    case 'submitted':
+    case 'under_review':
+      return 'bg-emerald-500';
+    case 'completed':
+      return 'bg-primary';
+    case 'cancelled':
+      return 'bg-zinc-500';
+    default:
+      return 'bg-amber-500';
+  }
+}
+
+/**
+ * Switches between the organization's bounties from the management sidebar,
+ * mirroring the hackathon selector. Selecting one navigates to its dashboard.
+ */
+export default function BountySelector({
+  organizationId,
+  bounties,
+  currentId,
+}: {
+  organizationId: string;
+  bounties: SidebarBounty[];
+  currentId: string;
+}) {
+  const router = useRouter();
+  const current = bounties.find(b => b.id === currentId);
+
+  if (!current) {
+    return (
+      <div className='flex items-center gap-3 px-3 py-2'>
+        <div className='h-2 w-2 animate-pulse rounded-full bg-zinc-700' />
+        <span className='text-sm font-medium text-zinc-400'>Loading…</span>
+      </div>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild className='focus-visible:ring-0'>
+        <Button className='flex w-full items-center gap-3 bg-transparent px-3 py-2 hover:bg-transparent focus-visible:ring-0'>
+          <span
+            className={`h-2 w-2 rounded-full ${statusDot(current.status)}`}
+          />
+          <span className='max-w-[180px] truncate text-sm font-medium text-white'>
+            {current.title || 'Untitled bounty'}
+          </span>
+          <ChevronsUpDown className='ml-auto h-4 w-4 text-zinc-400' />
+        </Button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent
+        align='start'
+        className='w-[260px] rounded-lg border border-[#2B2B2B] bg-[#1A1A1A] p-2 shadow-lg'
+      >
+        {bounties.map(b => (
+          <DropdownMenuItem
+            key={b.id}
+            onClick={() =>
+              router.push(`/organizations/${organizationId}/bounties/${b.id}`)
+            }
+            className='flex cursor-pointer items-center gap-3 rounded-md px-3 py-2.5 hover:bg-[#252525] focus:bg-[#252525]'
+          >
+            <span
+              className={`h-2 w-2 shrink-0 rounded-full ${statusDot(b.status)}`}
+            />
+            <div className='flex flex-1 flex-col gap-0.5'>
+              <span className='truncate text-sm font-medium text-white'>
+                {b.title || 'Untitled bounty'}
+              </span>
+              <span className='text-xs text-zinc-400 capitalize'>
+                {b.status.replace(/_/g, ' ')}
+              </span>
+            </div>
+            {b.id === currentId && <Check className='text-primary h-4 w-4' />}
+          </DropdownMenuItem>
+        ))}
+
+        <DropdownMenuSeparator className='bg-[#2B2B2B]' />
+        <DropdownMenuItem
+          onClick={() =>
+            router.push(`/organizations/${organizationId}/bounties/new`)
+          }
+          className='text-primary flex cursor-pointer items-center gap-3 rounded-md px-3 py-2.5 hover:bg-[#252525] focus:bg-[#252525]'
+        >
+          <Plus className='h-4 w-4 shrink-0' />
+          <span className='text-sm font-medium'>New bounty</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/components/organization/bounties/manage/BountySettingsPanel.tsx
+++ b/components/organization/bounties/manage/BountySettingsPanel.tsx
@@ -143,7 +143,7 @@ export default function BountySettingsPanel({
             ) : (
               <BoundlessButton
                 variant='destructive'
-                className='mt-4'
+                className='mt-4 bg-red-500 text-white hover:bg-red-600'
                 onClick={() => {
                   setConfirmText('');
                   setConfirmOpen(true);
@@ -256,6 +256,7 @@ export default function BountySettingsPanel({
             </BoundlessButton>
             <BoundlessButton
               variant='destructive'
+              className='bg-red-500 text-white hover:bg-red-600 disabled:opacity-50'
               disabled={confirmText.trim() !== CONFIRM_PHRASE}
               onClick={() => {
                 setConfirmOpen(false);

--- a/components/organization/bounties/settings/BountyGeneralSettingsTab.tsx
+++ b/components/organization/bounties/settings/BountyGeneralSettingsTab.tsx
@@ -1,0 +1,428 @@
+'use client';
+
+import { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { Loader2 } from 'lucide-react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { BoundlessButton } from '@/components/buttons';
+import { api } from '@/lib/api/api';
+import { bountyKeys, useBounty, type BountyPublic } from '@/features/bounties';
+import {
+  BOUNTY_CATEGORIES,
+  CATEGORY_LABELS,
+  type BountyCategory,
+} from '@/components/organization/bounties/new/tabs/schemas/scopeSchema';
+
+const generalSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(1, 'Title is required')
+    .max(200, 'Title must be 200 characters or fewer'),
+  description: z
+    .string()
+    .trim()
+    .min(1, 'Description is required')
+    .max(5000, 'Description must be 5000 characters or fewer'),
+  category: z.enum(BOUNTY_CATEGORIES),
+  submissionVisibility: z.enum(['ORGANIZER_ONLY', 'HIDDEN_UNTIL_DEADLINE']),
+  documentation: z.boolean(),
+  tweet: z.boolean(),
+  demoVideo: z.boolean(),
+  media: z.boolean(),
+  reputationMinimum: z.union([z.number().int().min(0), z.nan()]).optional(),
+  applicationWindowCloseAt: z.string().optional(),
+  maxApplicants: z.union([z.number().int().min(1), z.nan()]).optional(),
+  shortlistSize: z.union([z.number().int().min(1), z.nan()]).optional(),
+});
+
+type GeneralFormValues = z.infer<typeof generalSchema>;
+
+const inputClassName =
+  'h-12 w-full rounded-xl border border-zinc-700 bg-zinc-900/80 p-4 text-white placeholder:text-zinc-500 focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-primary/30';
+
+const REQUIREMENTS: Array<{
+  name: 'documentation' | 'tweet' | 'demoVideo' | 'media';
+  label: string;
+  hint: string;
+}> = [
+  {
+    name: 'documentation',
+    label: 'Documentation',
+    hint: 'A docs or write-up link is required.',
+  },
+  { name: 'tweet', label: 'Tweet', hint: 'A tweet/X post link is required.' },
+  {
+    name: 'demoVideo',
+    label: 'Demo video',
+    hint: 'A demo video link is required.',
+  },
+  { name: 'media', label: 'Media', hint: 'At least one image is required.' },
+];
+
+/** ISO date-time -> value for <input type="datetime-local"> (local time). */
+function toLocalInput(iso?: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/** Empty / NaN number field -> null; otherwise the number. */
+function numOrNull(v: number | undefined): number | null {
+  return v == null || Number.isNaN(v) ? null : v;
+}
+
+/**
+ * Editable off-chain settings for a published bounty, covering every off-chain
+ * field from the Configure wizard: scope (title / description / category) and
+ * submission + application controls (visibility, required fields, reputation,
+ * application window, applicant / shortlist limits). On-chain values (rewards,
+ * prize tiers, escrow deadline) and the mode are immutable after funding and
+ * live in the read-only Reward / Timeline tabs. Saving hits the organizer
+ * off-chain PATCH endpoint (tracked in boundless-nestjs#373).
+ */
+export default function BountyGeneralSettingsTab({
+  organizationId,
+  bountyId,
+}: {
+  organizationId: string;
+  bountyId: string;
+}) {
+  const { data: bounty, isLoading } = useBounty(bountyId);
+
+  if (isLoading || !bounty) {
+    return (
+      <div className='flex min-h-[30vh] items-center justify-center'>
+        <Loader2 className='h-6 w-6 animate-spin text-zinc-500' />
+      </div>
+    );
+  }
+
+  return (
+    <GeneralForm
+      organizationId={organizationId}
+      bountyId={bountyId}
+      bounty={bounty}
+    />
+  );
+}
+
+function GeneralForm({
+  organizationId,
+  bountyId,
+  bounty,
+}: {
+  organizationId: string;
+  bountyId: string;
+  bounty: BountyPublic;
+}) {
+  const queryClient = useQueryClient();
+  const [saving, setSaving] = useState(false);
+
+  const isApplication =
+    bounty.entryType === 'APPLICATION_LIGHT' ||
+    bounty.entryType === 'APPLICATION_FULL';
+  const isCompetition = bounty.claimType === 'COMPETITION';
+  const isOpenSingle =
+    bounty.entryType === 'OPEN' && bounty.claimType === 'SINGLE_CLAIM';
+
+  const {
+    register,
+    control,
+    handleSubmit,
+    formState: { errors, isDirty },
+  } = useForm<GeneralFormValues>({
+    resolver: zodResolver(generalSchema),
+    defaultValues: {
+      title: bounty.title,
+      description: bounty.description,
+      category: BOUNTY_CATEGORIES.includes(bounty.category as BountyCategory)
+        ? (bounty.category as BountyCategory)
+        : 'DEVELOPMENT',
+      submissionVisibility: bounty.submissionVisibility,
+      documentation: bounty.submissionRequirements.documentation,
+      tweet: bounty.submissionRequirements.tweet,
+      demoVideo: bounty.submissionRequirements.demoVideo,
+      media: bounty.submissionRequirements.media,
+      reputationMinimum: bounty.reputationMinimum ?? undefined,
+      applicationWindowCloseAt: toLocalInput(bounty.applicationWindowCloseAt),
+      maxApplicants: bounty.maxApplicants ?? undefined,
+      shortlistSize: bounty.shortlistSize ?? undefined,
+    },
+  });
+
+  const onSubmit = async (values: GeneralFormValues) => {
+    setSaving(true);
+    try {
+      await api.patch(`/organizations/${organizationId}/bounties/${bountyId}`, {
+        title: values.title,
+        description: values.description,
+        category: values.category,
+        submissionVisibility: values.submissionVisibility,
+        submissionRequirements: {
+          documentation: values.documentation,
+          tweet: values.tweet,
+          demoVideo: values.demoVideo,
+          media: values.media,
+        },
+        reputationMinimum: isOpenSingle
+          ? numOrNull(values.reputationMinimum)
+          : undefined,
+        applicationWindowCloseAt:
+          isApplication && values.applicationWindowCloseAt
+            ? new Date(values.applicationWindowCloseAt).toISOString()
+            : undefined,
+        maxApplicants:
+          isApplication || (bounty.entryType === 'OPEN' && isCompetition)
+            ? numOrNull(values.maxApplicants)
+            : undefined,
+        shortlistSize: isCompetition
+          ? numOrNull(values.shortlistSize)
+          : undefined,
+      });
+      toast.success('Bounty settings saved.');
+      void queryClient.invalidateQueries({
+        queryKey: bountyKeys.detail(bountyId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: bountyKeys.overview(organizationId, bountyId),
+      });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to save settings';
+      toast.error(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const showMaxApplicants =
+    isApplication || (bounty.entryType === 'OPEN' && isCompetition);
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className='max-w-2xl space-y-8'>
+      {/* ── Scope ── */}
+      <Section
+        title='Scope'
+        description="The bounty's identity and discipline."
+      >
+        <Field label='Title' required error={errors.title?.message}>
+          <Input
+            {...register('title')}
+            placeholder='Bounty title'
+            className={inputClassName}
+          />
+        </Field>
+
+        <Field label='Description' required error={errors.description?.message}>
+          <Textarea
+            {...register('description')}
+            rows={8}
+            placeholder='Describe the work, scope, and acceptance criteria (markdown supported).'
+            className='focus-visible:border-primary/50 focus-visible:ring-primary/30 w-full rounded-xl border border-zinc-700 bg-zinc-900/80 p-4 text-white placeholder:text-zinc-500 focus-visible:ring-2'
+          />
+        </Field>
+
+        <Field label='Category'>
+          <Controller
+            control={control}
+            name='category'
+            render={({ field }) => (
+              <Select value={field.value} onValueChange={field.onChange}>
+                <SelectTrigger className='border-zinc-700 bg-zinc-900/80 text-white'>
+                  <SelectValue placeholder='Choose a category' />
+                </SelectTrigger>
+                <SelectContent className='border-zinc-800 bg-zinc-900 text-white'>
+                  {BOUNTY_CATEGORIES.map(c => (
+                    <SelectItem key={c} value={c}>
+                      {CATEGORY_LABELS[c]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          />
+        </Field>
+      </Section>
+
+      {/* ── Submissions & applications ── */}
+      <Section
+        title='Submissions & applications'
+        description='Who can enter and what each submission must include.'
+      >
+        <Field label='Submission visibility'>
+          <Controller
+            control={control}
+            name='submissionVisibility'
+            render={({ field }) => (
+              <Select value={field.value} onValueChange={field.onChange}>
+                <SelectTrigger className='border-zinc-700 bg-zinc-900/80 text-white'>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className='border-zinc-800 bg-zinc-900 text-white'>
+                  <SelectItem value='ORGANIZER_ONLY'>Organizer only</SelectItem>
+                  <SelectItem value='HIDDEN_UNTIL_DEADLINE'>
+                    Hidden until deadline
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          />
+        </Field>
+
+        <div className='space-y-2'>
+          <p className='text-sm font-medium text-zinc-200'>
+            Required submission fields
+          </p>
+          <div className='space-y-2'>
+            {REQUIREMENTS.map(req => (
+              <div
+                key={req.name}
+                className='flex items-center justify-between rounded-xl border border-zinc-800 bg-zinc-900/40 px-4 py-3'
+              >
+                <div>
+                  <p className='text-sm font-medium text-white'>{req.label}</p>
+                  <p className='text-xs text-zinc-500'>{req.hint}</p>
+                </div>
+                <Controller
+                  control={control}
+                  name={req.name}
+                  render={({ field }) => (
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  )}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {isOpenSingle && (
+          <Field
+            label='Minimum reputation'
+            error={errors.reputationMinimum?.message}
+          >
+            <Input
+              type='number'
+              min={0}
+              {...register('reputationMinimum', { valueAsNumber: true })}
+              placeholder='0'
+              className={inputClassName}
+            />
+          </Field>
+        )}
+
+        {isApplication && (
+          <Field
+            label='Applications close'
+            error={errors.applicationWindowCloseAt?.message}
+          >
+            <Input
+              type='datetime-local'
+              {...register('applicationWindowCloseAt')}
+              className={inputClassName}
+            />
+          </Field>
+        )}
+
+        {showMaxApplicants && (
+          <Field label='Max applicants' error={errors.maxApplicants?.message}>
+            <Input
+              type='number'
+              min={1}
+              {...register('maxApplicants', { valueAsNumber: true })}
+              placeholder='No limit'
+              className={inputClassName}
+            />
+          </Field>
+        )}
+
+        {isCompetition && (
+          <Field label='Shortlist size' error={errors.shortlistSize?.message}>
+            <Input
+              type='number'
+              min={1}
+              {...register('shortlistSize', { valueAsNumber: true })}
+              placeholder='Shortlist size'
+              className={inputClassName}
+            />
+          </Field>
+        )}
+      </Section>
+
+      <div className='flex justify-end'>
+        <BoundlessButton type='submit' size='lg' disabled={saving || !isDirty}>
+          {saving ? (
+            <>
+              <Loader2 className='h-4 w-4 animate-spin' />
+              Saving…
+            </>
+          ) : (
+            'Save changes'
+          )}
+        </BoundlessButton>
+      </div>
+    </form>
+  );
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className='rounded-2xl border border-zinc-800 bg-zinc-950/60 p-6'>
+      <div className='mb-5'>
+        <h2 className='text-lg font-semibold text-white'>{title}</h2>
+        <p className='mt-1 text-sm text-zinc-400'>{description}</p>
+      </div>
+      <div className='space-y-5'>{children}</div>
+    </section>
+  );
+}
+
+function Field({
+  label,
+  required,
+  error,
+  children,
+}: {
+  label: string;
+  required?: boolean;
+  error?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className='space-y-2'>
+      <label className='text-sm font-medium text-zinc-200'>
+        {label}
+        {required && <span className='text-red-400'> *</span>}
+      </label>
+      {children}
+      {error && <p className='text-xs text-red-400'>{error}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Brings the bounty organizer experience in line with the hackathon organizer pages — persistent management sidebar, an analytics Overview, a full settings surface, and hackathon-style cards.

## Changes

**Management shell**
- **`BountyManageSidebar`** (new) — persistent sidebar that **replaces the general org sidebar** on bounty management routes (wired in `organizations/layout.tsx`, same mechanism as the hackathon sidebar). Fixed desktop + mobile sheet.
- **`BountySelector`** (new) — bounty switcher dropdown at the top of the sidebar (switch bounties / new bounty), mirroring the hackathon selector.
- **`BountyManagementDashboard`** — horizontal tabs removed; sections are driven by the sidebar via `?tab=`. Settings tab removed (moved to its own page).

**Overview = analytics dashboard**
- **`BountyOverviewPanel`** (new) — mirrors the hackathon overview: an Analytics section (intake stat cards + trend chart cards) and a lifecycle Timeline, plus the details/prize-tier cards. (Trend charts show an empty state pending a bounty analytics/trends endpoint.)

**Settings page**
- **`/organizations/[id]/bounties/[bountyId]/settings`** (new) — standalone page with the sidebar and tabs (General · Rewards · Timeline · Close-out).
- **`BountyGeneralSettingsTab`** (new) — editable form covering **every off-chain Configure field**: scope (title / description / category) and submission + application controls (visibility, required fields, reputation minimum, application window, max applicants, shortlist size), shown conditionally by mode. Saves via the off-chain organizer PATCH.
- **Rewards / Timeline** stay **read-only** (on-chain: reward amount, prize tiers, escrow deadline) with a "locked after funding" notice.
- **Close-out** — cancel/refund + archive, moved out of the dashboard. Cancel buttons rendered solid red.

**Organizer cards**
- Published cards mirror the hackathon card: hover **Settings** + **Remove** actions and a submission count; card click → the dashboard.
- **`RemoveBountyDialog`** (new) — confirmation modal: archives a completed/cancelled bounty (soft-delete, recoverable) or routes to cancel/refund for a live one. Nothing is ever hard-deleted on-chain.

## Constraints honored

- **Off-chain edits only**: editable settings are limited to backend-stored fields; on-chain values (rewards, prize tiers, escrow deadline, mode) are read-only.
- The off-chain edit save + a few wizard fields not exposed by the public read (country / GitHub issue / resources) depend on a backend endpoint — tracked in **boundlessfi/boundless-nestjs#373**. The form is fully wired and lights up when that lands.

## Verification

- `tsc --noEmit` — 0 errors.
- `eslint .` — clean.