### PR TITLE
feat(bounty): full config in settings + open single-claim submit-entry

### DIFF
--- a/app/(landing)/organizations/[id]/bounties/[bountyId]/settings/page.tsx
+++ b/app/(landing)/organizations/[id]/bounties/[bountyId]/settings/page.tsx
@@ -9,6 +9,7 @@ import {
   Lock,
   Settings,
   ShieldAlert,
+  SlidersHorizontal,
   Trophy,
 } from 'lucide-react';
 
@@ -17,6 +18,7 @@ import { AuthGuard } from '@/components/auth';
 import Loading from '@/components/Loading';
 import EmptyState from '@/components/EmptyState';
 import BountyGeneralSettingsTab from '@/components/organization/bounties/settings/BountyGeneralSettingsTab';
+import BountyConfigurationTab from '@/components/organization/bounties/settings/BountyConfigurationTab';
 import BountyTimelineSettingsTab from '@/components/organization/bounties/settings/BountyTimelineSettingsTab';
 import BountySettingsPanel from '@/components/organization/bounties/manage/BountySettingsPanel';
 import {
@@ -30,6 +32,7 @@ const tabTriggerClassName =
 
 const SETTINGS_SECTIONS = new Set([
   'general',
+  'configuration',
   'rewards',
   'timeline',
   'closeout',
@@ -118,6 +121,10 @@ function BountySettingsContent({
             <Info className='h-4 w-4' />
             General
           </TabsTrigger>
+          <TabsTrigger value='configuration' className={tabTriggerClassName}>
+            <SlidersHorizontal className='h-4 w-4' />
+            Configuration
+          </TabsTrigger>
           <TabsTrigger value='rewards' className={tabTriggerClassName}>
             <Trophy className='h-4 w-4' />
             Rewards
@@ -139,6 +146,11 @@ function BountySettingsContent({
           organizationId={organizationId}
           bountyId={bountyId}
         />
+      </TabsContent>
+
+      {/* Configuration — read-only mode + resources set at creation. */}
+      <TabsContent value='configuration' className='mt-0'>
+        <BountyConfigurationTab bountyId={bountyId} />
       </TabsContent>
 
       {/* Rewards — on-chain, immutable once funded. */}

--- a/components/bounties/detail/BountyEntryCta.tsx
+++ b/components/bounties/detail/BountyEntryCta.tsx
@@ -64,12 +64,18 @@ export function BountyEntryCta({
     bounty.entryType === 'APPLICATION_FULL';
   const isCompetition =
     bounty.entryType === 'OPEN' && bounty.claimType === 'COMPETITION';
+  // open single claim: there is no separate claim step. The CTA sends the
+  // builder straight to the entry form, where submitting locks them in.
+  const isOpenSingle =
+    bounty.entryType === 'OPEN' && bounty.claimType === 'SINGLE_CLAIM';
 
   const primaryLabel = isApplication
     ? 'Apply'
     : isCompetition
       ? 'Join competition'
-      : 'Claim this bounty';
+      : isOpenSingle
+        ? 'Submit entry'
+        : 'Claim this bounty';
 
   const deadlinePassed =
     !!bounty.applicationWindowCloseAt &&
@@ -239,17 +245,26 @@ export function BountyEntryCta({
         </div>
       ) : (
         <>
-          <BoundlessButton
-            size='lg'
-            className='w-full'
-            disabled={!accepting || deadlinePassed}
-            onClick={() => {
-              setEditing(false);
-              setDialogOpen(true);
-            }}
-          >
-            {primaryLabel}
-          </BoundlessButton>
+          {isOpenSingle && accepting && !deadlinePassed ? (
+            // Straight to the entry form: submitting is the claim.
+            <Link href={`/bounties/${bounty.id}/submit`} className='block'>
+              <BoundlessButton size='lg' className='w-full'>
+                {primaryLabel}
+              </BoundlessButton>
+            </Link>
+          ) : (
+            <BoundlessButton
+              size='lg'
+              className='w-full'
+              disabled={!accepting || deadlinePassed}
+              onClick={() => {
+                setEditing(false);
+                setDialogOpen(true);
+              }}
+            >
+              {primaryLabel}
+            </BoundlessButton>
+          )}
           <p className='mt-2 flex items-center justify-center gap-1.5 text-center text-xs text-zinc-500'>
             {!accepting ? (
               <>
@@ -262,7 +277,9 @@ export function BountyEntryCta({
                 Applications have closed.
               </>
             ) : withdrawn ? (
-              'You withdrew earlier — you can enter again.'
+              'You withdrew earlier, you can enter again.'
+            ) : isOpenSingle ? (
+              'The first valid entry locks in this bounty. Funds are paid on-chain.'
             ) : (
               'Funds are held in escrow and paid on-chain to winners.'
             )}

--- a/components/bounties/detail/submit/BountySubmitForm.tsx
+++ b/components/bounties/detail/submit/BountySubmitForm.tsx
@@ -7,7 +7,9 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { toast } from 'sonner';
+import { useQueryClient } from '@tanstack/react-query';
 import {
+  AlertTriangle,
   FileText,
   Github,
   Loader2,
@@ -23,6 +25,9 @@ import { Input } from '@/components/ui/input';
 import { uploadService } from '@/lib/api/upload';
 import { useWalletContext } from '@/components/providers/wallet-provider';
 import {
+  bountyKeys,
+  useApplyToBountyEscrow,
+  useMyBountyApplication,
   useSubmitBounty,
   ESCROW_PHASE_LABEL,
   type BountyPublic,
@@ -32,6 +37,15 @@ const PHASE_LABEL = {
   ...ESCROW_PHASE_LABEL,
   starting: 'Preparing submission…',
   polling: 'Anchoring on-chain…',
+};
+
+/** The submit-work payload, minus the wallet address which is added at run. */
+type EntryPayload = {
+  contentUri: string;
+  documentationUrl?: string;
+  tweetUrl?: string;
+  demoVideoUrl?: string;
+  mediaUrls?: string[];
 };
 
 type Requirements = BountyPublic['submissionRequirements'];
@@ -87,13 +101,27 @@ function LinkField({
 
 export default function BountySubmitForm({ bounty }: { bounty: BountyPublic }) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { walletAddress } = useWalletContext();
   const submit = useSubmitBounty(bounty.id);
+  const claim = useApplyToBountyEscrow(bounty.id);
+  const { data: myApplication } = useMyBountyApplication(bounty.id);
   const req = bounty.submissionRequirements;
+
+  // open single claim: submitting an entry IS the claim. The first eligible
+  // entrant is locked in. If the caller is not yet the active claimant, the
+  // "Submit entry" action first runs the on-chain apply, then the submit.
+  const isOpenSingle =
+    bounty.entryType === 'OPEN' && bounty.claimType === 'SINGLE_CLAIM';
+  const alreadyClaimed = myApplication?.status === 'active';
+  const needsClaim = isOpenSingle && !alreadyClaimed;
 
   const [mediaUrls, setMediaUrls] = useState<string[]>([]);
   const [uploading, setUploading] = useState(false);
   const [mediaError, setMediaError] = useState<string | null>(null);
+  // Set when a claim must land before the submit fires (the apply -> submit
+  // chain). Cleared once the submit is dispatched or the claim fails.
+  const [pendingEntry, setPendingEntry] = useState<EntryPayload | null>(null);
 
   const {
     register,
@@ -118,6 +146,36 @@ export default function BountySubmitForm({ bounty }: { bounty: BountyPublic }) {
       toast.error(submit.error || 'Submission failed.');
     }
   }, [submit.isCompleted, submit.isFailed, submit.error, bounty.id, router]);
+
+  // Second half of the apply -> submit chain: once the on-chain claim lands,
+  // refresh the application state and fire the queued submit. If the claim
+  // fails (e.g. someone else got in first), surface it and drop the queue.
+  useEffect(() => {
+    if (!pendingEntry) return;
+    if (claim.isCompleted) {
+      void queryClient.invalidateQueries({
+        queryKey: bountyKeys.myApplication(bounty.id),
+      });
+      if (walletAddress) {
+        void submit.run({ applicantAddress: walletAddress, ...pendingEntry });
+      }
+      setPendingEntry(null);
+    } else if (claim.isFailed) {
+      toast.error(claim.error || 'Could not lock in your entry.');
+      setPendingEntry(null);
+    }
+    // submit is intentionally omitted: run() is stable and we only want this to
+    // fire on a claim state transition, not on submit's own updates.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    claim.isCompleted,
+    claim.isFailed,
+    claim.error,
+    pendingEntry,
+    walletAddress,
+    bounty.id,
+    queryClient,
+  ]);
 
   const handleFiles = async (files: FileList | null) => {
     if (!files?.length) return;
@@ -155,17 +213,28 @@ export default function BountySubmitForm({ bounty }: { bounty: BountyPublic }) {
       setMediaError('At least one image is required.');
       return;
     }
-    void submit.run({
-      applicantAddress: walletAddress,
+    const entry: EntryPayload = {
       contentUri: data.contentUri.trim(),
       documentationUrl: data.documentationUrl.trim() || undefined,
       tweetUrl: data.tweetUrl.trim() || undefined,
       demoVideoUrl: data.demoVideoUrl.trim() || undefined,
       mediaUrls: mediaUrls.length ? mediaUrls : undefined,
-    });
+    };
+    // open single claim first-entry: lock in the claim on-chain, then submit
+    // (the queued effect above fires the submit when the claim completes).
+    if (needsClaim) {
+      setPendingEntry(entry);
+      void claim.run({ applicantAddress: walletAddress });
+      return;
+    }
+    void submit.run({ applicantAddress: walletAddress, ...entry });
   };
 
-  const running = submit.isRunning;
+  const claiming = claim.isRunning || !!pendingEntry;
+  const running = claiming || submit.isRunning;
+  const phaseLabel = claiming
+    ? 'Locking in your entry…'
+    : PHASE_LABEL[submit.phase] || 'Working…';
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className='w-full space-y-10'>
@@ -180,6 +249,33 @@ export default function BountySubmitForm({ bounty }: { bounty: BountyPublic }) {
           primary submission.
         </p>
       </header>
+
+      {/* open single claim: submitting locks you in as the sole worker. */}
+      {needsClaim && (
+        <div className='space-y-3'>
+          <div className='border-primary/30 bg-primary/5 flex items-start gap-2.5 rounded-xl border p-3.5 text-sm text-zinc-300'>
+            <AlertTriangle className='text-primary mt-0.5 h-4 w-4 shrink-0' />
+            <span>
+              Submitting locks this bounty to you as the sole worker. The first
+              valid entry wins, so make sure your work is ready before you
+              submit.
+            </span>
+          </div>
+          {bounty.reputationMinimum != null && bounty.reputationMinimum > 0 && (
+            <div className='flex items-start gap-2.5 rounded-xl border border-zinc-800 bg-zinc-900/50 p-3.5 text-xs text-zinc-400'>
+              <AlertTriangle className='mt-0.5 h-4 w-4 shrink-0 text-amber-500' />
+              <span>
+                This bounty requires a minimum of{' '}
+                <span className='font-medium text-white'>
+                  {bounty.reputationMinimum}
+                </span>{' '}
+                completed bounties. Your entry is rejected if you don&apos;t
+                meet it.
+              </span>
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Primary submission */}
       <section className='space-y-2'>
@@ -321,7 +417,7 @@ export default function BountySubmitForm({ bounty }: { bounty: BountyPublic }) {
         ) : running ? (
           <div className='flex items-center gap-2 rounded-lg border border-zinc-800 bg-zinc-900/50 p-3 text-sm text-zinc-300'>
             <Loader2 className='text-primary h-4 w-4 animate-spin' />
-            {PHASE_LABEL[submit.phase] || 'Working…'}
+            {phaseLabel}
           </div>
         ) : (
           <div className='flex items-center gap-3'>

--- a/components/bounties/detail/submit/BountySubmitGate.tsx
+++ b/components/bounties/detail/submit/BountySubmitGate.tsx
@@ -17,6 +17,16 @@ function canSubmit(
   bounty: BountyPublic,
   app: MyBountyApplication | null
 ): boolean {
+  // open single claim: submitting an entry IS the claim, so the first eligible
+  // entrant can reach the form without a prior claim. Allow whenever nobody
+  // else already holds the bounty (or the caller is the active claimant).
+  const isOpenSingle =
+    bounty.entryType === 'OPEN' && bounty.claimType === 'SINGLE_CLAIM';
+  if (isOpenSingle) {
+    if (app?.status === 'active') return true;
+    return !bounty.claimedBy;
+  }
+
   if (!app) return false;
   const withdrawn =
     app.applicationStatus === 'WITHDRAWN' || app.status === 'withdrawn';

--- a/components/organization/bounties/settings/BountyConfigurationTab.tsx
+++ b/components/organization/bounties/settings/BountyConfigurationTab.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { Loader2, Lock } from 'lucide-react';
+
+import { useBounty, type BountyPublic } from '@/features/bounties';
+import {
+  computeBountyModeLabel,
+  type BountyClaimType,
+  type BountyEntryType,
+} from '@/components/organization/bounties/new/tabs/schemas/modeSchema';
+
+/** Read-only plain-language descriptions of the entry / claim axes. */
+const ENTRY_INFO: Record<BountyEntryType, { label: string; hint: string }> = {
+  OPEN: { label: 'Open', hint: 'Anyone can start working right away.' },
+  APPLICATION_LIGHT: {
+    label: 'Application (light)',
+    hint: 'A short application before work begins.',
+  },
+  APPLICATION_FULL: {
+    label: 'Application (full)',
+    hint: 'A full application and review before work begins.',
+  },
+};
+
+const CLAIM_INFO: Record<BountyClaimType, { label: string; hint: string }> = {
+  SINGLE_CLAIM: {
+    label: 'Single claim',
+    hint: 'One contributor works exclusively and is paid.',
+  },
+  COMPETITION: {
+    label: 'Competition',
+    hint: 'Several work in parallel; the best win.',
+  },
+};
+
+/**
+ * Read-only view of how the bounty was set up: its mode (entry x claim) and the
+ * organizer-supplied resources. These choices are anchored at publish and can
+ * never be changed here, so they are shown for context but never editable. The
+ * editable off-chain fields live in the General tab.
+ */
+export default function BountyConfigurationTab({
+  bountyId,
+}: {
+  bountyId: string;
+}) {
+  const { data: bounty, isLoading } = useBounty(bountyId);
+
+  if (isLoading || !bounty) {
+    return (
+      <div className='flex min-h-[30vh] items-center justify-center'>
+        <Loader2 className='h-6 w-6 animate-spin text-zinc-500' />
+      </div>
+    );
+  }
+
+  return <ConfigurationView bounty={bounty} />;
+}
+
+function ConfigurationView({ bounty }: { bounty: BountyPublic }) {
+  const entryInfo = bounty.entryType
+    ? ENTRY_INFO[bounty.entryType as BountyEntryType]
+    : undefined;
+  const claimInfo = bounty.claimType
+    ? CLAIM_INFO[bounty.claimType as BountyClaimType]
+    : undefined;
+  const resources = bounty.resources ?? [];
+
+  return (
+    <div className='space-y-4'>
+      <div className='flex items-start gap-2.5 rounded-xl border border-zinc-800 bg-zinc-900/30 p-3.5 text-sm text-zinc-400'>
+        <Lock className='mt-0.5 h-4 w-4 shrink-0 text-zinc-500' />
+        <span>
+          How this bounty was set up. These choices are fixed once the bounty is
+          published and cannot be changed here.
+        </span>
+      </div>
+
+      {/* ── Mode ── */}
+      <Section
+        title='Mode'
+        description='The entry and claim rules chosen when the bounty was created.'
+      >
+        <ReadField
+          label='Mode'
+          value={
+            bounty.entryType && bounty.claimType
+              ? computeBountyModeLabel(
+                  bounty.entryType as BountyEntryType,
+                  bounty.claimType as BountyClaimType
+                )
+              : 'Bounty'
+          }
+        />
+        {entryInfo && (
+          <ReadField
+            label='How do contributors enter?'
+            value={entryInfo.label}
+            hint={entryInfo.hint}
+          />
+        )}
+        {claimInfo && (
+          <ReadField
+            label='How is the work claimed?'
+            value={claimInfo.label}
+            hint={claimInfo.hint}
+          />
+        )}
+      </Section>
+
+      {/* ── Resources ── */}
+      <Section
+        title='Resources'
+        description='Links and files shared with contributors, set in the Configure wizard.'
+      >
+        {resources.length === 0 ? (
+          <p className='text-sm text-zinc-500'>No resources were added.</p>
+        ) : (
+          <ul className='space-y-2'>
+            {resources.map((resource, i) => {
+              const href = resource.link || resource.file?.url;
+              const label =
+                resource.description ||
+                resource.file?.name ||
+                resource.link ||
+                'Resource';
+              return (
+                <li
+                  key={resource.id ?? i}
+                  className='rounded-xl border border-zinc-800 bg-zinc-900/50 px-4 py-3 text-sm'
+                >
+                  {href ? (
+                    <a
+                      href={href}
+                      target='_blank'
+                      rel='noreferrer'
+                      className='text-primary hover:underline'
+                    >
+                      {label}
+                    </a>
+                  ) : (
+                    <span className='text-white'>{label}</span>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </Section>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className='rounded-2xl border border-zinc-800 bg-zinc-950/60 p-6'>
+      <div className='mb-5'>
+        <h2 className='text-lg font-semibold text-white'>{title}</h2>
+        <p className='mt-1 text-sm text-zinc-400'>{description}</p>
+      </div>
+      <div className='space-y-5'>{children}</div>
+    </section>
+  );
+}
+
+function ReadField({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: React.ReactNode;
+  hint?: string;
+}) {
+  return (
+    <div className='space-y-1'>
+      <p className='text-sm font-medium text-zinc-200'>{label}</p>
+      <div className='rounded-xl border border-zinc-800 bg-zinc-900/50 px-4 py-3 text-white'>
+        {value}
+        {hint && <p className='mt-0.5 text-xs text-zinc-400'>{hint}</p>}
+      </div>
+    </div>
+  );
+}

--- a/components/organization/bounties/settings/BountyGeneralSettingsTab.tsx
+++ b/components/organization/bounties/settings/BountyGeneralSettingsTab.tsx
@@ -39,6 +39,13 @@ const generalSchema = z.object({
     .min(1, 'Description is required')
     .max(5000, 'Description must be 5000 characters or fewer'),
   category: z.enum(BOUNTY_CATEGORIES),
+  country: z.string().trim().max(100).optional(),
+  githubIssueUrl: z
+    .string()
+    .trim()
+    .url('Enter a valid URL')
+    .or(z.literal(''))
+    .optional(),
   submissionVisibility: z.enum(['ORGANIZER_ONLY', 'HIDDEN_UNTIL_DEADLINE']),
   documentation: z.boolean(),
   tweet: z.boolean(),
@@ -145,6 +152,8 @@ function GeneralForm({
       category: BOUNTY_CATEGORIES.includes(bounty.category as BountyCategory)
         ? (bounty.category as BountyCategory)
         : 'DEVELOPMENT',
+      country: bounty.country ?? '',
+      githubIssueUrl: bounty.githubIssueUrl ?? '',
       submissionVisibility: bounty.submissionVisibility,
       documentation: bounty.submissionRequirements.documentation,
       tweet: bounty.submissionRequirements.tweet,
@@ -163,6 +172,10 @@ function GeneralForm({
         title: values.title,
         description: values.description,
         category: values.category,
+        country: values.country?.trim() ? values.country.trim() : null,
+        githubIssueUrl: values.githubIssueUrl?.trim()
+          ? values.githubIssueUrl.trim()
+          : null,
         submissionVisibility: values.submissionVisibility,
         submissionRequirements: {
           documentation: values.documentation,
@@ -242,6 +255,22 @@ function GeneralForm({
                 </SelectContent>
               </Select>
             )}
+          />
+        </Field>
+
+        <Field label='GitHub issue URL' error={errors.githubIssueUrl?.message}>
+          <Input
+            {...register('githubIssueUrl')}
+            placeholder='https://github.com/org/repo/issues/1'
+            className={inputClassName}
+          />
+        </Field>
+
+        <Field label='Country / region' error={errors.country?.message}>
+          <Input
+            {...register('country')}
+            placeholder='e.g. Nigeria (leave blank for global)'
+            className={inputClassName}
           />
         </Field>
       </Section>

--- a/lib/api/generated/schema.d.ts
+++ b/lib/api/generated/schema.d.ts
@@ -23200,6 +23200,12 @@ export interface components {
       escrowTxHash?: string | null;
       /** @description Bounty discipline (DESIGN, DEVELOPMENT, CONTENT, GROWTH, COMMUNITY). */
       category?: string | null;
+      /** @description GitHub issue URL (required for development bounties). */
+      githubIssueUrl?: string | null;
+      /** @description Country/region the bounty targets, if any. */
+      country?: string | null;
+      /** @description Organizer-supplied resources (links and files) shared with contributors. */
+      resources?: components['schemas']['BountyResourceItemDto'][] | null;
       /**
        * Format: date-time
        * @description Work/submission deadline (set at publish); null while in draft.


### PR DESCRIPTION
## Summary

Two bounty changes.

### 1. Surface the full configuration in bounty settings
The organizer settings page hid the mode and several fields chosen at creation, which was confusing. This adds a read-only **Configuration** tab (its own tab, alongside General / Rewards / Timeline / Close-out) showing the bounty mode ("How do contributors enter?" and "How is the work claimed?") plus organizer resources. The off-chain **country** and **GitHub issue URL** become editable in the General tab. On-chain values stay read-only.

### 2. Open single-claim: submit-entry, first entry locks in
For OPEN + SINGLE_CLAIM there is no longer a separate claim step. The detail-page CTA reads **Submit entry** and goes straight to the entry form, where submitting runs the on-chain apply then submit as one action. The first valid entry locks the bounty to that builder; a second entrant is rejected. The submit gate admits a first entrant while nobody else holds the claim, and the form shows the lock-in and reputation notices.

## Notes
- `schema.d.ts` carries a minimal, hand-applied addition of `country`, `githubIssueUrl` and `resources` to `BountyPublicDto` (a full codegen regen produced unrelated backend drift, so it was kept out).
- Pairs with the backend PR that exposes those fields and moves the reputation gate to submission time.

## Testing
- Settings: open a bounty's settings, confirm the Configuration tab shows mode + resources, and that country / GitHub URL save from General.
- Submit-entry: on an OPEN + SINGLE_CLAIM bounty the CTA is "Submit entry"; submitting claims then submits in one flow. From a second account, submitting fails with "already claimed".