### PR TITLE
feat(bounty): treasury payout/cancel without the caller's personal wallet

### DIFF
--- a/hooks/use-bounty-cancel.ts
+++ b/hooks/use-bounty-cancel.ts
@@ -77,19 +77,21 @@ export const useBountyCancel = ({
 
   const cancel = async (): Promise<void> => {
     if (!organizationId || !bountyId) return;
-    if (!ownerAddress) {
-      toast.error(
-        isExternal
-          ? 'Connect a wallet to sign the cancellation.'
-          : 'Please connect your wallet first'
-      );
+    // EXTERNAL is signed by the connected wallet; MANAGED is signed server-side
+    // by the on-chain event manager (the treasury/owner that published), so no
+    // connected wallet is needed. ownerAddress is a hint the backend may use as
+    // a fallback.
+    if (isExternal && !ownerAddress) {
+      toast.error('Connect a wallet to sign the cancellation.');
       return;
     }
 
-    const body: CancelBountyEscrowRequest = {
-      ownerAddress,
+    // ownerAddress is optional on the backend (boundless-nestjs#392); until
+    // codegen picks that up the generated type marks it required, so cast.
+    const body = {
       fundingMode,
-    };
+      ...(ownerAddress ? { ownerAddress } : {}),
+    } as CancelBountyEscrowRequest;
 
     finalizedRef.current = false;
     toast.info('Submitting cancellation…');

--- a/hooks/use-bounty-payout.ts
+++ b/hooks/use-bounty-payout.ts
@@ -72,20 +72,23 @@ export const useBountyPayout = ({
     selections: BountyWinnerSelection[]
   ): Promise<void> => {
     if (!organizationId || !bountyId || selections.length === 0) return;
-    if (!ownerAddress) {
-      toast.error(
-        isExternal
-          ? 'Connect a wallet to sign the payout.'
-          : 'Please connect your wallet first'
-      );
+    // EXTERNAL is signed by the connected wallet, so it's required there.
+    // MANAGED is signed server-side by the on-chain event manager (the treasury
+    // / owner that published) — no connected wallet needed. ownerAddress is a
+    // hint only; the backend resolves and signs with the real manager.
+    if (isExternal && !ownerAddress) {
+      toast.error('Connect a wallet to sign the payout.');
       return;
     }
 
-    const body: SelectBountyWinnersRequest = {
-      ownerAddress,
+    // ownerAddress is optional on the backend (it resolves the manager); until
+    // codegen picks that up (boundless-nestjs#392) the generated type still
+    // marks it required, so cast.
+    const body = {
       selections,
       fundingMode,
-    };
+      ...(ownerAddress ? { ownerAddress } : {}),
+    } as SelectBountyWinnersRequest;
 
     finalizedRef.current = false;
     toast.info('Submitting winner selection…');


### PR DESCRIPTION
## What

For a **treasury-funded** bounty, the organizer no longer needs to connect their **personal** wallet to pay out winners or cancel. It mirrors the hackathon `use-publish-winners` flow.

## Why

The backend already signs `select_winners` / `cancel` with the on-chain **event manager** (the treasury/owner that published) — see the pulled backend change + boundlessfi/boundless-nestjs#392, which makes `ownerAddress` optional. But the FE (`useBountyPayout` / `useBountyCancel`) still **required** the signed-in user's personal managed wallet and sent it as `ownerAddress`, which mismatches a treasury-owned bounty.

## Changes

- **`useBountyPayout` / `useBountyCancel`** — require a connected wallet **only for EXTERNAL** (which the wallet signs). For MANAGED, don't block on a personal wallet; send `ownerAddress` as an **optional hint** so the backend resolves + signs with the real manager.

## Note

`ownerAddress` is cast because the generated `SelectBountyWinnersDto` / `CancelBountyEscrowDto` still mark it required until FE codegen picks up boundless-nestjs#392 (which makes it optional). A codegen refresh after that merges removes the cast.

## Verification

- `tsc --noEmit` — 0 errors.
- `eslint .` — clean.