### PR TITLE
feat(bounty): allow up to 15 competition prize tiers

### DIFF
--- a/components/organization/bounties/new/tabs/schemas/modeSchema.ts
+++ b/components/organization/bounties/new/tabs/schemas/modeSchema.ts
@@ -21,7 +21,7 @@ export type BountyClaimType = (typeof CLAIM_TYPES)[number];
 export type BountySubmissionVisibility =
   (typeof SUBMISSION_VISIBILITIES)[number];
 
-export const MAX_PRIZE_TIERS = 3;
+export const MAX_PRIZE_TIERS = 15;
 
 /** Whether a contributor applies before working. */
 export const isApplicationEntry = (entryType: BountyEntryType): boolean =>
@@ -140,7 +140,8 @@ export const modeSchema = z
   .object({
     entryType: z.enum(ENTRY_TYPES),
     claimType: z.enum(CLAIM_TYPES),
-    // Number of prize positions. 1 for single claim; 1-3 for a competition.
+    // Number of prize positions. 1 for single claim; 1..MAX_PRIZE_TIERS for a
+    // competition.
     winnerCount: z.number().int().min(1).max(MAX_PRIZE_TIERS).default(1),
   })
   .superRefine((data, ctx) => {
@@ -157,7 +158,7 @@ export const modeSchema = z
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'A competition pays 1 to 3 winners',
+        message: `A competition pays 1 to ${MAX_PRIZE_TIERS} winners`,
         path: ['winnerCount'],
       });
     }


### PR DESCRIPTION
## What

A competition bounty can now have **up to 15** prize positions (was capped at 3).

`MAX_PRIZE_TIERS` 3 → 15 in `modeSchema.ts` — the single FE source of truth, so it propagates to the Mode step (winner-count stepper), the Reward step (tier inputs), and all validation/copy.

## Why it's safe on-chain

The on-chain `winner_distribution` is derived from the tier **amounts** and normalized to 100% by the **shared** `buildWinnerDistribution` — the same path hackathons already use to publish many winners. The contract accepts arbitrary positions (the DTO default even documents "5% for the rest" beyond position 3), so 3 was a product guard, not a contract limit.

## Paired change

Backend validation cap is bumped to match in boundless-nestjs (separate PR).

## Verification

- `tsc --noEmit` — 0 errors.
- `eslint .` — clean.