### PR TITLE
fix(bounty): update stale staged-for-payout hint copy

### DIFF
--- a/components/organization/bounties/manage/BountySubmissionsPanel.tsx
+++ b/components/organization/bounties/manage/BountySubmissionsPanel.tsx
@@ -114,7 +114,7 @@ export default function BountySubmissionsPanel({
           <Trophy className='text-primary h-4 w-4' />
           <span className='text-zinc-200'>{staged.size} staged for payout</span>
           <span className='text-xs text-zinc-500'>
-            (winner selection + signing lands in #633)
+            (assign them to prize tiers in the Payout tab)
           </span>
         </div>
       )}


### PR DESCRIPTION
The Submissions tab's "staged for payout" banner referenced an internal issue number (`#633`) as a build-order note. That work has shipped (the Payout & Winners tab), so this points organizers to the Payout tab instead of leaking an issue number into user-facing copy.