### PR TITLE
fix(bounty): settings polish — full-width tabs, editable timeline, drop back link

### DIFF
--- a/app/(landing)/organizations/[id]/bounties/[bountyId]/settings/page.tsx
+++ b/app/(landing)/organizations/[id]/bounties/[bountyId]/settings/page.tsx
@@ -16,8 +16,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { AuthGuard } from '@/components/auth';
 import Loading from '@/components/Loading';
 import EmptyState from '@/components/EmptyState';
-import { DueCountdown } from '@/components/bounties/DueCountdown';
 import BountyGeneralSettingsTab from '@/components/organization/bounties/settings/BountyGeneralSettingsTab';
+import BountyTimelineSettingsTab from '@/components/organization/bounties/settings/BountyTimelineSettingsTab';
 import BountySettingsPanel from '@/components/organization/bounties/manage/BountySettingsPanel';
 import {
   useBountyOverview,
@@ -177,52 +177,13 @@ function BountySettingsContent({
         </div>
       </TabsContent>
 
-      {/* Timeline — on-chain deadline, immutable once funded. */}
+      {/* Timeline — on-chain submission deadline (read-only) + editable
+          off-chain application window. */}
       <TabsContent value='timeline' className='mt-0'>
-        <div className='space-y-4'>
-          <OnChainNotice />
-          <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5'>
-            <h3 className='mb-3 text-sm font-semibold text-white'>Timeline</h3>
-            <dl className='space-y-2.5 text-sm'>
-              {overview.submissionDeadline ? (
-                <div className='flex items-center justify-between gap-3'>
-                  <dt className='text-zinc-400'>Submission deadline</dt>
-                  <dd>
-                    <DueCountdown
-                      deadline={overview.submissionDeadline}
-                      className='flex items-center gap-1.5 text-xs font-medium text-zinc-200'
-                    />
-                  </dd>
-                </div>
-              ) : (
-                <Row label='Submission deadline' value='Not set' />
-              )}
-              {overview.applicationWindowCloseAt && (
-                <div className='flex items-center justify-between gap-3'>
-                  <dt className='text-zinc-400'>Applications close</dt>
-                  <dd>
-                    <DueCountdown
-                      deadline={overview.applicationWindowCloseAt}
-                      className='flex items-center gap-1.5 text-xs font-medium text-zinc-200'
-                    />
-                  </dd>
-                </div>
-              )}
-              {overview.maxApplicants != null && (
-                <Row
-                  label='Max applicants'
-                  value={String(overview.maxApplicants)}
-                />
-              )}
-              {overview.shortlistSize != null && (
-                <Row
-                  label='Shortlist size'
-                  value={String(overview.shortlistSize)}
-                />
-              )}
-            </dl>
-          </div>
-        </div>
+        <BountyTimelineSettingsTab
+          organizationId={organizationId}
+          bountyId={bountyId}
+        />
       </TabsContent>
 
       {/* Close-out — cancel / refund + archive (moved from the dashboard). */}
@@ -245,34 +206,6 @@ function OnChainNotice() {
         These values are anchored on-chain in the escrow and cannot be changed
         after funding.
       </span>
-    </div>
-  );
-}
-
-function Row({
-  label,
-  value,
-  hint,
-  capitalize,
-}: {
-  label: string;
-  value: string;
-  hint?: string | null;
-  capitalize?: boolean;
-}) {
-  return (
-    <div className='flex items-start justify-between gap-4'>
-      <dt className='text-zinc-400'>{label}</dt>
-      <dd className='max-w-[60%] text-right'>
-        <span
-          className={`font-medium text-white ${capitalize ? 'capitalize' : ''}`}
-        >
-          {value}
-        </span>
-        {hint && (
-          <span className='mt-0.5 block text-xs text-zinc-500'>{hint}</span>
-        )}
-      </dd>
     </div>
   );
 }

--- a/app/(landing)/organizations/[id]/bounties/[bountyId]/settings/page.tsx
+++ b/app/(landing)/organizations/[id]/bounties/[bountyId]/settings/page.tsx
@@ -2,9 +2,7 @@
 
 import { Suspense } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
-import Link from 'next/link';
 import {
-  ArrowLeft,
   CalendarClock,
   Info,
   Loader2,
@@ -64,15 +62,7 @@ function BountySettingsView() {
   return (
     <AuthGuard redirectTo='/auth?mode=signin' fallback={<Loading />}>
       <div className='bg-background min-h-screen'>
-        <div className='mx-auto max-w-7xl px-6 py-8'>
-          <Link
-            href={`/organizations/${organizationId}/bounties/${bountyId}`}
-            className='mb-6 inline-flex items-center gap-1.5 text-sm text-zinc-400 transition-colors hover:text-white'
-          >
-            <ArrowLeft className='h-4 w-4' />
-            Back to dashboard
-          </Link>
-
+        <div className='w-full px-6 py-8'>
           <div className='mb-6 flex items-center gap-3'>
             <Settings className='text-primary h-6 w-6' />
             <div>
@@ -153,7 +143,7 @@ function BountySettingsContent({
 
       {/* Rewards — on-chain, immutable once funded. */}
       <TabsContent value='rewards' className='mt-0'>
-        <div className='max-w-2xl space-y-4'>
+        <div className='space-y-4'>
           <OnChainNotice />
           <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5'>
             <h3 className='mb-3 text-sm font-semibold text-white'>
@@ -189,7 +179,7 @@ function BountySettingsContent({
 
       {/* Timeline — on-chain deadline, immutable once funded. */}
       <TabsContent value='timeline' className='mt-0'>
-        <div className='max-w-2xl space-y-4'>
+        <div className='space-y-4'>
           <OnChainNotice />
           <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5'>
             <h3 className='mb-3 text-sm font-semibold text-white'>Timeline</h3>

--- a/components/organization/bounties/manage/BountySettingsPanel.tsx
+++ b/components/organization/bounties/manage/BountySettingsPanel.tsx
@@ -93,7 +93,7 @@ export default function BountySettingsPanel({
   const archiveBusy = archiveMutation.isPending || restoreMutation.isPending;
 
   return (
-    <div className='max-w-2xl space-y-6'>
+    <div className='space-y-6'>
       <div className='rounded-2xl border border-red-500/30 bg-red-500/[0.04] p-5'>
         <div className='flex items-start gap-3'>
           <AlertTriangle className='mt-0.5 h-5 w-5 shrink-0 text-red-400' />

--- a/components/organization/bounties/settings/BountyGeneralSettingsTab.tsx
+++ b/components/organization/bounties/settings/BountyGeneralSettingsTab.tsx
@@ -216,7 +216,7 @@ function GeneralForm({
     isApplication || (bounty.entryType === 'OPEN' && isCompetition);
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className='max-w-2xl space-y-8'>
+    <form onSubmit={handleSubmit(onSubmit)} className='space-y-8'>
       {/* ── Scope ── */}
       <Section
         title='Scope'

--- a/components/organization/bounties/settings/BountyGeneralSettingsTab.tsx
+++ b/components/organization/bounties/settings/BountyGeneralSettingsTab.tsx
@@ -45,7 +45,6 @@ const generalSchema = z.object({
   demoVideo: z.boolean(),
   media: z.boolean(),
   reputationMinimum: z.union([z.number().int().min(0), z.nan()]).optional(),
-  applicationWindowCloseAt: z.string().optional(),
   maxApplicants: z.union([z.number().int().min(1), z.nan()]).optional(),
   shortlistSize: z.union([z.number().int().min(1), z.nan()]).optional(),
 });
@@ -73,15 +72,6 @@ const REQUIREMENTS: Array<{
   },
   { name: 'media', label: 'Media', hint: 'At least one image is required.' },
 ];
-
-/** ISO date-time -> value for <input type="datetime-local"> (local time). */
-function toLocalInput(iso?: string | null): string {
-  if (!iso) return '';
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return '';
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-}
 
 /** Empty / NaN number field -> null; otherwise the number. */
 function numOrNull(v: number | undefined): number | null {
@@ -161,7 +151,6 @@ function GeneralForm({
       demoVideo: bounty.submissionRequirements.demoVideo,
       media: bounty.submissionRequirements.media,
       reputationMinimum: bounty.reputationMinimum ?? undefined,
-      applicationWindowCloseAt: toLocalInput(bounty.applicationWindowCloseAt),
       maxApplicants: bounty.maxApplicants ?? undefined,
       shortlistSize: bounty.shortlistSize ?? undefined,
     },
@@ -184,10 +173,6 @@ function GeneralForm({
         reputationMinimum: isOpenSingle
           ? numOrNull(values.reputationMinimum)
           : undefined,
-        applicationWindowCloseAt:
-          isApplication && values.applicationWindowCloseAt
-            ? new Date(values.applicationWindowCloseAt).toISOString()
-            : undefined,
         maxApplicants:
           isApplication || (bounty.entryType === 'OPEN' && isCompetition)
             ? numOrNull(values.maxApplicants)
@@ -325,19 +310,6 @@ function GeneralForm({
               min={0}
               {...register('reputationMinimum', { valueAsNumber: true })}
               placeholder='0'
-              className={inputClassName}
-            />
-          </Field>
-        )}
-
-        {isApplication && (
-          <Field
-            label='Applications close'
-            error={errors.applicationWindowCloseAt?.message}
-          >
-            <Input
-              type='datetime-local'
-              {...register('applicationWindowCloseAt')}
               className={inputClassName}
             />
           </Field>

--- a/components/organization/bounties/settings/BountyTimelineSettingsTab.tsx
+++ b/components/organization/bounties/settings/BountyTimelineSettingsTab.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { Loader2, Lock } from 'lucide-react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { Input } from '@/components/ui/input';
+import { BoundlessButton } from '@/components/buttons';
+import { api } from '@/lib/api/api';
+import { bountyKeys, useBounty, type BountyPublic } from '@/features/bounties';
+
+const inputClassName =
+  'h-12 w-full rounded-xl border border-zinc-700 bg-zinc-900/80 p-4 text-white placeholder:text-zinc-500 focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-primary/30';
+
+/** ISO date-time -> value for <input type="datetime-local"> (local time). */
+function toLocalInput(iso?: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function formatDate(iso?: string | null): string {
+  if (!iso) return 'Not set';
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime())
+    ? 'Not set'
+    : d.toLocaleString(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      });
+}
+
+/**
+ * Timeline settings. The submission deadline is anchored on-chain at publish
+ * and is read-only. The application window close is off-chain (enforced by a
+ * backend cron), so it is editable here for application-mode bounties.
+ */
+export default function BountyTimelineSettingsTab({
+  organizationId,
+  bountyId,
+}: {
+  organizationId: string;
+  bountyId: string;
+}) {
+  const { data: bounty, isLoading } = useBounty(bountyId);
+
+  if (isLoading || !bounty) {
+    return (
+      <div className='flex min-h-[30vh] items-center justify-center'>
+        <Loader2 className='h-6 w-6 animate-spin text-zinc-500' />
+      </div>
+    );
+  }
+
+  return (
+    <TimelineForm
+      organizationId={organizationId}
+      bountyId={bountyId}
+      bounty={bounty}
+    />
+  );
+}
+
+function TimelineForm({
+  organizationId,
+  bountyId,
+  bounty,
+}: {
+  organizationId: string;
+  bountyId: string;
+  bounty: BountyPublic;
+}) {
+  const queryClient = useQueryClient();
+  const [saving, setSaving] = useState(false);
+  const isApplication =
+    bounty.entryType === 'APPLICATION_LIGHT' ||
+    bounty.entryType === 'APPLICATION_FULL';
+
+  const {
+    register,
+    handleSubmit,
+    formState: { isDirty },
+  } = useForm<{ applicationWindowCloseAt: string }>({
+    defaultValues: {
+      applicationWindowCloseAt: toLocalInput(bounty.applicationWindowCloseAt),
+    },
+  });
+
+  const onSubmit = async (values: { applicationWindowCloseAt: string }) => {
+    setSaving(true);
+    try {
+      await api.patch(`/organizations/${organizationId}/bounties/${bountyId}`, {
+        applicationWindowCloseAt: values.applicationWindowCloseAt
+          ? new Date(values.applicationWindowCloseAt).toISOString()
+          : null,
+      });
+      toast.success('Timeline saved.');
+      void queryClient.invalidateQueries({
+        queryKey: bountyKeys.detail(bountyId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: bountyKeys.overview(organizationId, bountyId),
+      });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to save timeline';
+      toast.error(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className='space-y-4'>
+      {/* Submission deadline — on-chain, read-only. */}
+      <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5'>
+        <div className='flex items-start justify-between gap-4'>
+          <div>
+            <h3 className='text-sm font-semibold text-white'>
+              Submission deadline
+            </h3>
+            <p className='mt-1 text-sm text-zinc-400'>
+              {formatDate(bounty.submissionDeadline)}
+            </p>
+          </div>
+          <span className='flex shrink-0 items-center gap-1.5 rounded-full border border-zinc-800 bg-zinc-900/60 px-2.5 py-1 text-xs text-zinc-400'>
+            <Lock className='h-3 w-3' />
+            On-chain
+          </span>
+        </div>
+        <p className='mt-3 border-t border-zinc-800 pt-3 text-xs text-zinc-500'>
+          Anchored in the escrow at publish; it can&apos;t be changed after
+          funding.
+        </p>
+      </div>
+
+      {/* Application window close — off-chain, editable (application modes). */}
+      {isApplication ? (
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className='rounded-2xl border border-zinc-800 bg-zinc-950/60 p-6'
+        >
+          <div className='mb-4'>
+            <h3 className='text-sm font-semibold text-white'>
+              Applications close
+            </h3>
+            <p className='mt-1 text-sm text-zinc-400'>
+              When the application window closes. Off-chain, so you can adjust
+              it any time before it passes.
+            </p>
+          </div>
+          <Input
+            type='datetime-local'
+            {...register('applicationWindowCloseAt')}
+            className={inputClassName}
+          />
+          <div className='mt-5 flex justify-end'>
+            <BoundlessButton
+              type='submit'
+              size='lg'
+              disabled={saving || !isDirty}
+            >
+              {saving ? (
+                <>
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                  Saving…
+                </>
+              ) : (
+                'Save changes'
+              )}
+            </BoundlessButton>
+          </div>
+        </form>
+      ) : (
+        <div className='rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5 text-sm text-zinc-500'>
+          This bounty has no application window — builders submit directly.
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Settings-page polish on the bounty organizer settings (follow-up to #678):

- **Full-width tabs** — removed the `max-w-2xl` caps on the tab content and let the page container span full width, so content extends to the edge instead of a narrow column.
- **Removed the "Back to dashboard" link** — the hackathon organizer settings has none (the sidebar handles nav), dropped for parity.
- **Editable application window in the Timeline tab** — the one timeline field that is **off-chain** (`applicationWindowCloseAt`, enforced by a backend cron) is now editable there, with a Save that PATCHes the off-chain endpoint. The **submission deadline stays read-only** with an "On-chain" badge (anchored in the escrow at publish). Moved the application-window field out of the General tab so it lives with the timeline it belongs to.

## On-chain vs off-chain (Timeline)

- Submission deadline → on-chain (`create_event` arg) → read-only.
- Application window close → off-chain (cron-enforced) → editable.

## Verification

- `tsc --noEmit` — 0 errors.
- `eslint .` — clean.